### PR TITLE
Accept X-Request-Id request header and log corrolation to retrieval ID

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -124,6 +124,17 @@ func ipfsHandler(lassie *lassie.Lassie) func(http.ResponseWriter, *http.Request)
 			return
 		}
 
+		// TODO: we should propogate this value throughout logs so
+		// that we can correlate specific requests to related logs.
+		// For now just using to log the corrolation and return the
+		// X-Trace-Id header.
+		requestId := req.Header.Get("X-Request-Id")
+		if requestId == "" {
+			requestId = retrievalId.String()
+		} else {
+			log.Debugw("Corrolating provided request ID with retrieval ID", "request_id", requestId, "retrieval_id", retrievalId)
+		}
+
 		// called once we start writing blocks into the CAR (on the first Put())
 		getWriter := func() (io.Writer, error) {
 			res.Header().Set("Content-Disposition", "attachment; filename="+filename)
@@ -135,7 +146,8 @@ func ipfsHandler(lassie *lassie.Lassie) func(http.ResponseWriter, *http.Request)
 			res.Header().Set("X-Ipfs-Path", req.URL.Path)
 			// TODO: set X-Ipfs-Roots header when we support root+path
 			// see https://github.com/ipfs/kubo/pull/8720
-			res.Header().Set("X-Trace-Id", retrievalId.String())
+
+			res.Header().Set("X-Trace-Id", requestId)
 
 			logger.logStatus(200, "OK")
 


### PR DESCRIPTION
## Summary
For debugging and troubleshooting, there is no way for the the HTTP use case to pass trace IDs along to Lassie to corrolate specific requests with related logs. This updates the IPFS handler to accept an `X-Request-Id` header that could be used to corrolate logs with a request.

We currently use a `RetrievalID` to uniquely identify our fetches across the stack. This doesn't pair well with the idea that the user can provide their own unique ID, as we use that unique ID to correlate events. The user could break the Retrievers if the same unique ID was used for multiple requests and passed along as the unique identifier of a retrieval.

Because passing the `X-Request-Id` value through the stack would take a little more thought to implement correctly without breaking the Retrievers, the minimum we could do is provide a mechanism to help the user manually corrolate a provided `X-Request-Id` value with our uniquely generated `RetrievalID`.

This doesn't completely solve #88 as that ticket mentions propogating the `X-Request-Id` value across logs, but it does provide a stop-gap to the corrolation problem for the time being.