### PR TITLE
Make temp files dir configurable

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -26,6 +26,14 @@ var daemonFlags = []cli.Flag{
 		DefaultText: "random",
 		EnvVars:     []string{"LASSIE_PORT"},
 	},
+	&cli.StringFlag{
+		Name:        "tempdir",
+		Aliases:     []string{"td"},
+		Usage:       "directory to store temporary files while downloading",
+		Value:       "",
+		DefaultText: "os temp directory",
+		EnvVars:     []string{"LASSIE_TEMP_DIRECTORY"},
+	},
 	FlagEventRecorderAuth,
 	FlagEventRecorderInstanceId,
 	FlagEventRecorderUrl,
@@ -44,6 +52,7 @@ var daemonCmd = &cli.Command{
 func daemonCommand(cctx *cli.Context) error {
 	address := cctx.String("address")
 	port := cctx.Uint("port")
+	tempDir := cctx.String("tempdir")
 
 	// create a lassie instance
 	lassie, err := lassie.NewLassie(cctx.Context, lassie.WithProviderTimeout(20*time.Second))
@@ -54,7 +63,7 @@ func daemonCommand(cctx *cli.Context) error {
 	// create and subscribe an event recorder API if configured
 	setupLassieEventRecorder(cctx, lassie)
 
-	httpServer, err := httpserver.NewHttpServer(cctx.Context, lassie, address, port)
+	httpServer, err := httpserver.NewHttpServer(cctx.Context, lassie, address, port, tempDir)
 	if err != nil {
 		log.Errorw("failed to create http server", "err", err)
 		return err

--- a/pkg/internal/itest/bitswapfetch_test.go
+++ b/pkg/internal/itest/bitswapfetch_test.go
@@ -88,7 +88,7 @@ func TestBitswapFetchTwoPeers(t *testing.T) {
 	lassie, err := lassie.NewLassie(ctx, lassie.WithFinder(finder), lassie.WithHost(self), lassie.WithGlobalTimeout(5*time.Second))
 	req.NoError(err)
 
-	httpServer, err := httpserver.NewHttpServer(ctx, lassie, "127.0.0.1", 8888)
+	httpServer, err := httpserver.NewHttpServer(ctx, lassie, "127.0.0.1", 8888, "")
 	req.NoError(err)
 	baseURL := httpServer.Addr()
 	serverError := make(chan error, 1)

--- a/pkg/internal/streamingstore/streamingstore.go
+++ b/pkg/internal/streamingstore/streamingstore.go
@@ -42,14 +42,16 @@ type StreamingStore struct {
 	f         *os.File
 	readWrite *carstore.StorageCar
 	write     storage.WritableStorage
+	tempDir   string
 }
 
-func NewStreamingStore(ctx context.Context, roots []cid.Cid, getWriter func() (io.Writer, error), errorCb func(error)) *StreamingStore {
+func NewStreamingStore(ctx context.Context, roots []cid.Cid, tempDir string, getWriter func() (io.Writer, error), errorCb func(error)) *StreamingStore {
 	return &StreamingStore{
 		ctx:       ctx,
 		roots:     roots,
 		getWriter: getWriter,
 		errorCb:   errorCb,
+		tempDir:   tempDir,
 	}
 }
 
@@ -137,7 +139,7 @@ func (ss *StreamingStore) lazyReadWrite() (*carstore.StorageCar, error) {
 // lazy*() methods.
 func (ss *StreamingStore) setupReadWrite() error {
 	var err error
-	ss.f, err = os.CreateTemp("", "lassie_carstore")
+	ss.f, err = os.CreateTemp(ss.tempDir, "lassie_carstore")
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/streamingstore/streamingstore_test.go
+++ b/pkg/internal/streamingstore/streamingstore_test.go
@@ -68,7 +68,7 @@ func TestStreamingStoreWritesCARv1(t *testing.T) {
 				return &buf, nil
 			}
 
-			ss := streamingstore.NewStreamingStore(context.TODO(), []cid.Cid{testCid1}, getWriter, errorCb)
+			ss := streamingstore.NewStreamingStore(context.TODO(), []cid.Cid{testCid1}, "", getWriter, errorCb)
 			t.Cleanup(func() { ss.Close() })
 
 			if tt.readBeforeWrite {

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -17,7 +17,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 )
 
-func ipfsHandler(lassie *lassie.Lassie) func(http.ResponseWriter, *http.Request) {
+func ipfsHandler(lassie *lassie.Lassie, tempDir string) func(http.ResponseWriter, *http.Request) {
 	return func(res http.ResponseWriter, req *http.Request) {
 		logger := newRequestLogger(req.Method, req.URL.Path)
 		logger.logPath()
@@ -168,7 +168,7 @@ func ipfsHandler(lassie *lassie.Lassie) func(http.ResponseWriter, *http.Request)
 			}
 		}
 
-		store := streamingstore.NewStreamingStore(req.Context(), []cid.Cid{rootCid}, getWriter, errorCb)
+		store := streamingstore.NewStreamingStore(req.Context(), []cid.Cid{rootCid}, tempDir, getWriter, errorCb)
 		defer func() {
 			if err := store.Close(); err != nil {
 				log.Errorw("failed to close streaming store after retrieval", "retrievalId", retrievalId, "err", err)

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -16,13 +16,12 @@ var log = logging.Logger("lassie/httpserver")
 type HttpServer struct {
 	cancel   context.CancelFunc
 	ctx      context.Context
-	lassie   *lassie.Lassie
 	listener net.Listener
 	server   *http.Server
 }
 
 // NewHttpServer creates a new HttpServer
-func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, address string, port uint) (*HttpServer, error) {
+func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, address string, port uint, tempDir string) (*HttpServer, error) {
 	addr := fmt.Sprintf("%s:%d", address, port)
 	listener, err := net.Listen("tcp", addr) // assigns a port if port is 0
 	if err != nil {
@@ -42,13 +41,12 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, address string, p
 	httpServer := &HttpServer{
 		cancel:   cancel,
 		ctx:      ctx,
-		lassie:   lassie,
 		listener: listener,
 		server:   server,
 	}
 
 	// Routes
-	mux.HandleFunc("/ipfs/", ipfsHandler(lassie))
+	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, tempDir))
 
 	return httpServer, nil
 }


### PR DESCRIPTION
# Goals

Request from Saturn (their OS tmp directory is very small): allow the user to configure the directory used for storing temporary files while streaming

# Implementation

-- Add a tempdir flag to the daemon command, pass it through
-- tested and verified manually (no tests on http server still)
