### PR TITLE
Break scanning loop on EOF

### DIFF
--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -173,6 +173,9 @@ func (idxf *IndexerCandidateFinder) decodeProviderResultStream(ctx context.Conte
 				} else if r.Err = scanner.Err(); r.Err != nil {
 					rch <- r
 					return
+				} else {
+					// There are no more lines remaining to scan as we have reached EOF.
+					return
 				}
 			}
 		}


### PR DESCRIPTION
Fix a bug where the scanner does not break out of loop when `io.EOF` is reached. Note that `scanner.Err()` does not return error on EOF.

Many thanks to @kylehuntsman for pointing this out.