### PR TITLE
Make project installable with go install

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import "github.com/urfave/cli/v2"
 

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 
 var log = logging.Logger("lassie")
 
-func main() {
+func Run() {
 	// set up a context that is canceled when a command is interrupted
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -12,8 +12,11 @@ import (
 )
 
 var log = logging.Logger("lassie")
+var buildVersion string
 
-func Run() {
+func Run(version string) {
+	buildVersion = version
+
 	// set up a context that is canceled when a command is interrupted
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/lassie/version.go
+++ b/cmd/lassie/version.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"

--- a/cmd/lassie/version.go
+++ b/cmd/lassie/version.go
@@ -2,34 +2,34 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/urfave/cli/v2"
 )
-
-var version string // supplied during build with `go build -ldflags="-X main.version=v0.0.0"`
-
-type Version struct {
-	Version string `json:"version"`
-}
 
 var versionCmd = &cli.Command{
 	Name:      "version",
 	Before:    before,
 	Usage:     "Prints the version and exits",
 	UsageText: "lassie version",
-	Flags: []cli.Flag{
-		FlagVerbose,
-	},
-	Action: versionCommand,
+	Action:    versionCommand,
 }
 
 func versionCommand(cctx *cli.Context) error {
-	if version == "" {
-		log.Warn("executable built without a version")
-		log.Warn("set version with `go build -ldflags=\"-X main.version=v0.0.0\"")
-		version = "[not set]"
+	// buildVersion will be populated if we're running an official built binary
+	if buildVersion != "" {
+		fmt.Printf("lassie version %s\n", buildVersion)
+		return nil
 	}
 
-	fmt.Printf("lassie version %s\n", version)
+	// build info main version will be populated if installed from commit hash
+	info, ok := debug.ReadBuildInfo()
+	if ok && info.Main.Version != "(devel)" {
+		fmt.Printf("lassie version %s\n", info.Main.Version)
+		return nil
+	}
+
+	// otherwise we don't know the version
+	fmt.Println("lassie version (devel)")
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import cmd "github.com/filecoin-project/lassie/cmd/lassie"
 
+var version string // supplied during build with `go build -ldflags="-X main.version=v0.0.0"`
+
 func main() {
-	cmd.Run()
+	cmd.Run(version)
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import cmd "github.com/filecoin-project/lassie/cmd/lassie"
+
+func main() {
+	cmd.Run()
+}


### PR DESCRIPTION
Lassie is now installable via `go install`, and outputs a correct version upon install of a non-tagged commit. You can install this version via `go install github.com/filecoin-project/lassie@52e3ae871527f2a0a8cae51ba25869dae7045c4d`, adding the `lassie` executable to the user's GOBIN. This also has the side affect of being able to build lassie via `go build` without specifying the `/cmd/lassie` directory.

#### How to verify
1. Run `go install github.com/filecoin-project/lassie@52e3ae871527f2a0a8cae51ba25869dae7045c4d`
2. Running `lassie version` should output a pseudo version that includes the next minor up and the commit hash

#### Screenshot of version commands with different builds
![image](https://user-images.githubusercontent.com/3432646/216752275-a01dfa02-1586-4ae7-98d7-4db2ac2e86b0.png)