### PR TITLE
factor out retriever/interface package

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/lassie/pkg/eventpublisher"
 	"github.com/filecoin-project/lassie/pkg/indexerlookup"
 	"github.com/filecoin-project/lassie/pkg/retriever"
+	ri "github.com/filecoin-project/lassie/pkg/retriever/interface"
 	"github.com/google/uuid"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -136,8 +137,8 @@ func setupRetriever(c *cli.Context, timeout time.Duration, blockstore blockstore
 		return blockstore.Has(c.Context, cid)
 	}
 
-	retrieverCfg := retriever.RetrieverConfig{
-		DefaultMinerConfig: retriever.MinerConfig{
+	retrieverCfg := ri.RetrieverConfig{
+		DefaultProviderConfig: ri.ProviderConfig{
 			RetrievalTimeout: timeout,
 		},
 	}

--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"github.com/filecoin-project/index-provider/metadata"
-	"github.com/filecoin-project/lassie/pkg/retriever"
 	"github.com/ipfs/go-cid"
 	"github.com/ipni/storetheindex/api/v0/finder/model"
 	"github.com/multiformats/go-multicodec"
+
+	ri "github.com/filecoin-project/lassie/pkg/retriever/interface"
 )
 
 type IndexerCandidateFinder struct {
@@ -52,7 +53,7 @@ func (idxf *IndexerCandidateFinder) sendRequest(req *http.Request) (*model.FindR
 	return model.UnmarshalFindResponse(b)
 }
 
-func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]retriever.RetrievalCandidate, error) {
+func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]ri.RetrievalCandidate, error) {
 	u := fmt.Sprint(idxf.baseUrl, "/multihash/", cid.Hash().B58String())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
@@ -65,7 +66,7 @@ func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.
 	}
 	hash := string(cid.Hash())
 	// turn parsedResp into records.
-	var matches []retriever.RetrievalCandidate
+	var matches []ri.RetrievalCandidate
 
 	indices := rand.Perm(len(parsedResp.MultihashResults))
 	for _, i := range indices {
@@ -89,7 +90,7 @@ func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.
 						pmd = payload
 					}
 				}
-				matches = append(matches, retriever.RetrievalCandidate{
+				matches = append(matches, ri.RetrievalCandidate{
 					RootCid:          cid,
 					SourcePeer:       val.Provider,
 					Protocol:         p,

--- a/pkg/retriever/interface/retrieveinterface.go
+++ b/pkg/retriever/interface/retrieveinterface.go
@@ -1,0 +1,111 @@
+package retrieveinterface
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multicodec"
+)
+
+var (
+	ErrNoCandidates                = errors.New("no candidates")
+	ErrUnexpectedRetrieval         = errors.New("unexpected active retrieval")
+	ErrHitRetrievalLimit           = errors.New("hit retrieval limit")
+	ErrProposalCreationFailed      = errors.New("proposal creation failed")
+	ErrRetrievalRegistrationFailed = errors.New("retrieval registration failed")
+	ErrRetrievalFailed             = errors.New("retrieval failed")
+	ErrAllRetrievalsFailed         = errors.New("all retrievals failed")
+	ErrQueryFailed                 = errors.New("query failed")
+	ErrAllQueriesFailed            = errors.New("all queries failed")
+	ErrRetrievalTimedOut           = errors.New("retrieval timed out")
+)
+
+type ErrRetrievalAlreadyRunning struct {
+	C     cid.Cid
+	Extra string
+}
+
+func (e ErrRetrievalAlreadyRunning) Error() string {
+	return fmt.Sprintf("retrieval already running for CID: %s (%s)", e.C, e.Extra)
+}
+
+type RetrievalCandidate struct {
+	SourcePeer       peer.AddrInfo
+	RootCid          cid.Cid
+	Protocol         multicodec.Code
+	ProtocolMetadata interface{}
+}
+
+type CounterCallback func(int) error
+type CandidateCallback func(RetrievalCandidate) error
+type CandidateErrorCallback func(RetrievalCandidate, error)
+
+type GetStorageProviderTimeout func(peer peer.ID) time.Duration
+type IsAcceptableStorageProvider func(peer peer.ID) bool
+type IsAcceptableQueryResponse func(*retrievalmarket.QueryResponse) bool
+
+type Instrumentation interface {
+	// OnRetrievalCandidatesFound is called once after querying the indexer
+	OnRetrievalCandidatesFound(foundCount int) error
+	// OnRetrievalCandidatesFiltered is called once after filtering is applied to indexer candidates
+	OnRetrievalCandidatesFiltered(filteredCount int) error
+	// OnErrorQueryingRetrievalCandidate may be called up to once per retrieval candidate
+	OnErrorQueryingRetrievalCandidate(candidate RetrievalCandidate, err error)
+	// OnErrorRetrievingFromCandidate may be called up to once per retrieval candidate
+	OnErrorRetrievingFromCandidate(candidate RetrievalCandidate, err error)
+	// OnRetrievalQueryForCandidate may be called up to once per retrieval candidate
+	OnRetrievalQueryForCandidate(candidate RetrievalCandidate, queryResponse *retrievalmarket.QueryResponse)
+	// OnFilteredRetrievalQueryForCandidate may be called up to once per retrieval candidate
+	OnFilteredRetrievalQueryForCandidate(candidate RetrievalCandidate, queryResponse *retrievalmarket.QueryResponse)
+	// OnRetrievingFromCandidate may be called up to once per retrieval candidate
+	OnRetrievingFromCandidate(candidate RetrievalCandidate)
+}
+
+type RetrievalConfig struct {
+	Instrumentation             Instrumentation
+	GetStorageProviderTimeout   GetStorageProviderTimeout
+	IsAcceptableStorageProvider IsAcceptableStorageProvider
+	IsAcceptableQueryResponse   IsAcceptableQueryResponse
+
+	WaitGroup sync.WaitGroup // only used internally for testing cleanup
+}
+
+// wait is used internally for testing that we do proper goroutine cleanup
+func (cfg *RetrievalConfig) Wait() {
+	cfg.WaitGroup.Wait()
+}
+
+type ProviderConfig struct {
+	RetrievalTimeout        time.Duration
+	MaxConcurrentRetrievals uint
+}
+
+// All config values should be safe to leave uninitialized
+type RetrieverConfig struct {
+	ProviderDenylist      map[peer.ID]bool
+	ProviderAllowlist     map[peer.ID]bool
+	DefaultProviderConfig ProviderConfig
+	ProviderConfigs       map[peer.ID]ProviderConfig
+	PaidRetrievals        bool
+}
+
+func (cfg *RetrieverConfig) GetProviderConfig(peer peer.ID) ProviderConfig {
+	provCfg := cfg.DefaultProviderConfig
+
+	if individual, ok := cfg.ProviderConfigs[peer]; ok {
+		if individual.MaxConcurrentRetrievals != 0 {
+			provCfg.MaxConcurrentRetrievals = individual.MaxConcurrentRetrievals
+		}
+
+		if individual.RetrievalTimeout != 0 {
+			provCfg.RetrievalTimeout = individual.RetrievalTimeout
+		}
+	}
+
+	return provCfg
+}


### PR DESCRIPTION
having a separate interface package gives us flexibility to have multiple retrievers of different protocols in different packages

Also updated to current nomenclature of 'storage provider' and 'allowlist'