### PR TITLE
Cancelled http test fix

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -406,7 +406,11 @@ func (rc *RetrievalClient) RetrieveFromPeer(
 		// We could fail before a successful proposal
 		return nil, fmt.Errorf("%w: %s", retriever.ErrDealProposalFailed, err)
 	}
-	defer rc.dataTransfer.CloseDataTransferChannel(ctx, chanid)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
+		rc.dataTransfer.CloseDataTransferChannel(ctx, chanid)
+	}()
 
 	// Wait for the retrieval to finish before exiting the function
 awaitfinished:


### PR DESCRIPTION
# Goals

Looks like our issue again is that the context is closed when CloseDataTransferChannel is called. I'm not sure if this should be fixed inside of go-data-transfer -- I can certainly do that. However, I'm not clear what the context parameter in this case would mean then. If I issue a command to go-data-transfer, with a context, usually I expect that the this means "run this command until the context closes" -- so I would sort of expect this bahavior?