### PR TITLE
feat: remove state persistence for datatransfer

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -81,7 +81,6 @@ type RetrievalClient struct {
 
 type Config struct {
 	ChannelMonitorConfig dtchannelmonitor.Config
-	Datastore            datastore.Batching
 	GraphsyncOpts        []graphsync.Option
 	Host                 host.Host
 	PayChannelManager    PayChannelManager
@@ -102,7 +101,6 @@ func NewClient(datastore datastore.Batching, host host.Host, payChanMgr PayChann
 			// Called when a restart completes successfully
 			//OnRestartComplete func(id datatransfer.ChannelID)
 		},
-		Datastore: datastore,
 		GraphsyncOpts: []graphsync.Option{
 			graphsync.MaxInProgressIncomingRequests(maxInProgressIncomingRequests),
 			graphsync.MaxInProgressOutgoingRequests(maxInProgressOutgoingRequests),
@@ -146,7 +144,8 @@ func NewClientWithConfig(cfg *Config) (*RetrievalClient, error) {
 
 	dtRestartConfig := dtimpl.ChannelRestartConfig(cfg.ChannelMonitorConfig)
 
-	dataTransfer, err := dtimpl.NewDataTransfer(cfg.Datastore, dtNetwork, dtTransport, dtRestartConfig)
+	datastore := datastore.NewMapDatastore() // don't persist state across restarts
+	dataTransfer, err := dtimpl.NewDataTransfer(datastore, dtNetwork, dtTransport, dtRestartConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This just removes the configuration option entirely, I don't think there's going to be a use for it for any lassie users, even as a library, are there? We're not designing for restartability.