### PR TITLE
Switch errors to 504

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -188,8 +188,8 @@ func ipfsHandler(lassie *lassie.Lassie) func(http.ResponseWriter, *http.Request)
 				http.Error(res, msg, http.StatusNotFound)
 			} else {
 				msg := fmt.Sprintf("Failed to fetch CID: %s", err.Error())
-				logger.logStatus(http.StatusInternalServerError, msg)
-				http.Error(res, msg, http.StatusInternalServerError)
+				logger.logStatus(http.StatusGatewayTimeout, msg)
+				http.Error(res, msg, http.StatusGatewayTimeout)
 			}
 
 			return


### PR DESCRIPTION
# Goals

Request is to use 504 for all our timeouts / failure to retrieve. Realize this global switch may cover some true 500s but all indications are that the vast majority are failure to retrieve (within timelimit or having exhausted solutions). We should get more fine grained later