### PR TITLE
Dispatch indexer events

### DIFF
--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -96,7 +96,7 @@ func setupLassieEventRecorder(cctx *cli.Context, lassie *lassie.Lassie) {
 			instanceID = uuid.String() // returns "" if uuid is invalid
 		}
 
-		eventRecorder := eventrecorder.NewEventRecorder(cctx.Context, instanceID, eventRecorderUrl, authToken)
+		eventRecorder := eventrecorder.NewEventRecorder(cctx.Context, instanceID, eventRecorderUrl, authToken, eventrecorder.EventRecorderConfig{})
 		lassie.RegisterSubscriber(eventRecorder.RecordEvent)
 		log.Infow("Reporting retrieval events to event recorder API", "url", eventRecorderUrl, "instance_id", instanceID)
 	}

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -84,8 +84,8 @@ func before(cctx *cli.Context) error {
 
 // setupLassieEventRecorder creates and subscribes an EventRecorder if an event recorder URL is given
 func setupLassieEventRecorder(cctx *cli.Context, lassie *lassie.Lassie) {
-	eventRecorderUrl := cctx.String("event-recorder-url")
-	if eventRecorderUrl != "" {
+	eventRecorderURL := cctx.String("event-recorder-url")
+	if eventRecorderURL != "" {
 		authToken := cctx.String("event-recorder-auth")
 		instanceID := cctx.String("event-recorder-instance-id")
 		if instanceID == "" {
@@ -96,8 +96,12 @@ func setupLassieEventRecorder(cctx *cli.Context, lassie *lassie.Lassie) {
 			instanceID = uuid.String() // returns "" if uuid is invalid
 		}
 
-		eventRecorder := eventrecorder.NewEventRecorder(cctx.Context, instanceID, eventRecorderUrl, authToken, eventrecorder.EventRecorderConfig{})
+		eventRecorder := eventrecorder.NewEventRecorder(cctx.Context, eventrecorder.EventRecorderConfig{
+			InstanceID:            instanceID,
+			EndpointURL:           eventRecorderURL,
+			EndpointAuthorization: authToken,
+		})
 		lassie.RegisterSubscriber(eventRecorder.RecordEvent)
-		log.Infow("Reporting retrieval events to event recorder API", "url", eventRecorderUrl, "instance_id", instanceID)
+		log.Infow("Reporting retrieval events to event recorder API", "url", eventRecorderURL, "instance_id", instanceID)
 	}
 }

--- a/pkg/eventrecorder/eventrecorder_test.go
+++ b/pkg/eventrecorder/eventrecorder_test.go
@@ -402,7 +402,11 @@ func TestEventRecorder(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
-			er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue, eventrecorder.EventRecorderConfig{})
+			er := eventrecorder.NewEventRecorder(ctx, eventrecorder.EventRecorderConfig{
+				InstanceID:            "test-instance",
+				EndpointURL:           fmt.Sprintf("%s/test-path/here", ts.URL),
+				EndpointAuthorization: authHeaderValue,
+			})
 			id, err := types.NewRetrievalID()
 			qt.Assert(t, err, qt.IsNil)
 			etime := time.Now()
@@ -487,7 +491,11 @@ func TestEventRecorderSlowPost(t *testing.T) {
 	numParallel := 500
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue, eventrecorder.EventRecorderConfig{})
+	er := eventrecorder.NewEventRecorder(ctx, eventrecorder.EventRecorderConfig{
+		InstanceID:            "test-instance",
+		EndpointURL:           fmt.Sprintf("%s/test-path/here", ts.URL),
+		EndpointAuthorization: authHeaderValue,
+	})
 	id, err := types.NewRetrievalID()
 	qt.Assert(t, err, qt.IsNil)
 	ptime := time.Now().Add(time.Hour * -1)

--- a/pkg/eventrecorder/eventrecorder_test.go
+++ b/pkg/eventrecorder/eventrecorder_test.go
@@ -314,13 +314,95 @@ func TestEventRecorder(t *testing.T) {
 				qt.Assert(t, etime.Sub(atime) < 50*time.Millisecond, qt.IsTrue)
 			},
 		},
+		{
+			name: "CandidatesFound",
+			exec: func(t *testing.T, ctx context.Context, er *eventrecorder.EventRecorder, id types.RetrievalID, etime, ptime time.Time, spid peer.ID) {
+				er.RecordEvent(events.CandidatesFound(id, ptime, testCid1, []types.RetrievalCandidate{
+					types.NewRetrievalCandidate(spid, testCid1, metadata.Bitswap{}),
+				}))
+
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-receivedChan:
+				}
+
+				qt.Assert(t, req.Length(), qt.Equals, int64(1))
+				eventList := verifyListNode(t, req, "events", 1)
+				event := verifyListElement(t, eventList, 0)
+				qt.Assert(t, event.Length(), qt.Equals, int64(9))
+				verifyStringNode(t, event, "retrievalId", id.String())
+				verifyStringNode(t, event, "instanceId", "test-instance")
+				verifyStringNode(t, event, "cid", testCid1.String())
+				verifyStringNode(t, event, "storageProviderId", "")
+				verifyStringNode(t, event, "phase", "indexer")
+				verifyStringNode(t, event, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "eventName", "candidates-found")
+				atime, err := time.Parse(time.RFC3339Nano, nodeToString(t, event, "eventTime"))
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, etime.Sub(atime) < 50*time.Millisecond, qt.IsTrue)
+
+				detailsNode, err := event.LookupByString("eventDetails")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(2))
+				verifyIntNode(t, detailsNode, "candidateCount", 1)
+				protocolsNode, err := detailsNode.LookupByString("protocols")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, protocolsNode.Length(), qt.Equals, int64(1))
+				protocolNode := verifyListElement(t, protocolsNode, 0)
+				s, err := protocolNode.AsString()
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, s, qt.Equals, "transport-bitswap")
+			},
+		},
+		{
+			name: "CandidatesFiltered",
+			exec: func(t *testing.T, ctx context.Context, er *eventrecorder.EventRecorder, id types.RetrievalID, etime, ptime time.Time, spid peer.ID) {
+				er.RecordEvent(events.CandidatesFiltered(id, ptime, testCid1, []types.RetrievalCandidate{
+					types.NewRetrievalCandidate(spid, testCid1, metadata.Bitswap{}),
+				}))
+
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-receivedChan:
+				}
+
+				qt.Assert(t, req.Length(), qt.Equals, int64(1))
+				eventList := verifyListNode(t, req, "events", 1)
+				event := verifyListElement(t, eventList, 0)
+				qt.Assert(t, event.Length(), qt.Equals, int64(9))
+				verifyStringNode(t, event, "retrievalId", id.String())
+				verifyStringNode(t, event, "instanceId", "test-instance")
+				verifyStringNode(t, event, "cid", testCid1.String())
+				verifyStringNode(t, event, "storageProviderId", "")
+				verifyStringNode(t, event, "phase", "indexer")
+				verifyStringNode(t, event, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "eventName", "candidates-filtered")
+				atime, err := time.Parse(time.RFC3339Nano, nodeToString(t, event, "eventTime"))
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, etime.Sub(atime) < 50*time.Millisecond, qt.IsTrue)
+
+				detailsNode, err := event.LookupByString("eventDetails")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(2))
+				verifyIntNode(t, detailsNode, "candidateCount", 1)
+				protocolsNode, err := detailsNode.LookupByString("protocols")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, protocolsNode.Length(), qt.Equals, int64(1))
+				protocolNode := verifyListElement(t, protocolsNode, 0)
+				s, err := protocolNode.AsString()
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, s, qt.Equals, "transport-bitswap")
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
-			er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue)
+			er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue, eventrecorder.EventRecorderConfig{})
 			id, err := types.NewRetrievalID()
 			qt.Assert(t, err, qt.IsNil)
 			etime := time.Now()
@@ -405,7 +487,7 @@ func TestEventRecorderSlowPost(t *testing.T) {
 	numParallel := 500
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue)
+	er := eventrecorder.NewEventRecorder(ctx, "test-instance", fmt.Sprintf("%s/test-path/here", ts.URL), authHeaderValue, eventrecorder.EventRecorderConfig{})
 	id, err := types.NewRetrievalID()
 	qt.Assert(t, err, qt.IsNil)
 	ptime := time.Now().Add(time.Hour * -1)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -26,10 +26,12 @@ var (
 )
 
 type EventWithCandidates interface {
+	types.RetrievalEvent
 	Candidates() []types.RetrievalCandidate
 }
 
 type EventWithQueryResponse interface {
+	types.RetrievalEvent
 	QueryResponse() retrievalmarket.QueryResponse
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -171,7 +171,7 @@ func Identifier(event RetrievalEvent) string {
 		return event.StorageProviderId().String()
 	}
 	protocols := event.Protocols()
-	if len(protocols) == 1 && protocols[0] == multicodec.TransportBitswap {
+	if len(protocols) == 1 && protocols[0] == multicodec.TransportBitswap && event.Phase() != IndexerPhase {
 		return BitswapIndentifier
 	}
 	return ""


### PR DESCRIPTION
# Goals

Enable publishing logs of indexer events, we will need this data.

# Implementation

- Make disabling optional
- Add recording of details
- Write tests to verify behavior 