### PR TITLE
feat: reduce concurrency for SPs who drop out early from retrieval process (dupe of #46)

### DIFF
--- a/pkg/retriever/retrieve.go
+++ b/pkg/retriever/retrieve.go
@@ -24,7 +24,7 @@ type CandidateErrorCallback func(types.RetrievalCandidate, error)
 
 type GetStorageProviderTimeout func(peer peer.ID) time.Duration
 type IsAcceptableStorageProvider func(peer peer.ID) bool
-type IsAcceptableQueryResponse func(*retrievalmarket.QueryResponse) bool
+type IsAcceptableQueryResponse func(peer peer.ID, qr *retrievalmarket.QueryResponse) bool
 
 type queryCandidate struct {
 	*retrievalmarket.QueryResponse
@@ -258,7 +258,7 @@ func runRetrievalCandidate(ctx context.Context, cfg *RetrievalConfig, client Ret
 	if queryResponse != nil {
 		retrieval.sendEvent(events.QueryAsked(retrieval.retrievalId, phaseStartTime, candidate, *queryResponse))
 		if queryResponse.Status != retrievalmarket.QueryResponseAvailable ||
-			(cfg.IsAcceptableQueryResponse != nil && !cfg.IsAcceptableQueryResponse(queryResponse)) {
+			(cfg.IsAcceptableQueryResponse != nil && !cfg.IsAcceptableQueryResponse(candidate.MinerPeer.ID, queryResponse)) {
 			queryResponse = nil
 		}
 	}

--- a/pkg/retriever/retrieve_test.go
+++ b/pkg/retriever/retrieve_test.go
@@ -319,7 +319,7 @@ func TestRetrievalRacing(t *testing.T) {
 			cfg := &RetrievalConfig{
 				GetStorageProviderTimeout:   func(peer peer.ID) time.Duration { return time.Second },
 				IsAcceptableStorageProvider: func(peer peer.ID) bool { return true },
-				IsAcceptableQueryResponse:   func(qr *retrievalmarket.QueryResponse) bool { return true },
+				IsAcceptableQueryResponse:   func(peer peer.ID, qr *retrievalmarket.QueryResponse) bool { return true },
 			}
 
 			retrievingPeers := make([]peer.ID, 0)
@@ -430,7 +430,7 @@ func TestMultipleRetrievals(t *testing.T) {
 	cfg := &RetrievalConfig{
 		GetStorageProviderTimeout:   func(peer peer.ID) time.Duration { return time.Second },
 		IsAcceptableStorageProvider: func(peer peer.ID) bool { return true },
-		IsAcceptableQueryResponse:   func(qr *retrievalmarket.QueryResponse) bool { return true },
+		IsAcceptableQueryResponse:   func(peer peer.ID, qr *retrievalmarket.QueryResponse) bool { return true },
 	}
 
 	candidateQueries := make([]candidateQuery, 0)


### PR DESCRIPTION
This is the same commit as in #46 but that PR targetted `rvagg/events-consolidation` which was merged but not deleted so the PR didn't get auto-retargetted to `main` but instead was merged into a dead branch and is not on main!