### PR TITLE
fix: use correct RetrievalSubscriber reference in MockClient function

### DIFF
--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lassie/pkg/eventpublisher"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -181,7 +182,7 @@ func (mc *MockClient) RetrieveContentFromPeerAsync(
 	return resChan, nil, func() {}
 }
 
-func (*MockClient) SubscribeToRetrievalEvents(subscriber RetrievalSubscriber) {}
+func (*MockClient) SubscribeToRetrievalEvents(subscriber eventpublisher.RetrievalSubscriber) {}
 
 type DummyEndpoint struct{}
 


### PR DESCRIPTION
This was somehow missed, but the retriever tests were not passing because of a bad reference. This was caused by a greater problem that I've outlined in our [Lassie Design issue](https://github.com/filecoin-project/lassie/issues/10#issuecomment-1371269542) about having duplicate types declared.