### PR TITLE
Add more detailed no-candidates error

### DIFF
--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -51,16 +51,16 @@ func (idxf *IndexerCandidateFinder) sendRequest(req *http.Request) (*model.FindR
 	return model.UnmarshalFindResponse(b)
 }
 
-func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]retriever.RetrievalCandidate, error) {
+func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]retriever.RetrievalCandidate, int, error) {
 	u := fmt.Sprint(idxf.baseUrl, "/multihash/", cid.Hash().B58String())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	parsedResp, err := idxf.sendRequest(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	hash := string(cid.Hash())
 	// turn parsedResp into records.
@@ -86,5 +86,5 @@ func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.
 			})
 		}
 	}
-	return matches, nil
+	return matches, len(indices), nil
 }

--- a/pkg/retriever/retrieve.go
+++ b/pkg/retriever/retrieve.go
@@ -141,7 +141,7 @@ func RetrieveFromCandidates(
 
 // findCandidates calls the indexer for the given CID
 func findCandidates(ctx context.Context, cfg *RetrievalConfig, candidateFinder CandidateFinder, cid cid.Cid) ([]RetrievalCandidate, error) {
-	candidates, err := candidateFinder.FindCandidates(ctx, cid)
+	candidates, total, err := candidateFinder.FindCandidates(ctx, cid)
 	if err != nil {
 		return nil, fmt.Errorf("could not get retrieval candidates for %s: %w", cid, err)
 	}
@@ -151,7 +151,7 @@ func findCandidates(ctx context.Context, cfg *RetrievalConfig, candidateFinder C
 	}
 
 	if len(candidates) == 0 {
-		return nil, ErrNoCandidates
+		return nil, ErrNoCandidates{unsupportedProtocols: total != 0}
 	}
 
 	acceptableCandidates := make([]RetrievalCandidate, 0)
@@ -168,7 +168,9 @@ func findCandidates(ctx context.Context, cfg *RetrievalConfig, candidateFinder C
 	}
 
 	if len(acceptableCandidates) == 0 {
-		return nil, ErrNoCandidates
+		return nil, ErrNoCandidates{
+			unacceptable: true,
+		}
 	}
 
 	return acceptableCandidates, nil

--- a/pkg/retriever/retrieve_test.go
+++ b/pkg/retriever/retrieve_test.go
@@ -543,8 +543,8 @@ type mockCandidateFinder struct {
 	candidates map[cid.Cid][]RetrievalCandidate
 }
 
-func (me *mockCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]RetrievalCandidate, error) {
-	return me.candidates[cid], nil
+func (me *mockCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]RetrievalCandidate, int, error) {
+	return me.candidates[cid], len(me.candidates[cid]), nil
 }
 
 func dummyBlockConfirmer(c cid.Cid) (bool, error) {

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -21,7 +21,6 @@ import (
 )
 
 var (
-	ErrNoCandidates                = errors.New("no candidates")
 	ErrUnexpectedRetrieval         = errors.New("unexpected active retrieval")
 	ErrHitRetrievalLimit           = errors.New("hit retrieval limit")
 	ErrProposalCreationFailed      = errors.New("proposal creation failed")
@@ -40,6 +39,21 @@ type ErrRetrievalAlreadyRunning struct {
 
 func (e ErrRetrievalAlreadyRunning) Error() string {
 	return fmt.Sprintf("retrieval already running for CID: %s (%s)", e.c, e.extra)
+}
+
+type ErrNoCandidates struct {
+	unsupportedProtocols bool
+	unacceptable         bool
+}
+
+func (e ErrNoCandidates) Error() string {
+	if e.unsupportedProtocols {
+		return "no candidates with supported protocols"
+	}
+	if e.unacceptable {
+		return "no acceptable candidates"
+	}
+	return "no candidates"
 }
 
 type MinerConfig struct {
@@ -89,7 +103,7 @@ type RetrievalCandidate struct {
 }
 
 type CandidateFinder interface {
-	FindCandidates(context.Context, cid.Cid) ([]RetrievalCandidate, error)
+	FindCandidates(context.Context, cid.Cid) ([]RetrievalCandidate, int, error)
 }
 
 type BlockConfirmer func(c cid.Cid) (bool, error)


### PR DESCRIPTION
Can distinguish between no candidates at all, no candidates with supported protocols and no acceptable candidates