### PR TITLE
Alternative retriever implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/multiformats/go-multiaddr v0.7.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/rvagg/go-prioritywaitqueue v1.0.3
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.23.7
 	go.opencensus.io v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1096,8 +1096,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/rvagg/go-prioritywaitqueue v1.0.3 h1:+YQwo80uQcUCDs1zkuLt0Frt+97ljghYjWq4WoZPdHs=
-github.com/rvagg/go-prioritywaitqueue v1.0.3/go.mod h1:fvzih7jz43jygRQKhaITNW3wLfUiWeA3qIH0rUTBhZI=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=

--- a/pkg/retriever/priorityqueue.go
+++ b/pkg/retriever/priorityqueue.go
@@ -1,0 +1,85 @@
+package retriever
+
+import (
+	"container/heap"
+	"context"
+)
+
+type PriorityQueue[T any] struct {
+	itemsCh chan sortableItems[T] // holds our heap items
+	emptyCh chan bool             // true if the queue is empty
+	cmp     func(a, b T) bool     // compare function
+}
+
+// Makes a new Queue
+func NewPriorityQueue[T any](cmp func(a, b T) bool) PriorityQueue[T] {
+	itemsCh := make(chan sortableItems[T], 1)
+	emptyCh := make(chan bool, 1)
+	emptyCh <- true
+	return PriorityQueue[T]{itemsCh, emptyCh, cmp}
+}
+
+func (q *PriorityQueue[T]) Get(ctx context.Context) (T, error) {
+	var items sortableItems[T]
+
+	select {
+	case items = <-q.itemsCh: // grab the items
+	case <-ctx.Done():
+		return *new(T), ctx.Err()
+	}
+
+	// safely grab last item
+	item := heap.Pop(&items).(*T)
+	if items.Len() == 0 {
+		q.emptyCh <- true // mark queue as empty
+	} else {
+		q.itemsCh <- items // communicate remaining items back to the channel
+	}
+
+	return *item, nil
+}
+
+func (q *PriorityQueue[T]) Put(item T) {
+	items := sortableItems[T]{[]*T{}, q.cmp}
+
+	// wait until...
+	select {
+	case items = <-q.itemsCh: // we can grab existing items
+	case <-q.emptyCh: // or queue is empty
+	}
+
+	heap.Push(&items, item)
+	q.itemsCh <- items
+}
+
+func (q *PriorityQueue[T]) Len() int { return len(q.itemsCh) }
+
+// sortableItems implements sort.Interface
+type sortableItems[T any] struct {
+	data []*T
+	cmp  func(a, b T) bool
+}
+
+func (t sortableItems[T]) Len() int { return len(t.data) }
+
+func (t sortableItems[T]) Less(i, j int) bool {
+	return t.cmp(*t.data[i], *t.data[j])
+}
+
+func (t sortableItems[T]) Swap(i, j int) {
+	t.data[i], t.data[j] = t.data[j], t.data[i]
+}
+
+func (t *sortableItems[T]) Push(x any) {
+	item := x.(T)
+	t.data = append(t.data, &item)
+}
+
+func (t *sortableItems[T]) Pop() any {
+	old := t
+	n := len(old.data) - 1
+	item := old.data[n]
+	old.data[n] = nil
+	t.data = old.data[:n]
+	return item
+}

--- a/pkg/retriever/priorityqueue_test.go
+++ b/pkg/retriever/priorityqueue_test.go
@@ -1,0 +1,121 @@
+package retriever
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type item struct {
+	id  int
+	put int // the number of seconds to sleep before being added to the queue
+	get int // the number of seconds to sleep before being removed from the queue
+}
+
+var cmdFunc = func(a, b *item) bool { return a.id < b.id }
+
+func TestQueue(t *testing.T) {
+	tests := []struct {
+		name     string
+		puts     []int // how long to sleep before queueing
+		gets     []int // how long to sleep before dequeueing
+		expected []int // the order we expect the items to be in
+	}{
+		{
+			// queue all at the same time and
+			// expect them to all be run in proper order
+			name:     "same start",
+			puts:     []int{10, 10, 10, 10, 10, 10, 10, 10, 10, 10},
+			gets:     []int{50, 10, 10, 10, 10, 10, 10, 10, 10, 10},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// same as previous but with messy arrival order
+			name:     "same start, skewed",
+			puts:     []int{00, 10, 15, 10, 15, 10, 15, 10, 15, 10},
+			gets:     []int{50, 10, 10, 10, 10, 10, 10, 10, 10, 10},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// start one, block queue, then queue 4, run them, with the final one
+			// blocking beyond when we add 5 more and expect them all to be run in
+			// proper order
+			name:     "batched start",
+			puts:     []int{00, 20, 20, 20, 20, 150, 150, 150, 150, 150},
+			gets:     []int{50, 10, 10, 10, 100, 10, 10, 10, 10, 10},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// same as previous but with different batches
+			name:     "batched start reverse",
+			puts:     []int{00, 150, 150, 150, 150, 150, 20, 20, 20, 20},
+			gets:     []int{50, 10, 10, 10, 10, 10, 10, 10, 10, 100},
+			expected: []int{0, 6, 7, 8, 9, 1, 2, 3, 4, 5},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup
+			queue := NewPriorityQueue(cmdFunc)
+			out := make(chan int, len(tc.puts))
+			wg := sync.WaitGroup{}
+			wg.Add(len(tc.puts))
+
+			items := make([]item, len(tc.puts))
+			for i := range tc.puts {
+				items[i] = item{i, tc.puts[i], tc.gets[i]}
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			for i := range tc.puts {
+				go func(t *item, q *PriorityQueue[*item]) {
+					defer wg.Done()
+
+					time.Sleep(time.Duration(t.put) * time.Millisecond)
+					q.Put(t)
+					time.Sleep(time.Duration(t.get) * time.Millisecond)
+					item, _ := q.Get(ctx)
+					out <- item.id
+				}(&items[i], &queue)
+			}
+
+			wg.Wait()
+			close(out)
+
+			var results []int
+			for id := range out {
+				results = append(results, id)
+			}
+
+			if len(results) != 10 {
+				t.Errorf("recorded %d outputs, expected 10", len(out))
+			}
+
+			if !reflect.DeepEqual(results, tc.expected) {
+				t.Errorf("did not get expected order of execution: %v <> %v", results, tc.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkEmptyQueuePut(b *testing.B) {
+	queue := NewPriorityQueue(cmdFunc)
+
+	for n := 0; n < b.N; n++ {
+		queue.Put(&item{0, 10, 20})
+	}
+}
+
+func BenchmarkNotEmptyQueuePut(b *testing.B) {
+	queue := NewPriorityQueue(cmdFunc)
+	queue.Put(&item{0, 10, 20})
+
+	for n := 0; n < b.N; n++ {
+		queue.Put(&item{0, 10, 20})
+	}
+}

--- a/pkg/retriever/priorityqueue_test.go
+++ b/pkg/retriever/priorityqueue_test.go
@@ -1,7 +1,6 @@
 package retriever
 
 import (
-	"context"
 	"reflect"
 	"sync"
 	"testing"
@@ -69,9 +68,6 @@ func TestQueue(t *testing.T) {
 				items[i] = item{i, tc.puts[i], tc.gets[i]}
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			for i := range tc.puts {
 				go func(t *item, q *PriorityQueue[*item]) {
 					defer wg.Done()
@@ -79,7 +75,7 @@ func TestQueue(t *testing.T) {
 					time.Sleep(time.Duration(t.put) * time.Millisecond)
 					q.Put(t)
 					time.Sleep(time.Duration(t.get) * time.Millisecond)
-					item, _ := q.Get(ctx)
+					item, _ := q.Get()
 					out <- item.id
 				}(&items[i], &queue)
 			}

--- a/pkg/retriever/retrieve.go
+++ b/pkg/retriever/retrieve.go
@@ -361,13 +361,8 @@ func runRetrievalPhase(
 
 		// retrieval routine
 		go func() {
-			// timeout the queue after a short time to not block forever,
-			// closing the routine and checking for success or no more attempts
-			getCtx, cancelCtx := context.WithTimeout(ctx, time.Second)
-			queryCandidate, err := retrieval.queue.Get(getCtx) // blocks until there is a value or timeout
-			cancelCtx()
-
-			if err != nil { // context cancel will release the retrieval
+			queryCandidate, empty := retrieval.queue.Get()
+			if empty { // if there's nothing to get at the moment, release this retrieval
 				<-retrieveSem
 				return
 			}

--- a/pkg/retriever/retrieve_test.go
+++ b/pkg/retriever/retrieve_test.go
@@ -472,9 +472,9 @@ func TestMultipleRetrievals(t *testing.T) {
 
 	waitStart := time.Now()
 	cfg.wait() // internal goroutine cleanup
-	qt.Assert(t, time.Since(waitStart) < time.Millisecond*20, qt.IsTrue, qt.Commentf("wait took %s", time.Since(waitStart)))
+	qt.Assert(t, time.Since(waitStart) < time.Millisecond*50, qt.IsTrue, qt.Commentf("wait took %s", time.Since(waitStart)))
 	wg.Wait() // make sure we're done with our own goroutine
-	qt.Assert(t, time.Since(waitStart) < time.Millisecond*20, qt.IsTrue, qt.Commentf("wg wait took %s", time.Since(waitStart)))
+	qt.Assert(t, time.Since(waitStart) < time.Millisecond*50, qt.IsTrue, qt.Commentf("wg wait took %s", time.Since(waitStart)))
 
 	// make sure we handled the queries we expected
 	qt.Assert(t, len(mockClient.Received_queriedPeers), qt.Equals, 6)


### PR DESCRIPTION
This is an alternative implementation of the retriever that touches on a few things that I felt could be improved. Overall I feel this improves the readability/digestibility of Retrieve() while removing some strange implementation details due to managing concurrency.

#### Notable Changes
- The queue implementation is a native golang heap, with logic to implement a priority max heap, that tracks candidates with a `Get` and `Put` API. This has the benefit of having a clearer API without having to mentally manage the lock and done call of a sync.Cond. The queue implementation is also included in this repo, which I believe is a better long term choice as opposed to having the implementation in a repo PL doesn't directly control.
- Queries and retrievals are now broken out into their own routines, ran via the `runQueryPhase` and `runRetreivalPhase` functions. This allowed the logic between queries and retrievals to be separate logical units that could keep track of their own state instead of having to constantly check "if this is not related to queries, then this is related to retrievals". This also means we have the freedom to easily control the queries and retrievals individually of each other, ie: allow an arbitrary number of parallel retrievals consuming queries by specifying the buffer size of the retrieval semaphore, adding a wait group that waits for an arbitrary number of queries to finish before retrievals, etc.
- The number of retrieval attempts is now tracked via `retrieval.attempts`. As queries and retrievals fail, the number of attempts is reduced by one. Zero attempts triggers a finish. Collecting the results no longer needs to know how many candidates we started with or how many retrieval attempts were made before failing or succeeding. It only watches for the results with a stats property to succeed.
- Because the queries and retrievals pass information via the queue, there is no longer a requirement to close any channels since they don't talk to each other over channels.
- Finish channel now has a buffer size of one, allowing it to be used a notification channel. Sending results and events no longer need to check if the finish channel is closed since the finish channel is never actually closed.