### PR TITLE
fix: merge common itest components

### DIFF
--- a/pkg/internal/itest/client_query_test.go
+++ b/pkg/internal/itest/client_query_test.go
@@ -88,7 +88,7 @@ func TestQuery(t *testing.T) {
 			require.NoError(t, err)
 
 			var connected bool
-			qr, err := client.RetrievalQueryToPeer(ctx, mrn.Remotes[0].AddrInfo(), tt.requestCid, func() {
+			qr, err := client.RetrievalQueryToPeer(ctx, *mrn.Remotes[0].AddrInfo(), tt.requestCid, func() {
 				connected = true
 			})
 

--- a/pkg/internal/itest/client_query_test.go
+++ b/pkg/internal/itest/client_query_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ipfs/go-cid"
 	datastore "github.com/ipfs/go-datastore"
 	dss "github.com/ipfs/go-datastore/sync"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,16 +78,17 @@ func TestQuery(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			mrn := mocknet.NewMockRetrievalNet()
-			mrn.SetupNet(ctx, t)
-			mrn.SetupQuery(ctx, t, tt.expectCid, tt.expectResponse)
+			mrn := mocknet.NewMockRetrievalNet(ctx, t)
+			mrn.AddGraphsyncPeers(1)
+			mocknet.SetupQuery(t, mrn.Remotes[0], tt.expectCid, tt.expectResponse)
+			mrn.MN.LinkAll()
 
 			ds1 := dss.MutexWrap(datastore.NewMapDatastore())
-			client, err := client.NewClient(ds1, mrn.HostLocal, nil)
+			client, err := client.NewClient(ds1, mrn.Self, nil)
 			require.NoError(t, err)
 
 			var connected bool
-			qr, err := client.RetrievalQueryToPeer(ctx, peer.AddrInfo{ID: mrn.HostRemote.ID(), Addrs: mrn.HostRemote.Addrs()}, tt.requestCid, func() {
+			qr, err := client.RetrievalQueryToPeer(ctx, mrn.Remotes[0].AddrInfo(), tt.requestCid, func() {
 				connected = true
 			})
 

--- a/pkg/internal/itest/client_retrieval_test.go
+++ b/pkg/internal/itest/client_retrieval_test.go
@@ -61,15 +61,16 @@ func TestRetrieval(t *testing.T) {
 			defer cancel()
 
 			// Setup mocknet
-			mrn := mocknet.NewMockRetrievalNet()
-			mrn.SetupNet(ctx, t)
-			mrn.SetupRetrieval(ctx, t)
+			mrn := mocknet.NewMockRetrievalNet(ctx, t)
+			mrn.AddGraphsyncPeers(1)
+			finishedChan := mocknet.SetupRetrieval(t, mrn.Remotes[0])
+			mrn.MN.LinkAll()
 
 			// Generate source data on the remote
-			rootCid, srcData := tt.generate(t, mrn.LinkSystemRemote)
+			rootCid, srcData := tt.generate(t, mrn.Remotes[0].LinkSystem)
 
 			// Perform retrieval
-			linkSystemLocal := runRetrieval(t, ctx, mrn, rootCid)
+			linkSystemLocal := runRetrieval(t, ctx, mrn, rootCid, finishedChan)
 
 			// Check retrieved data by loading it from the blockstore via UnixFS so we
 			// reify the original single file data from the DAG
@@ -83,7 +84,7 @@ func TestRetrieval(t *testing.T) {
 	}
 }
 
-func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalNet, rootCid cid.Cid) linking.LinkSystem {
+func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalNet, rootCid cid.Cid, finishedChan chan []datatransfer.Event) linking.LinkSystem {
 	req := require.New(t)
 
 	// Setup local datastore and blockstore
@@ -93,21 +94,21 @@ func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalN
 	linkSystemLocal := storeutil.LinkSystemForBlockstore(bsLocal)
 
 	// New client
-	client, err := client.NewClient(dtDsLocal, mrn.HostLocal, nil)
+	client, err := client.NewClient(dtDsLocal, mrn.Self, nil)
 	req.NoError(err)
 	req.NoError(client.AwaitReady())
 
 	// Collect events & stats
-	gotEvents := make([]datatransfer.Event, 0)
+	selfEvents := make([]datatransfer.Event, 0)
 	var lastReceivedBytes uint64
 	var lastReceivedBlocks uint64
-	finishedChan := make(chan struct{}, 1)
+	cleanupChan := make(chan struct{}, 1)
 	subscriberLocal := func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-		gotEvents = append(gotEvents, event)
+		selfEvents = append(selfEvents, event)
 		lastReceivedBytes = channelState.Received()
 		lastReceivedBlocks = uint64(channelState.ReceivedCidsTotal())
 		if event.Code == datatransfer.CleanupComplete {
-			finishedChan <- struct{}{}
+			cleanupChan <- struct{}{}
 		}
 	}
 
@@ -125,7 +126,7 @@ func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalN
 	stats, err := client.RetrieveFromPeer(
 		ctx,
 		linkSystemLocal,
-		mrn.HostRemote.ID(),
+		mrn.Remotes[0].Host.ID(),
 		paymentAddress,
 		proposal,
 		subscriberLocal,
@@ -135,8 +136,18 @@ func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalN
 	req.NotNil(stats)
 
 	// Ensure we are properly cleaned up
-	req.Eventually(mocknet.ChanCheck(ctx, t, finishedChan), 1*time.Second, 100*time.Millisecond)
-	mrn.WaitForFinish(ctx, t)
+	req.Eventually(func() bool {
+		select {
+		case <-cleanupChan:
+			return true
+		case <-ctx.Done():
+			require.Fail(t, ctx.Err().Error())
+			return false
+		default:
+			return false
+		}
+	}, 1*time.Second, 100*time.Millisecond)
+	remoteEvents := mocknet.WaitForFinish(ctx, t, finishedChan, 1*time.Second)
 
 	// Check stats
 	req.Equal(lastReceivedBytes, stats.Size)
@@ -147,22 +158,22 @@ func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalN
 	req.True(stats.TimeToFirstByte <= stats.Duration)
 
 	// Check events
-	req.Len(eventSliceFilter(gotEvents, datatransfer.Error), 0)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.Open), 1)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.Opened), 1)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.TransferInitiated), 1)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.Accept), 1)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.ResumeResponder), 1)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.FinishTransfer), 1)
-	req.Len(eventSliceFilter(gotEvents, datatransfer.CleanupComplete), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.Error), 0)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.Open), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.Opened), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.TransferInitiated), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.Accept), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.ResumeResponder), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.FinishTransfer), 1)
+	req.Len(eventSliceFilter(selfEvents, datatransfer.CleanupComplete), 1)
 
 	// Check remote events
-	req.Len(eventSliceFilter(mrn.RemoteEvents, datatransfer.Error), 0)
-	req.Len(eventSliceFilter(mrn.RemoteEvents, datatransfer.Open), 1)
-	req.Len(eventSliceFilter(mrn.RemoteEvents, datatransfer.Accept), 1)
-	req.Len(eventSliceFilter(mrn.RemoteEvents, datatransfer.TransferInitiated), 1)
-	req.Len(eventSliceFilter(mrn.RemoteEvents, datatransfer.CleanupComplete), 1)
-	req.Len(eventSliceFilter(mrn.RemoteEvents, datatransfer.Complete), 1)
+	req.Len(eventSliceFilter(remoteEvents, datatransfer.Error), 0)
+	req.Len(eventSliceFilter(remoteEvents, datatransfer.Open), 1)
+	req.Len(eventSliceFilter(remoteEvents, datatransfer.Accept), 1)
+	req.Len(eventSliceFilter(remoteEvents, datatransfer.TransferInitiated), 1)
+	req.Len(eventSliceFilter(remoteEvents, datatransfer.CleanupComplete), 1)
+	req.Len(eventSliceFilter(remoteEvents, datatransfer.Complete), 1)
 
 	return linkSystemLocal
 }

--- a/pkg/internal/itest/mocknet/mocknet.go
+++ b/pkg/internal/itest/mocknet/mocknet.go
@@ -194,7 +194,7 @@ func (mcf *mockCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid)
 			} else {
 				md = metadata.Default.New(&metadata.GraphsyncFilecoinV1{PieceCID: cid})
 			}
-			candidates = append(candidates, types.RetrievalCandidate{MinerPeer: h.AddrInfo(), RootCid: cid, Metadata: md})
+			candidates = append(candidates, types.RetrievalCandidate{MinerPeer: *h.AddrInfo(), RootCid: cid, Metadata: md})
 		}
 	}
 	return candidates, nil

--- a/pkg/internal/itest/testpeer/generator.go
+++ b/pkg/internal/itest/testpeer/generator.go
@@ -139,8 +139,8 @@ func (i *TestPeer) SetBlockstoreLatency(t time.Duration) time.Duration {
 	return i.blockstoreDelay.Set(t)
 }
 
-func (i TestPeer) AddrInfo() peer.AddrInfo {
-	return peer.AddrInfo{
+func (i TestPeer) AddrInfo() *peer.AddrInfo {
+	return &peer.AddrInfo{
 		ID:    i.ID,
 		Addrs: i.Host.Addrs(),
 	}


### PR DESCRIPTION
A bit yak-shavy but I didn't realise how much commonality there was between the graphsync work I did and the existing bitswap work @hannahhoward did, so I've rectified that and merged all the "mocknet" stuff into a single place so we now have a growing framework for setting up integration test environments. So far no graphsync+bitswap tests but that should be now possible, we even have a common mocknet CandidateFinder that would work for this.