### PR TITLE
Add EventRecorder configuration flags

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -26,6 +26,9 @@ var daemonFlags = []cli.Flag{
 		DefaultText: "random",
 		EnvVars:     []string{"LASSIE_PORT"},
 	},
+	FlagEventRecorderAuth,
+	FlagEventRecorderInstanceId,
+	FlagEventRecorderUrl,
 	FlagVerbose,
 	FlagVeryVerbose,
 }
@@ -47,6 +50,9 @@ func daemonCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// create and subscribe an event recorder API if configured
+	setupLassieEventRecorder(cctx, lassie)
 
 	httpServer, err := httpserver.NewHttpServer(cctx.Context, lassie, address, port)
 	if err != nil {

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -56,6 +56,9 @@ var fetchCmd = &cli.Command{
 				return err
 			},
 		},
+		FlagEventRecorderAuth,
+		FlagEventRecorderInstanceId,
+		FlagEventRecorderUrl,
 		FlagVerbose,
 		FlagVeryVerbose,
 	},
@@ -85,6 +88,9 @@ func Fetch(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// create and subscribe an event recorder API if configured
+	setupLassieEventRecorder(c, lassie)
 
 	if fetchProviderAddrInfo == nil {
 		fmt.Printf("Fetching %s", rootCid)

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -29,3 +29,29 @@ var FlagVeryVerbose = &cli.BoolFlag{
 	Usage:       "enable very verbose mode for debugging",
 	Destination: &IsVeryVerbose,
 }
+
+// FlagEventRecorderAuth asks for and provides the authorization token for
+// sending metrics to an event recorder API via a Basic auth Authorization
+// HTTP header. Value will formatted as "Basic <value>" if provided.
+var FlagEventRecorderAuth = &cli.StringFlag{
+	Name:    "event-recorder-auth",
+	Usage:   "the authorization token for an event recorder API",
+	EnvVars: []string{"LASSIE_EVENT_RECORDER_AUTH"},
+}
+
+// FlagEventRecorderUrl asks for and provides the URL for an event recorder API
+// to send metrics to.
+var FlagEventRecorderInstanceId = &cli.StringFlag{
+	Name:        "event-recorder-instance-id",
+	Usage:       "the instance ID to use for an event recorder API request",
+	DefaultText: "a random v4 uuid",
+	EnvVars:     []string{"LASSIE_EVENT_RECORDER_INSTANCE_ID"},
+}
+
+// FlagEventRecorderUrl asks for and provides the URL for an event recorder API
+// to send metrics to.
+var FlagEventRecorderUrl = &cli.StringFlag{
+	Name:    "event-recorder-url",
+	Usage:   "the url of an event recorder API",
+	EnvVars: []string{"LASSIE_EVENT_RECORDER_URL"},
+}


### PR DESCRIPTION
## Summary
Adds `EventRecorder` configuration flags to the `daemon` and `fetch` CLI commands to enable sending retrieval events off to an event recorder API.

A single `setupLassieEventRecorder()` function was created in `/cmd/lassie/main.go` to encapsulate the logic for setting up the `EventRecorder` to ensure consistent setup across CLI commands.

## Flags added:
- **--event-recorder-url**: The URL of the event recorder API. Including this flag in either command will kick off the creation of an `EventRecorder` and subscribe it with the provided `Lassie` instance.
- **--event-recorder-auth**: The authentication token for the event recorder API. This flag is not required when using `--event-recorder-url`, as the `EventRecorder` is aware that if the token is an empty string an `Authorization` header will not be added to the API request.
- **--event-recorder-instance-id**: The instance ID to use for any event recorder API requests. If no value for this flag is provided, a random v4 UUID is generated.

### Flag Usage
![image](https://user-images.githubusercontent.com/3432646/219317461-3cecbd03-a88b-4c34-9ba1-ea798b151f61.png)

### Using Instance ID
In the following two images, you can see I configure the daemon with an instance ID, the server handles a fetch, and then the resulting SQL events show the same retrievals with the provided instance ID.

**Retrieval ID**: `ba0a18`
**Instance ID**: `test`

#### HTTP Daemon Request
![ewV96Mm3JM](https://user-images.githubusercontent.com/3432646/219318168-953695f6-f72b-4428-9204-66a435c6e84c.png)

#### SQL Events
![YJer4wiuve](https://user-images.githubusercontent.com/3432646/219318448-51032d0c-e99e-4937-8173-34250cdc10c8.png)
