### PR TITLE
Saturn optimizations

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -44,14 +44,6 @@ var daemonFlags = []cli.Flag{
 		DefaultText: "no limit",
 		EnvVars:     []string{"LASSIE_MAX_BLOCKS_PER_REQUEST"},
 	},
-	&cli.Uint64Flag{
-		Name:        "maxblocks",
-		Aliases:     []string{"mb"},
-		Usage:       "maximum number of blocks sent before closing connection",
-		Value:       0,
-		DefaultText: "no limit",
-		EnvVars:     []string{"LASSIE_MAX_BLOCKS_PER_REQUEST"},
-	},
 	&cli.IntFlag{
 		Name:        "libp2p-conns-lowwater",
 		Aliases:     []string{"lw"},

--- a/pkg/internal/itest/bitswapfetch_test.go
+++ b/pkg/internal/itest/bitswapfetch_test.go
@@ -76,7 +76,10 @@ func TestBitswapFetchTwoPeers(t *testing.T) {
 	lassie, err := lassie.NewLassie(ctx, lassie.WithFinder(finder), lassie.WithHost(self), lassie.WithGlobalTimeout(5*time.Second))
 	req.NoError(err)
 
-	httpServer, err := httpserver.NewHttpServer(ctx, lassie, "127.0.0.1", 8888, "")
+	httpServer, err := httpserver.NewHttpServer(ctx, lassie, httpserver.HttpServerConfig{
+		Address: "127.0.0.1",
+		Port:    8888,
+	})
 	req.NoError(err)
 	baseURL := httpServer.Addr()
 	serverError := make(chan error, 1)

--- a/pkg/internal/itest/httpdaemon_test.go
+++ b/pkg/internal/itest/httpdaemon_test.go
@@ -16,77 +16,110 @@ import (
 	"github.com/filecoin-project/lassie/pkg/lassie"
 	httpserver "github.com/filecoin-project/lassie/pkg/server/http"
 	"github.com/ipfs/go-unixfsnode"
+	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/storage"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHttpRetrieval(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	testCases := []struct {
+		name  string
+		limit uint64
+	}{
+		{
+			name: "regular",
+		},
+		{
+			name:  "max block limit",
+			limit: 3,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-	rndSeed := time.Now().UTC().UnixNano()
-	t.Logf("random seed: %d", rndSeed)
-	var rndReader io.Reader = rand.New(rand.NewSource(rndSeed))
+			rndSeed := time.Now().UTC().UnixNano()
+			t.Logf("random seed: %d", rndSeed)
+			var rndReader io.Reader = rand.New(rand.NewSource(rndSeed))
 
-	// Setup remote, with data, and prepare it for query and retrieval
-	mrn := mocknet.NewMockRetrievalNet()
-	mrn.SetupNet(ctx, t)
-	mrn.SetupRetrieval(ctx, t)
-	rootCid, srcBytes := unixfs.GenerateFile(t, &mrn.LinkSystemRemote, rndReader, 4<<20)
-	srcData := []unixfs.DirEntry{{Path: "", Cid: rootCid, Content: srcBytes}}
-	qr := testQueryResponse
-	qr.MinPricePerByte = abi.NewTokenAmount(0) // make it free so it's not filtered
-	mrn.SetupQuery(ctx, t, rootCid, qr)
+			// Setup remote, with data, and prepare it for query and retrieval
+			mrn := mocknet.NewMockRetrievalNet()
+			mrn.SetupNet(ctx, t)
+			mrn.SetupRetrieval(ctx, t)
+			rootCid, srcBytes := unixfs.GenerateFile(t, &mrn.LinkSystemRemote, rndReader, 4<<20)
+			srcData := []unixfs.DirEntry{{Path: "", Cid: rootCid, Content: srcBytes}}
+			qr := testQueryResponse
+			qr.MinPricePerByte = abi.NewTokenAmount(0) // make it free so it's not filtered
+			mrn.SetupQuery(ctx, t, rootCid, qr)
 
-	// Setup a new lassie
-	req := require.New(t)
-	lassie, err := lassie.NewLassie(
-		ctx,
-		lassie.WithProviderTimeout(20*time.Second),
-		lassie.WithHost(mrn.HostLocal),
-		lassie.WithFinder(mrn.Finder),
-	)
-	req.NoError(err)
+			// Setup a new lassie
+			req := require.New(t)
+			lassie, err := lassie.NewLassie(
+				ctx,
+				lassie.WithProviderTimeout(20*time.Second),
+				lassie.WithHost(mrn.HostLocal),
+				lassie.WithFinder(mrn.Finder),
+			)
+			req.NoError(err)
 
-	// Start an HTTP server
-	httpServer, err := httpserver.NewHttpServer(ctx, lassie, httpserver.HttpServerConfig{
-		Address: "127.0.0.1",
-		Port:    0,
-		TempDir: t.TempDir(),
-	})
-	req.NoError(err)
-	go func() {
-		err := httpServer.Start()
-		req.NoError(err)
-	}()
-	t.Cleanup(func() {
-		req.NoError(httpServer.Close())
-	})
+			// Start an HTTP server
+			httpServer, err := httpserver.NewHttpServer(ctx, lassie, httpserver.HttpServerConfig{
+				Address:             "127.0.0.1",
+				Port:                0,
+				TempDir:             t.TempDir(),
+				MaxBlocksPerRequest: testCase.limit,
+			})
+			req.NoError(err)
+			go func() {
+				err := httpServer.Start()
+				req.NoError(err)
+			}()
+			t.Cleanup(func() {
+				req.NoError(httpServer.Close())
+			})
 
-	// Make a request for our CID and read the complete CAR bytes
-	addr := fmt.Sprintf("http://%s/ipfs/%s", httpServer.Addr(), rootCid.String())
-	getReq, err := http.NewRequest("GET", addr, nil)
-	req.NoError(err)
-	getReq.Header.Add("Accept", "application/vnd.ipld.car")
-	client := &http.Client{}
-	resp, err := client.Do(getReq)
-	req.NoError(err)
-	req.Equal(http.StatusOK, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
-	req.NoError(err)
-	resp.Body.Close()
-	req.NoError(err)
+			// Make a request for our CID and read the complete CAR bytes
+			addr := fmt.Sprintf("http://%s/ipfs/%s", httpServer.Addr(), rootCid.String())
+			getReq, err := http.NewRequest("GET", addr, nil)
+			req.NoError(err)
+			getReq.Header.Add("Accept", "application/vnd.ipld.car")
+			client := &http.Client{}
+			resp, err := client.Do(getReq)
+			req.NoError(err)
+			req.Equal(http.StatusOK, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			req.NoError(err)
+			resp.Body.Close()
+			req.NoError(err)
 
-	// Open the CAR bytes as read-only storage
-	reader, err := storage.OpenReadable(bytes.NewReader(body))
-	req.NoError(err)
+			if testCase.limit == 0 {
+				// Open the CAR bytes as read-only storage
+				reader, err := storage.OpenReadable(bytes.NewReader(body))
+				req.NoError(err)
 
-	// Load our UnixFS data and compare it to the original
-	linkSys := cidlink.DefaultLinkSystem()
-	linkSys.SetReadStorage(reader)
-	linkSys.NodeReifier = unixfsnode.Reify
-	linkSys.TrustedStorage = true
-	gotDir := unixfs.ToDirEntry(t, linkSys, rootCid)
-	unixfs.CompareDirEntries(t, srcData, gotDir)
+				// Load our UnixFS data and compare it to the original
+				linkSys := cidlink.DefaultLinkSystem()
+				linkSys.SetReadStorage(reader)
+				linkSys.NodeReifier = unixfsnode.Reify
+				linkSys.TrustedStorage = true
+				gotDir := unixfs.ToDirEntry(t, linkSys, rootCid)
+				unixfs.CompareDirEntries(t, srcData, gotDir)
+			} else {
+				br, err := carv2.NewBlockReader(bytes.NewReader(body))
+				req.NoError(err)
+				count := uint64(0)
+				for {
+					_, err := br.Next()
+					if err != nil {
+						req.EqualError(err, io.EOF.Error())
+						break
+					}
+					count++
+				}
+				req.Equal(testCase.limit, count)
+			}
+		})
+	}
 }

--- a/pkg/internal/itest/httpdaemon_test.go
+++ b/pkg/internal/itest/httpdaemon_test.go
@@ -50,7 +50,11 @@ func TestHttpRetrieval(t *testing.T) {
 	req.NoError(err)
 
 	// Start an HTTP server
-	httpServer, err := httpserver.NewHttpServer(ctx, lassie, "127.0.0.1", 0, t.TempDir())
+	httpServer, err := httpserver.NewHttpServer(ctx, lassie, httpserver.HttpServerConfig{
+		Address: "127.0.0.1",
+		Port:    0,
+		TempDir: t.TempDir(),
+	})
 	req.NoError(err)
 	go func() {
 		err := httpServer.Start()

--- a/pkg/internal/libp2p.go
+++ b/pkg/internal/libp2p.go
@@ -9,6 +9,10 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-func InitHost(ctx context.Context, listenAddrs ...multiaddr.Multiaddr) (host.Host, error) {
-	return libp2p.New(libp2p.ListenAddrs(listenAddrs...), libp2p.Identity(nil), libp2p.ResourceManager(&network.NullResourceManager{}))
+func InitHost(ctx context.Context, opts []libp2p.Option, listenAddrs ...multiaddr.Multiaddr) (host.Host, error) {
+	opts = append([]libp2p.Option{libp2p.Identity(nil), libp2p.ResourceManager(&network.NullResourceManager{})}, opts...)
+	if len(listenAddrs) > 0 {
+		opts = append([]libp2p.Option{libp2p.ListenAddrs(listenAddrs...)}, opts...)
+	}
+	return libp2p.New(opts...)
 }

--- a/pkg/internal/limitstore/limitstore.go
+++ b/pkg/internal/limitstore/limitstore.go
@@ -1,0 +1,50 @@
+package limitstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime/storage"
+)
+
+type ErrExceededLimit struct {
+	Limit uint64
+}
+
+func (e ErrExceededLimit) Error() string {
+	return fmt.Sprintf("cannot write - exceeded block limit: %d", e.Limit)
+}
+
+type Storage interface {
+	storage.ReadableStorage
+	storage.WritableStorage
+	storage.StreamingReadableStorage
+}
+
+type LimitStore struct {
+	Storage
+	counter uint64
+	limit   uint64
+}
+
+func NewLimitStore(storage Storage, limit uint64) *LimitStore {
+	return &LimitStore{
+		Storage: storage,
+		limit:   limit,
+	}
+}
+
+func (ls *LimitStore) Put(ctx context.Context, key string, data []byte) error {
+	if ls.counter >= ls.limit {
+		return ErrExceededLimit{ls.limit}
+	}
+	has, err := ls.Storage.Has(ctx, key)
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
+	}
+	ls.counter++
+	return ls.Storage.Put(ctx, key, data)
+}

--- a/pkg/internal/limitstore/limitstore_test.go
+++ b/pkg/internal/limitstore/limitstore_test.go
@@ -1,0 +1,60 @@
+package limitstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/lassie/pkg/internal/limitstore"
+	"github.com/filecoin-project/lassie/pkg/internal/testutil"
+	"github.com/ipld/go-ipld-prime/storage/memstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitStore(t *testing.T) {
+	req := require.New(t)
+	ctx := context.Background()
+	ms := &memstore.Store{Bag: make(map[string][]byte)}
+
+	err := ms.Put(ctx, "apples", testutil.RandomBytes(1000))
+	req.NoError(err)
+
+	limitStore := limitstore.NewLimitStore(ms, 5)
+	has, err := limitStore.Has(ctx, "apples")
+	req.NoError(err)
+	req.True(has)
+
+	fruits := map[string][]byte{
+		"oranges": testutil.RandomBytes(1000),
+		"bananas": testutil.RandomBytes(1000),
+		"plums":   testutil.RandomBytes(1000),
+		"grapes":  testutil.RandomBytes(1000),
+	}
+	for fruit, data := range fruits {
+		err := limitStore.Put(ctx, fruit, data)
+		req.NoError(err)
+	}
+
+	for fruit := range fruits {
+		has, err := limitStore.Has(ctx, fruit)
+		req.NoError(err)
+		req.True(has)
+		data, err := limitStore.Get(ctx, fruit)
+		req.NoError(err)
+		req.Equal(fruits[fruit], data)
+	}
+
+	// writing the fruits again is ok cause of the has check
+	for fruit, data := range fruits {
+		err := limitStore.Put(ctx, fruit, data)
+		req.NoError(err)
+	}
+
+	// put last block (the first block to the underlying store does not count)
+	err = limitStore.Put(ctx, "cheese", testutil.RandomBytes(1000))
+	req.NoError(err)
+
+	// put block over limit
+	err = limitStore.Put(ctx, "yogurt", testutil.RandomBytes(1000))
+	req.EqualError(err, limitstore.ErrExceededLimit{Limit: 5}.Error())
+
+}

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -120,11 +120,6 @@ func WithLibp2pOpts(libp2pOptions ...libp2p.Option) LassieOption {
 	}
 }
 
-func WithMaximumBlocksPerRequest(maximumBlocksPerRequest uint64) LassieOption {
-	return func(cfg *LassieConfig) {
-	}
-}
-
 func (l *Lassie) Retrieve(ctx context.Context, request types.RetrievalRequest) (*types.RetrievalStats, error) {
 	var cancel context.CancelFunc
 	if l.cfg.GlobalTimeout != time.Duration(0) {

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-ipld-prime/linking"
+	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/multiformats/go-multiaddr"
 )
 
 type Lassie struct {
@@ -27,6 +27,7 @@ type LassieConfig struct {
 	Host            host.Host
 	ProviderTimeout time.Duration
 	GlobalTimeout   time.Duration
+	Libp2pOptions   []libp2p.Option
 }
 
 type LassieOption func(cfg *LassieConfig)
@@ -56,7 +57,7 @@ func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error
 
 	if cfg.Host == nil {
 		var err error
-		cfg.Host, err = internal.InitHost(ctx, multiaddr.StringCast("/ip4/0.0.0.0/tcp/6746"))
+		cfg.Host, err = internal.InitHost(ctx, cfg.Libp2pOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -112,6 +113,18 @@ func WithHost(host host.Host) LassieOption {
 		cfg.Host = host
 	}
 }
+
+func WithLibp2pOpts(libp2pOptions ...libp2p.Option) LassieOption {
+	return func(cfg *LassieConfig) {
+		cfg.Libp2pOptions = libp2pOptions
+	}
+}
+
+func WithMaximumBlocksPerRequest(maximumBlocksPerRequest uint64) LassieOption {
+	return func(cfg *LassieConfig) {
+	}
+}
+
 func (l *Lassie) Retrieve(ctx context.Context, request types.RetrievalRequest) (*types.RetrievalStats, error) {
 	var cancel context.CancelFunc
 	if l.cfg.GlobalTimeout != time.Duration(0) {

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -20,9 +20,16 @@ type HttpServer struct {
 	server   *http.Server
 }
 
+type HttpServerConfig struct {
+	Address             string
+	Port                uint
+	TempDir             string
+	MaxBlocksPerRequest uint64
+}
+
 // NewHttpServer creates a new HttpServer
-func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, address string, port uint, tempDir string) (*HttpServer, error) {
-	addr := fmt.Sprintf("%s:%d", address, port)
+func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, cfg HttpServerConfig) (*HttpServer, error) {
+	addr := fmt.Sprintf("%s:%d", cfg.Address, cfg.Port)
 	listener, err := net.Listen("tcp", addr) // assigns a port if port is 0
 	if err != nil {
 		return nil, err
@@ -33,7 +40,7 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, address string, p
 	// create server
 	mux := http.NewServeMux()
 	server := &http.Server{
-		Addr:        fmt.Sprintf(":%d", port),
+		Addr:        fmt.Sprintf(":%d", cfg.Port),
 		BaseContext: func(listener net.Listener) context.Context { return ctx },
 		Handler:     mux,
 	}
@@ -46,7 +53,7 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, address string, p
 	}
 
 	// Routes
-	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, tempDir))
+	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, cfg))
 
 	return httpServer, nil
 }


### PR DESCRIPTION
# Goals

fix #107 and add a maximum blocks sent per request to the daemon

# Implementation

- New limitstore, an ipld.Storage that errors after n unique block puts
- New libp2p options config for Lassie
- New command line args for the daemon (I know this is getting ridiculous, let's define a config file, but next ticket. Also, it's all env vars so what's the diff?)
- Too many params on the HTTPServe so now it has a config
- Add integration test for limiting blocks per response.