### PR TITLE
feat: require LinkSystem argument for each retrieval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-cbor-util v0.0.1
-	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230111032640-1da99777ed8b
+	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230131030609-5f9a1d9b4d60
 	github.com/filecoin-project/go-fil-markets v1.25.3-0.20230107010325-143abaddd0f3
 	github.com/filecoin-project/go-state-types v0.9.9
 	github.com/filecoin-project/index-provider v0.9.2
@@ -20,6 +20,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-graphsync v0.14.0
 	github.com/ipfs/go-ipfs-blockstore v1.2.0
+	github.com/ipfs/go-ipld-format v0.4.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-car/v2 v2.5.1
 	github.com/ipld/go-ipld-prime v0.19.0
@@ -83,7 +84,6 @@ require (
 	github.com/ipfs/go-ipfs-pq v0.0.2 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.0.6 // indirect
-	github.com/ipfs/go-ipld-format v0.4.0 // indirect
 	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-merkledag v0.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-cbor-util v0.0.1
-	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230131030609-5f9a1d9b4d60
+	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc2
 	github.com/filecoin-project/go-fil-markets v1.25.3-0.20230107010325-143abaddd0f3
 	github.com/filecoin-project/go-state-types v0.9.9
 	github.com/filecoin-project/index-provider v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/filecoin-project/go-commp-utils/nonffi v0.0.0-20220905160352-62059082
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0dKsJcVJrioJJnjnKmxlk=
-github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230111032640-1da99777ed8b h1:Tk0nxIJOcpJc4pQa/uC5ykt9AmzaykcSUdyDlUT9+Dk=
-github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230111032640-1da99777ed8b/go.mod h1:zcT4aJHBC+BnaF9tZrrevG30eaPezi5aGokP6YAW2PY=
+github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230131030609-5f9a1d9b4d60 h1:V1CjLl7gK4zXIh2UDiluJDRIK0cWcCqXyFdsXVMs8cY=
+github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230131030609-5f9a1d9b4d60/go.mod h1:DckrS1zxrtRNtIu3YdylWUKR4ZyJYNGHnox9n1eY/O4=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/filecoin-project/go-commp-utils/nonffi v0.0.0-20220905160352-62059082
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0dKsJcVJrioJJnjnKmxlk=
-github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230131030609-5f9a1d9b4d60 h1:V1CjLl7gK4zXIh2UDiluJDRIK0cWcCqXyFdsXVMs8cY=
-github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1.0.20230131030609-5f9a1d9b4d60/go.mod h1:DckrS1zxrtRNtIu3YdylWUKR4ZyJYNGHnox9n1eY/O4=
+github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc2 h1:O0SKeCU9eokmERkOFEzgW2vvFuBSQeLAywvUSao+Gh0=
+github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc2/go.mod h1:DckrS1zxrtRNtIu3YdylWUKR4ZyJYNGHnox9n1eY/O4=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=

--- a/pkg/retriever/retrievalclient.go
+++ b/pkg/retriever/retrievalclient.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -21,6 +22,7 @@ type RetrievalClient interface {
 
 	RetrieveFromPeer(
 		ctx context.Context,
+		linkSystem ipld.LinkSystem,
 		peerID peer.ID,
 		minerWallet address.Address,
 		proposal *retrievalmarket.DealProposal,

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/lassie/pkg/metrics"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.opencensus.io/stats"
 )
@@ -164,7 +165,13 @@ func (retriever *Retriever) isAcceptableQueryResponse(queryResponse *retrievalma
 
 // Retrieve attempts to retrieve the given CID using the configured
 // CandidateFinder to find storage providers that should have the CID.
-func (retriever *Retriever) Retrieve(ctx context.Context, retrievalId types.RetrievalID, cid cid.Cid) (*types.RetrievalStats, error) {
+func (retriever *Retriever) Retrieve(
+	ctx context.Context,
+	linkSystem ipld.LinkSystem,
+	retrievalId types.RetrievalID,
+	cid cid.Cid,
+) (*types.RetrievalStats, error) {
+
 	if !retriever.eventManager.IsStarted() {
 		return nil, ErrRetrieverNotStarted
 	}
@@ -200,6 +207,7 @@ func (retriever *Retriever) Retrieve(ctx context.Context, retrievalId types.Retr
 	retrievalStats, err := RetrieveFromCandidates(
 		ctx,
 		config,
+		linkSystem,
 		retriever.candidateFinder,
 		retriever.client,
 		retrievalId,

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/linking"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +31,7 @@ func TestRetrieverStart(t *testing.T) {
 	require.NoError(t, err)
 
 	// --- run ---
-	result, err := ret.Retrieve(context.Background(), types.RetrievalID(uuid.New()), cid.MustParse("bafkqaalb"))
+	result, err := ret.Retrieve(context.Background(), cidlink.DefaultLinkSystem(), types.RetrievalID(uuid.New()), cid.MustParse("bafkqaalb"))
 	require.ErrorIs(t, err, retriever.ErrRetrieverNotStarted)
 	require.Nil(t, result)
 }
@@ -344,10 +348,7 @@ func TestRetriever(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// --- setup ---
 			candidateFinder := &testutil.MockCandidateFinder{Candidates: map[cid.Cid][]types.RetrievalCandidate{cid1: tc.candidates}}
-			client := &testutil.MockClient{
-				Returns_queries:    tc.returns_queries,
-				Returns_retrievals: tc.returns_retrievals,
-			}
+			client := testutil.NewMockClient(tc.returns_queries, tc.returns_retrievals)
 			subscriber := testutil.NewCollectingEventsListener()
 			config := retriever.RetrieverConfig{
 				MinerBlacklist: map[peer.ID]bool{blacklistedPeer: true},
@@ -366,7 +367,7 @@ func TestRetriever(t *testing.T) {
 
 			// --- retrieve ---
 			require.NoError(t, err)
-			result, err := ret.Retrieve(context.Background(), rid, cid1)
+			result, err := ret.Retrieve(context.Background(), cidlink.DefaultLinkSystem(), rid, cid1)
 			if tc.err == nil {
 				require.NoError(t, err)
 				successfulPeer := string(tc.successfulPeer)
@@ -377,7 +378,7 @@ func TestRetriever(t *testing.T) {
 						}
 					}
 				}
-				require.Equal(t, client.Returns_retrievals[successfulPeer].ResultStats, result)
+				require.Equal(t, client.GetRetrievalReturns()[successfulPeer].ResultStats, result)
 			} else {
 				require.ErrorIs(t, tc.err, err)
 			}
@@ -408,4 +409,101 @@ func TestRetriever(t *testing.T) {
 			testutil.VerifyCollectedEventTimings(t, subscriber.CollectedEvents)
 		})
 	}
+}
+
+func TestLinkSystemPerRequest(t *testing.T) {
+	rid := types.RetrievalID(uuid.New())
+	cid1 := cid.MustParse("bafkqaalb")
+	peerA := peer.ID("A")
+	peerB := peer.ID("B")
+
+	candidates := []types.RetrievalCandidate{
+		{MinerPeer: peer.AddrInfo{ID: peerA}, RootCid: cid1},
+		{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid1},
+	}
+	returnsQueries := map[string]testutil.DelayedQueryReturn{
+		string(peerA): {QueryResponse: &retrievalmarket.QueryResponse{Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()}, Err: nil, Delay: time.Millisecond * 5},
+		string(peerB): {QueryResponse: &retrievalmarket.QueryResponse{Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()}, Err: nil, Delay: time.Millisecond * 50},
+	}
+	returnsRetrievals := map[string]testutil.DelayedRetrievalReturn{
+		string(peerA): {ResultStats: &types.RetrievalStats{
+			StorageProviderId: peerA,
+			Size:              1,
+			Blocks:            2,
+			Duration:          3 * time.Second,
+			TotalPayment:      big.Zero(),
+			RootCid:           cid1,
+			AskPrice:          abi.NewTokenAmount(0),
+		}, Delay: time.Millisecond * 5},
+		string(peerB): {ResultStats: &types.RetrievalStats{
+			StorageProviderId: peerB,
+			Size:              10,
+			Blocks:            11,
+			Duration:          12 * time.Second,
+			TotalPayment:      big.Zero(),
+			RootCid:           cid1,
+			AskPrice:          abi.NewTokenAmount(0),
+		}, Delay: time.Millisecond * 5},
+	}
+
+	candidateFinder := &testutil.MockCandidateFinder{Candidates: map[cid.Cid][]types.RetrievalCandidate{cid1: candidates}}
+	client := testutil.NewMockClient(returnsQueries, returnsRetrievals)
+	subscriber := testutil.NewCollectingEventsListener()
+	config := retriever.RetrieverConfig{}
+
+	// --- create ---
+	ret, err := retriever.NewRetriever(context.Background(), config, client, candidateFinder)
+	require.NoError(t, err)
+	ret.RegisterSubscriber(subscriber.Collect)
+
+	// --- start ---
+	ret.Start()
+
+	// --- retrieve ---
+	lsA := cidlink.DefaultLinkSystem()
+	lsA.NodeReifier = func(lc linking.LinkContext, n datamodel.Node, ls *linking.LinkSystem) (datamodel.Node, error) {
+		return basicnode.NewString("linkSystem A"), nil
+	}
+	lsB := cidlink.DefaultLinkSystem()
+	lsB.NodeReifier = func(lc linking.LinkContext, n datamodel.Node, ls *linking.LinkSystem) (datamodel.Node, error) {
+		return basicnode.NewString("linkSystem B"), nil
+	}
+	result, err := ret.Retrieve(context.Background(), lsA, rid, cid1)
+	require.NoError(t, err)
+	require.Equal(t, returnsRetrievals[string(peerA)].ResultStats, result)
+
+	// switch them around
+	returnsQueries = map[string]testutil.DelayedQueryReturn{
+		string(peerA): {QueryResponse: &retrievalmarket.QueryResponse{Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()}, Err: nil, Delay: time.Millisecond * 50},
+		string(peerB): {QueryResponse: &retrievalmarket.QueryResponse{Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()}, Err: nil, Delay: time.Millisecond * 5},
+	}
+	client.SetQueryReturns(returnsQueries)
+
+	// --- retrieve ---
+	result, err = ret.Retrieve(context.Background(), lsB, rid, cid1)
+	require.NoError(t, err)
+	require.Equal(t, returnsRetrievals[string(peerB)].ResultStats, result)
+
+	// --- stop ---
+	time.Sleep(time.Millisecond * 5) // sleep to allow events to flush
+	select {
+	case <-ret.Stop():
+	case <-time.After(time.Millisecond * 50):
+		require.Fail(t, "timed out waiting for retriever to stop")
+	}
+
+	// --- verify ---
+	// two different linksystems for the different calls, in the order that we
+	// supplied them in our call to Retrieve()
+	require.Len(t, client.GetReceivedLinkSystems(), 2)
+	nd, err := client.GetReceivedLinkSystems()[0].NodeReifier(linking.LinkContext{}, nil, nil)
+	require.NoError(t, err)
+	str, err := nd.AsString()
+	require.NoError(t, err)
+	require.Equal(t, "linkSystem A", str)
+	nd, err = client.GetReceivedLinkSystems()[1].NodeReifier(linking.LinkContext{}, nil, nil)
+	require.NoError(t, err)
+	str, err = nd.AsString()
+	require.NoError(t, err)
+	require.Equal(t, "linkSystem B", str)
 }


### PR DESCRIPTION
Allows for separate, or combined block storage for each retrieval.

Uses https://github.com/filecoin-project/go-data-transfer/pull/362, will be draft until that's merged.