### PR TITLE
feat: reduce concurrency for SPs who drop out early from retrieval process

### DIFF
--- a/pkg/retriever/retrieve.go
+++ b/pkg/retriever/retrieve.go
@@ -24,7 +24,7 @@ type CandidateErrorCallback func(types.RetrievalCandidate, error)
 
 type GetStorageProviderTimeout func(peer peer.ID) time.Duration
 type IsAcceptableStorageProvider func(peer peer.ID) bool
-type IsAcceptableQueryResponse func(*retrievalmarket.QueryResponse) bool
+type IsAcceptableQueryResponse func(peer peer.ID, qr *retrievalmarket.QueryResponse) bool
 
 type queryCandidate struct {
 	*retrievalmarket.QueryResponse
@@ -258,7 +258,7 @@ func runRetrievalCandidate(ctx context.Context, cfg *RetrievalConfig, client Ret
 	if queryResponse != nil {
 		retrieval.sendEvent(events.QueryAsked(retrieval.retrievalId, phaseStartTime, candidate, *queryResponse))
 		if queryResponse.Status != retrievalmarket.QueryResponseAvailable ||
-			(cfg.IsAcceptableQueryResponse != nil && !cfg.IsAcceptableQueryResponse(queryResponse)) {
+			(cfg.IsAcceptableQueryResponse != nil && !cfg.IsAcceptableQueryResponse(candidate.MinerPeer.ID, queryResponse)) {
 			queryResponse = nil
 		}
 	}

--- a/pkg/retriever/retrieve_test.go
+++ b/pkg/retriever/retrieve_test.go
@@ -319,7 +319,7 @@ func TestRetrievalRacing(t *testing.T) {
 			cfg := &RetrievalConfig{
 				GetStorageProviderTimeout:   func(peer peer.ID) time.Duration { return time.Second },
 				IsAcceptableStorageProvider: func(peer peer.ID) bool { return true },
-				IsAcceptableQueryResponse:   func(qr *retrievalmarket.QueryResponse) bool { return true },
+				IsAcceptableQueryResponse:   func(peer peer.ID, qr *retrievalmarket.QueryResponse) bool { return true },
 			}
 
 			retrievingPeers := make([]peer.ID, 0)
@@ -430,7 +430,7 @@ func TestMultipleRetrievals(t *testing.T) {
 	cfg := &RetrievalConfig{
 		GetStorageProviderTimeout:   func(peer peer.ID) time.Duration { return time.Second },
 		IsAcceptableStorageProvider: func(peer peer.ID) bool { return true },
-		IsAcceptableQueryResponse:   func(qr *retrievalmarket.QueryResponse) bool { return true },
+		IsAcceptableQueryResponse:   func(peer peer.ID, qr *retrievalmarket.QueryResponse) bool { return true },
 	}
 
 	candidateQueries := make([]candidateQuery, 0)


### PR DESCRIPTION
* QueryResponse for this retrieval isn't acceptable
* Failure has occurred, either in query or retrieval

Allows the SP to be attempted again.

---

Came up during discussion on the autoretrieve problems and what the main differences are between "new lassie" and "old lassie". This is one, where removing the ActiveRetrievalsManager removed the fine-grained concurrency tracking (I think).

Without this change, the list of SPs that we end up with after filtering the indexer list are blocked from being talked to again until we finish the whole retrieval process and get either a final success or fail on all of them.

It may be worth discussing how much this is really worth it - if they are giving a QR saying they only do paid retrievals, what are the chances that they'll do it again? Probably high, so we're just freeing them up to give us the same QR again. Maybe the same argument for failures, although at the moment there are somewhat random retrieval failures that aren't guaranteed to happen again, it's likely to be piece-related so another attempt for a different CID may work just fine.