### PR TITLE
Refactor hard-coded DHT cascade query string into option

### DIFF
--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -145,6 +145,11 @@ func (idxf *IndexerCandidateFinder) newFindHttpRequest(ctx context.Context, c ci
 	if idxf.httpUserAgent != "" {
 		req.Header.Set("User-Agent", idxf.httpUserAgent)
 	}
+	if idxf.ipfsDhtCascade {
+		query := req.URL.Query()
+		query.Add("cascade", "ipfs-dht")
+		req.URL.RawQuery = query.Encode()
+	}
 	return req, nil
 }
 
@@ -194,5 +199,5 @@ func (idxf *IndexerCandidateFinder) decodeProviderResultStream(ctx context.Conte
 func (idxf *IndexerCandidateFinder) findByMultihashEndpoint(mh multihash.Multihash) string {
 	// TODO: Replace with URL.JoinPath once minimum go version in CI is updated to 1.19; like this:
 	//       return idxf.httpEndpoint.JoinPath("multihash", mh.B58String()).String()
-	return idxf.httpEndpoint.String() + path.Join("/multihash", mh.B58String()) + "?cascade=ipfs-dht"
+	return idxf.httpEndpoint.String() + path.Join("/multihash", mh.B58String())
 }

--- a/pkg/indexerlookup/options.go
+++ b/pkg/indexerlookup/options.go
@@ -14,6 +14,7 @@ type (
 		httpClient             *http.Client
 		httpClientTimeout      time.Duration
 		httpUserAgent          string
+		ipfsDhtCascade         bool
 	}
 )
 
@@ -24,6 +25,7 @@ func newOptions(o ...Option) (*options, error) {
 		httpClient:             http.DefaultClient,
 		httpClientTimeout:      time.Minute,
 		httpUserAgent:          "lassie",
+		ipfsDhtCascade:         true,
 	}
 	for _, apply := range o {
 		if err := apply(&opts); err != nil {
@@ -86,6 +88,15 @@ func WithHttpUserAgent(a string) Option {
 func WithAsyncResultsChanBuffer(i int) Option {
 	return func(o *options) error {
 		o.asyncResultsChanBuffer = i
+		return nil
+	}
+}
+
+// WithIpfsDhtCascade sets weather to cascade lookups onto the IPFS DHT.
+// Enabled by default if unspecified.
+func WithIpfsDhtCascade(b bool) Option {
+	return func(o *options) error {
+		o.ipfsDhtCascade = b
 		return nil
 	}
 }


### PR DESCRIPTION
Add option to cascade lookups onto the DHT for both streaming and non streaming requests.