### PR TITLE
Implement asyc find candidate over IPNI `ndjson` APIs

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -199,6 +199,25 @@ type explicitCandidateFinder struct {
 	provider peer.AddrInfo
 }
 
+func (e explicitCandidateFinder) FindCandidatesAsync(ctx context.Context, c cid.Cid) (<-chan types.FindCandidatesResult, error) {
+	rs, err := e.FindCandidates(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	switch len(rs) {
+	case 0:
+		return nil, nil
+	default:
+		rch := make(chan types.FindCandidatesResult, len(rs))
+		for _, r := range rs {
+			rch <- types.FindCandidatesResult{
+				Candidate: r,
+			}
+		}
+		return rch, nil
+	}
+}
+
 func (e explicitCandidateFinder) FindCandidates(_ context.Context, c cid.Cid) ([]types.RetrievalCandidate, error) {
 	return []types.RetrievalCandidate{
 		{

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/ipni/storetheindex v0.5.4
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/multiformats/go-multiaddr v0.7.0
+	github.com/multiformats/go-multicodec v0.6.0
+	github.com/multiformats/go-multihash v0.2.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rvagg/go-prioritywaitqueue v1.0.3
 	github.com/stretchr/testify v1.8.1
@@ -129,8 +131,6 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
-	github.com/multiformats/go-multicodec v0.6.0 // indirect
-	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-multistream v0.3.3 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect

--- a/pkg/eventrecorder/eventrecorder_test.go
+++ b/pkg/eventrecorder/eventrecorder_test.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
+var testCid1 = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
 
 func TestEventRecorder(t *testing.T) {
 	var req datamodel.Node
@@ -63,6 +63,7 @@ func TestEventRecorder(t *testing.T) {
 
 				select {
 				case <-ctx.Done():
+					t.Fatal(ctx.Err())
 				case <-receivedChan:
 				}
 
@@ -102,6 +103,7 @@ func TestEventRecorder(t *testing.T) {
 
 				select {
 				case <-ctx.Done():
+					t.Fatal(ctx.Err())
 				case <-receivedChan:
 				}
 
@@ -135,6 +137,7 @@ func TestEventRecorder(t *testing.T) {
 
 				select {
 				case <-ctx.Done():
+					t.Fatal(ctx.Err())
 				case <-receivedChan:
 				}
 				qt.Assert(t, req.Length(), qt.Equals, int64(1))
@@ -165,6 +168,7 @@ func TestEventRecorder(t *testing.T) {
 
 				select {
 				case <-ctx.Done():
+					t.Fatal(ctx.Err())
 				case <-receivedChan:
 				}
 
@@ -196,6 +200,7 @@ func TestEventRecorder(t *testing.T) {
 
 				select {
 				case <-ctx.Done():
+					t.Fatal(ctx.Err())
 				case <-receivedChan:
 				}
 
@@ -222,6 +227,7 @@ func TestEventRecorder(t *testing.T) {
 
 				select {
 				case <-ctx.Done():
+					t.Fatal(ctx.Err())
 				case <-receivedChan:
 				}
 
@@ -245,7 +251,7 @@ func TestEventRecorder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
 			er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue)
 			id, err := types.NewRetrievalID()

--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -1,90 +1,184 @@
 package indexerlookup
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/filecoin-project/lassie/pkg/retriever"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-log/v2"
 	"github.com/ipni/storetheindex/api/v0/finder/model"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+)
+
+var (
+	_ retriever.CandidateFinder = (*IndexerCandidateFinder)(nil)
+
+	logger = log.Logger("indexerlookup")
 )
 
 type IndexerCandidateFinder struct {
-	c       *http.Client
-	baseUrl string
+	*options
 }
 
-func NewCandidateFinder(url string) *IndexerCandidateFinder {
+func NewCandidateFinder(o ...Option) (*IndexerCandidateFinder, error) {
+	opts, err := newOptions(o...)
+	if err != nil {
+		return nil, err
+	}
 	return &IndexerCandidateFinder{
-		c: &http.Client{
-			Timeout: time.Minute,
-		},
-		baseUrl: url,
-	}
+		options: opts,
+	}, nil
 }
 
-func (idxf *IndexerCandidateFinder) sendRequest(req *http.Request) (*model.FindResponse, error) {
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := idxf.c.Do(req)
+func (idxf *IndexerCandidateFinder) sendJsonRequest(req *http.Request) (*model.FindResponse, error) {
+	req.Header.Set("Accept", "application/json")
+	resp, err := idxf.httpClient.Do(req)
 	if err != nil {
+		logger.Debugw("Failed to perform json lookup", "err", err)
 		return nil, err
 	}
-	// Handle failed requests
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusNotFound {
-			return &model.FindResponse{}, nil
+	switch resp.StatusCode {
+	case http.StatusOK:
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Debugw("Failed to read response JSON response body", "err", err)
+			return nil, err
 		}
-		return nil, fmt.Errorf("batch find query failed: %v", http.StatusText(resp.StatusCode))
+		return model.UnmarshalFindResponse(b)
+	case http.StatusNotFound:
+		return &model.FindResponse{}, nil
+	default:
+		return nil, fmt.Errorf("batch find query failed: %s", http.StatusText(resp.StatusCode))
 	}
-
-	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return model.UnmarshalFindResponse(b)
 }
 
 func (idxf *IndexerCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]types.RetrievalCandidate, error) {
-	u := fmt.Sprint(idxf.baseUrl, "/multihash/", cid.Hash().B58String())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := idxf.newFindHttpRequest(ctx, cid)
 	if err != nil {
 		return nil, err
 	}
-
-	parsedResp, err := idxf.sendRequest(req)
+	parsedResp, err := idxf.sendJsonRequest(req)
 	if err != nil {
 		return nil, err
 	}
-	hash := string(cid.Hash())
 	// turn parsedResp into records.
 	var matches []types.RetrievalCandidate
 
 	indices := rand.Perm(len(parsedResp.MultihashResults))
 	for _, i := range indices {
 		multihashResult := parsedResp.MultihashResults[i]
-
-		if !(string(multihashResult.Multihash) == hash) {
+		if !bytes.Equal(cid.Hash(), multihashResult.Multihash) {
 			continue
 		}
 		for _, val := range multihashResult.ProviderResults {
 			// filter out any results that aren't filecoin graphsync
-			var dtm metadata.GraphsyncFilecoinV1
-			if err := dtm.UnmarshalBinary(val.Metadata); err != nil {
-				continue
+			if hasTransportGraphsyncFilecoinv1(val) {
+				matches = append(matches, types.RetrievalCandidate{
+					RootCid:   cid,
+					MinerPeer: val.Provider,
+				})
 			}
-
-			matches = append(matches, types.RetrievalCandidate{
-				RootCid:   cid,
-				MinerPeer: val.Provider,
-			})
 		}
 	}
 	return matches, nil
+}
+
+func hasTransportGraphsyncFilecoinv1(pr model.ProviderResult) bool {
+	if len(pr.Metadata) == 0 {
+		return false
+	}
+	// Metadata may contain more than one protocol, sorted by ascending order of their protocol ID.
+	// Therefore, decode the metadata as metadata.Metadata, then check if it supports Graphsync.
+	// See: https://github.com/ipni/specs/blob/main/IPNI.md#metadata
+	dtm := metadata.Default.New()
+	if err := dtm.UnmarshalBinary(pr.Metadata); err != nil {
+		logger.Debugw("Failed to unmarshal metadata", "err", err)
+		return false
+	}
+	return dtm.Get(multicodec.TransportGraphsyncFilecoinv1) != nil
+}
+
+func (idxf *IndexerCandidateFinder) FindCandidatesAsync(ctx context.Context, c cid.Cid) (<-chan types.FindCandidatesResult, error) {
+	req, err := idxf.newFindHttpRequest(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/x-ndjson")
+	resp, err := idxf.httpClient.Do(req)
+	if err != nil {
+		logger.Debugw("Failed to perform streaming lookup", "err", err)
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		defer resp.Body.Close()
+		return idxf.decodeProviderResultStream(ctx, c, resp.Body)
+	case http.StatusNotFound:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("batch find query failed: %v", http.StatusText(resp.StatusCode))
+	}
+}
+
+func (idxf *IndexerCandidateFinder) newFindHttpRequest(ctx context.Context, c cid.Cid) (*http.Request, error) {
+	endpoint := idxf.findByMultihashEndpoint(c.Hash())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if idxf.httpUserAgent != "" {
+		req.Header.Set("User-Agent", idxf.httpUserAgent)
+	}
+	return req, nil
+}
+
+func (idxf *IndexerCandidateFinder) decodeProviderResultStream(ctx context.Context, c cid.Cid, from io.Reader) (<-chan types.FindCandidatesResult, error) {
+	rch := make(chan types.FindCandidatesResult, idxf.asyncResultsChanBuffer)
+	go func() {
+		defer close(rch)
+		scanner := bufio.NewScanner(from)
+		for {
+			var r types.FindCandidatesResult
+			select {
+			case <-ctx.Done():
+				r.Err = ctx.Err()
+				rch <- r
+				return
+			default:
+				if scanner.Scan() {
+					line := scanner.Bytes()
+					if len(line) == 0 {
+						continue
+					}
+					var pr model.ProviderResult
+					if r.Err = json.Unmarshal(line, &pr); r.Err != nil {
+						rch <- r
+						return
+					}
+					r.Candidate.MinerPeer = pr.Provider
+					r.Candidate.RootCid = c
+					rch <- r
+				} else if r.Err = scanner.Err(); r.Err != nil {
+					rch <- r
+					return
+				}
+			}
+		}
+	}()
+	return rch, nil
+}
+
+func (idxf *IndexerCandidateFinder) findByMultihashEndpoint(mh multihash.Multihash) string {
+	return idxf.httpEndpoint.JoinPath("multihash", mh.B58String()).String()
 }

--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"path"
 
 	"github.com/filecoin-project/index-provider/metadata"
 	"github.com/filecoin-project/lassie/pkg/retriever"
@@ -180,5 +181,7 @@ func (idxf *IndexerCandidateFinder) decodeProviderResultStream(ctx context.Conte
 }
 
 func (idxf *IndexerCandidateFinder) findByMultihashEndpoint(mh multihash.Multihash) string {
-	return idxf.httpEndpoint.JoinPath("multihash", mh.B58String()).String()
+	// TODO: Replace with URL.JoinPath once minimum go version in CI is updated to 1.19; like this:
+	//       return idxf.httpEndpoint.JoinPath("multihash", mh.B58String()).String()
+	return idxf.httpEndpoint.String() + path.Join("/multihash", mh.B58String())
 }

--- a/pkg/indexerlookup/options.go
+++ b/pkg/indexerlookup/options.go
@@ -1,0 +1,91 @@
+package indexerlookup
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type (
+	Option  func(*options) error
+	options struct {
+		asyncResultsChanBuffer int
+		httpEndpoint           *url.URL
+		httpClient             *http.Client
+		httpClientTimeout      time.Duration
+		httpUserAgent          string
+	}
+)
+
+func newOptions(o ...Option) (*options, error) {
+	const defaultEndpoint = "https://cid.contact"
+	opts := options{
+		asyncResultsChanBuffer: 1,
+		httpClient:             http.DefaultClient,
+		httpClientTimeout:      time.Minute,
+		httpUserAgent:          "lassie",
+	}
+	for _, apply := range o {
+		if err := apply(&opts); err != nil {
+			return nil, err
+		}
+	}
+	var err error
+	if opts.httpEndpoint == nil {
+		opts.httpEndpoint, err = url.Parse(defaultEndpoint)
+		if err != nil {
+			// We can also panic here; but considering we can also return error
+			// let there be less panics in this world, and sanity check defaults
+			// in unit tests instead.
+			return nil, err
+		}
+	}
+	opts.httpClient.Timeout = opts.httpClientTimeout
+	return &opts, nil
+}
+
+// WithHttpClient sets the http.Client used to contact the indexer.
+// Defaults to http.DefaultClient if unspecified.
+func WithHttpClient(c *http.Client) Option {
+	return func(o *options) error {
+		o.httpClient = c
+		return nil
+	}
+}
+
+// WithHttpClientTimeout sets the timeout for the HTTP requests sent to the indexer.
+// Defaults to one minute if unspecified.
+func WithHttpClientTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.httpClientTimeout = t
+		return nil
+	}
+}
+
+// WithHttpEndpoint sets the indexer HTTP API endpoint.
+// Defaults to https://cid.contact if unspecified.
+func WithHttpEndpoint(e *url.URL) Option {
+	return func(o *options) error {
+		o.httpEndpoint = e
+		return nil
+	}
+}
+
+// WithHttpUserAgent sets the User-Agent header value when contacting the indexer HTTP API.
+// Setting this option to empty string will disable inclusion of User-Agent header.
+// Defaults to "lassie" if unspecified.
+func WithHttpUserAgent(a string) Option {
+	return func(o *options) error {
+		o.httpUserAgent = a
+		return nil
+	}
+}
+
+// WithAsyncResultsChanBuffer sets the channel buffer returned by IndexerCandidateFinder.FindCandidatesAsync.
+// Defaults to 1 if unspecified.
+func WithAsyncResultsChanBuffer(i int) Option {
+	return func(o *options) error {
+		o.asyncResultsChanBuffer = i
+		return nil
+	}
+}

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -39,7 +39,11 @@ func NewLassie(ctx context.Context, opts ...LassieOption) (*Lassie, error) {
 
 func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error) {
 	if cfg.Finder == nil {
-		cfg.Finder = indexerlookup.NewCandidateFinder("https://cid.contact")
+		var err error
+		cfg.Finder, err = indexerlookup.NewCandidateFinder()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if cfg.Timeout == 0 {

--- a/pkg/retriever/executor_test.go
+++ b/pkg/retriever/executor_test.go
@@ -100,7 +100,7 @@ func TestQueryFiltering(t *testing.T) {
 				dqr[p] = testutil.DelayedQueryReturn{QueryResponse: qr, Err: nil, Delay: time.Millisecond * 50}
 			}
 			mockClient := testutil.NewMockClient(dqr, nil)
-			candidates := []types.RetrievalCandidate{}
+			var candidates []types.RetrievalCandidate
 			for p := range tc.queryResponses {
 				candidates = append(candidates, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID(p)}})
 			}

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -74,6 +74,7 @@ type Retriever struct {
 
 type CandidateFinder interface {
 	FindCandidates(context.Context, cid.Cid) ([]types.RetrievalCandidate, error)
+	FindCandidatesAsync(context.Context, cid.Cid) (<-chan types.FindCandidatesResult, error)
 }
 
 type eventStats struct {

--- a/pkg/retriever/testutil/mockcandidatefinder.go
+++ b/pkg/retriever/testutil/mockcandidatefinder.go
@@ -12,6 +12,25 @@ type MockCandidateFinder struct {
 	Candidates map[cid.Cid][]types.RetrievalCandidate
 }
 
+func (me *MockCandidateFinder) FindCandidatesAsync(ctx context.Context, c cid.Cid) (<-chan types.FindCandidatesResult, error) {
+	rs, err := me.FindCandidates(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	switch len(rs) {
+	case 0:
+		return nil, nil
+	default:
+		rch := make(chan types.FindCandidatesResult, len(rs))
+		for _, r := range rs {
+			rch <- types.FindCandidatesResult{
+				Candidate: r,
+			}
+		}
+		return rch, nil
+	}
+}
+
 func (me *MockCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid) ([]types.RetrievalCandidate, error) {
 	if me.Error != nil {
 		return nil, me.Error

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -79,7 +79,7 @@ type RetrievalStats struct {
 	AskPrice          abi.TokenAmount
 
 	// TODO: we should be able to get this if we hook into the graphsync event stream
-	//TimeToFirstByte time.Duration
+	// TimeToFirstByte time.Duration
 }
 
 type Phase string
@@ -129,6 +129,11 @@ type RetrievalEvent interface {
 
 // RetrievalEventSubscriber is a function that receives a stream of retrieval
 // events from all retrievals that are in progress. Various different types
-// implement the RetrievalEvent interface and may contain additionl information
+// implement the RetrievalEvent interface and may contain additional information
 // about the event beyond what is available on the RetrievalEvent interface.
 type RetrievalEventSubscriber func(event RetrievalEvent)
+
+type FindCandidatesResult struct {
+	Candidate RetrievalCandidate
+	Err       error
+}


### PR DESCRIPTION
Implement the capability to find retrieval candidates for a given CID asynchronously using the new IPNI `ndjosn` APIs. The changes introduce an async variation of `FindCandidates` to the `retriever.CandidateFinder` interface.

Introduce options to indxer-lookup implementation and refactor the hardcoded defaults across the code.

Fix a couple of bugs in indexer-lookup implementation of candidate finder, namely:

* Set the mime-type correctly in request; use `Accept` header instead of `Content-Type`. The latter is for response, not needed in request.
* Decode metadata as whole, since it may contain multiple protocols. This would have resulted in false negative errors and ultimately exclusion of candidates that support multiple protocols including GraphSync.