### PR TITLE
Treat query response errors as query failures

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,14 +60,8 @@ var QueryErrorMetricMatches = map[string]*stats.Int64Measure{
 	"failed to open stream to peer":         QueryErrorFailedToOpenStreamCount,
 	"failed to read response: EOF":          QueryErrorResponseEOFCount,
 	"failed to read response: stream reset": QueryErrorResponseStreamResetCount,
-}
-
-// QueryResponseMetricMatches is a mapping of retrieval error message substrings
-// during the query phase when a response is sent but it is a failure
-// and metrics to report for that failure.
-var QueryResponseMetricMatches = map[string]*stats.Int64Measure{
-	"getting pieces for cid":             QueryErrorDAGStoreCount,
-	"failed to fetch storage deal state": QueryErrorDealNotFoundCount,
+	"getting pieces for cid":                QueryErrorDAGStoreCount,
+	"failed to fetch storage deal state":    QueryErrorDealNotFoundCount,
 }
 
 // ErrorMetricMatches is a mapping of retrieval error message substrings (i.e.

--- a/pkg/retriever/executor.go
+++ b/pkg/retriever/executor.go
@@ -209,6 +209,12 @@ func runRetrievalCandidate(
 		retrieval.sendEvent(events.Failed(req.RetrievalID, phaseStartTime, types.QueryPhase, candidate, queryErr.Error()))
 	}
 
+	// treat QueryResponseError as a failure
+	if queryResponse != nil && queryResponse.Status == retrievalmarket.QueryResponseError {
+		retrieval.sendEvent(events.Failed(req.RetrievalID, phaseStartTime, types.QueryPhase, candidate, queryResponse.Message))
+		queryResponse = nil
+	}
+
 	if queryResponse != nil {
 		retrieval.sendEvent(events.QueryAsked(req.RetrievalID, phaseStartTime, candidate, *queryResponse))
 		if queryResponse.Status != retrievalmarket.QueryResponseAvailable ||

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -295,20 +295,6 @@ func handleQueryAskEvent(
 	if eventStats.queryCount == 1 {
 		stats.Record(context.Background(), metrics.RequestWithSuccessfulQueriesCount.M(1))
 	}
-
-	if event.QueryResponse().Status == retrievalmarket.QueryResponseError {
-		var matched bool
-		for substr, metric := range metrics.QueryResponseMetricMatches {
-			if strings.Contains(event.QueryResponse().Message, substr) {
-				stats.Record(ctx, metric.M(1))
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			stats.Record(ctx, metrics.QueryErrorOtherCount.M(1))
-		}
-	}
 }
 
 // handleFailureEvent is called when a query _or_ retrieval fails


### PR DESCRIPTION
# Goals

Currently, DAG Store issues, and other query errors from the provider show up in metrics as "filtering" on a query. I think this is a mistake. They're a failure. It's making the query success rate look artificially high (96+% when it's actually nearer to 80%) and this isn't good for our ability to track errors or for golden retriever. We should subtract them from the successful query count and not record them as just candidates that got filtered.

# Implementation

- Handle QueryResponseError status seperately in executor
- Pass the "Message" parameter as the error
- We can now combine the "QueryResponseMetricMatches" & "QueryErrorMetricMatches" into one
- Simplifies queryasked event handling as well.