### PR TITLE
Build direct candidate finder

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -220,7 +220,7 @@ func (pp *progressPrinter) subscriber(event types.RetrievalEvent) {
 		if len(fetchProviderAddrInfos) > 0 {
 			fmt.Printf("Found %d storage providers candidates from the indexer, querying %s:\n", pp.candidatesFound, num)
 		} else {
-			fmt.Printf("Using the explicitly specified storage provider, querying %s:\n", num)
+			fmt.Printf("Using the explicitly specified storage provider(s), querying %s:\n", num)
 		}
 		for _, candidate := range ret.Candidates() {
 			fmt.Printf("\r\t%s, Protocols: %v\n", candidate.MinerPeer.ID, candidate.Metadata.Protocols())

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -17,11 +16,13 @@ import (
 	carv2 "github.com/ipld/go-car/v2"
 	carstore "github.com/ipld/go-car/v2/storage"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/urfave/cli/v2"
 )
 
-var fetchProviderAddrInfo *peer.AddrInfo
+var fetchProviderAddrInfos []peer.AddrInfo
 
 var fetchCmd = &cli.Command{
 	Name:   "fetch",
@@ -47,13 +48,19 @@ var fetchCmd = &cli.Command{
 			Usage:   "print progress output",
 		},
 		&cli.StringFlag{
-			Name:        "provider",
-			DefaultText: "The provider will be discovered automatically",
-			Usage:       "The provider addr including its peer ID. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+			Name:        "providers",
+			DefaultText: "Providers will be discovered automatically",
+			Usage:       "Provider addresses including its peer ID, seperated by a comma. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 			Action: func(cctx *cli.Context, v string) error {
-				var err error
-				fetchProviderAddrInfo, err = peer.AddrInfoFromString(v)
-				return err
+				vs := strings.Split(v, ",")
+				for _, v := range vs {
+					fetchProviderAddrInfo, err := peer.AddrInfoFromString(v)
+					if err != nil {
+						return err
+					}
+					fetchProviderAddrInfos = append(fetchProviderAddrInfos, *fetchProviderAddrInfo)
+				}
+				return nil
 			},
 		},
 		FlagEventRecorderAuth,
@@ -78,9 +85,14 @@ func Fetch(c *cli.Context) error {
 	timeout := c.Duration("timeout")
 	timeoutOpt := lassie.WithProviderTimeout(timeout)
 
-	var opts = []lassie.LassieOption{timeoutOpt}
-	if fetchProviderAddrInfo != nil {
-		finderOpt := lassie.WithFinder(explicitCandidateFinder{provider: *fetchProviderAddrInfo})
+	host, err := libp2p.New(libp2p.ResourceManager(&network.NullResourceManager{}))
+	if err != nil {
+		return err
+	}
+	hostOpt := lassie.WithHost(host)
+	var opts = []lassie.LassieOption{timeoutOpt, hostOpt}
+	if len(fetchProviderAddrInfos) > 0 {
+		finderOpt := lassie.WithFinder(retriever.NewDirectCandidateFinder(host, fetchProviderAddrInfos))
 		opts = append(opts, finderOpt)
 	}
 
@@ -92,10 +104,10 @@ func Fetch(c *cli.Context) error {
 	// create and subscribe an event recorder API if configured
 	setupLassieEventRecorder(c, lassie)
 
-	if fetchProviderAddrInfo == nil {
+	if len(fetchProviderAddrInfos) == 0 {
 		fmt.Printf("Fetching %s", rootCid)
 	} else {
-		fmt.Printf("Fetching %s from %s", rootCid, fetchProviderAddrInfo.String())
+		fmt.Printf("Fetching %s from %v", rootCid, fetchProviderAddrInfos)
 	}
 	if progress {
 		fmt.Println()
@@ -204,7 +216,7 @@ func (pp *progressPrinter) subscriber(event types.RetrievalEvent) {
 		} else if pp.candidatesFound == 1 {
 			num = "it"
 		}
-		if fetchProviderAddrInfo == nil {
+		if len(fetchProviderAddrInfos) > 0 {
 			fmt.Printf("Found %d storage providers candidates from the indexer, querying %s:\n", pp.candidatesFound, num)
 		} else {
 			fmt.Printf("Using the explicitly specified storage provider, querying %s:\n", num)
@@ -225,38 +237,4 @@ func (pp *progressPrinter) subscriber(event types.RetrievalEvent) {
 	case events.RetrievalEventSuccess:
 		// noop, handled at return from Retrieve()
 	}
-}
-
-var _ retriever.CandidateFinder = (*explicitCandidateFinder)(nil)
-
-type explicitCandidateFinder struct {
-	provider peer.AddrInfo
-}
-
-func (e explicitCandidateFinder) FindCandidatesAsync(ctx context.Context, c cid.Cid) (<-chan types.FindCandidatesResult, error) {
-	rs, err := e.FindCandidates(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-	switch len(rs) {
-	case 0:
-		return nil, nil
-	default:
-		rch := make(chan types.FindCandidatesResult, len(rs))
-		for _, r := range rs {
-			rch <- types.FindCandidatesResult{
-				Candidate: r,
-			}
-		}
-		return rch, nil
-	}
-}
-
-func (e explicitCandidateFinder) FindCandidates(_ context.Context, c cid.Cid) ([]types.RetrievalCandidate, error) {
-	return []types.RetrievalCandidate{
-		{
-			MinerPeer: e.provider,
-			RootCid:   c,
-		},
-	}, nil
 }

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -49,6 +49,7 @@ var fetchCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:        "providers",
+			Aliases:     []string{"provider"},
 			DefaultText: "Providers will be discovered automatically",
 			Usage:       "Provider addresses including its peer ID, seperated by a comma. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 			Action: func(cctx *cli.Context, v string) error {

--- a/pkg/internal/itest/direct_fetch_test.go
+++ b/pkg/internal/itest/direct_fetch_test.go
@@ -134,7 +134,7 @@ func TestDirectFetch(t *testing.T) {
 			req.NoError(err)
 			err = outCar.Finalize()
 			req.NoError(err)
-			outFile.Seek(0, os.SEEK_SET)
+			outFile.Seek(0, io.SeekStart)
 			// Open the CAR bytes as read-only storage
 			reader, err := storage.OpenReadable(outFile)
 			req.NoError(err)

--- a/pkg/internal/itest/direct_fetch_test.go
+++ b/pkg/internal/itest/direct_fetch_test.go
@@ -1,0 +1,181 @@
+package itest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lassie/pkg/internal/itest/mocknet"
+	"github.com/filecoin-project/lassie/pkg/internal/itest/testpeer"
+	"github.com/filecoin-project/lassie/pkg/internal/itest/unixfs"
+	"github.com/filecoin-project/lassie/pkg/internal/lp2ptransports"
+	"github.com/filecoin-project/lassie/pkg/lassie"
+	"github.com/filecoin-project/lassie/pkg/retriever"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync/storeutil"
+	bsnet "github.com/ipfs/go-libipfs/bitswap/network"
+	"github.com/ipfs/go-libipfs/bitswap/server"
+	"github.com/ipfs/go-unixfsnode"
+	carv2 "github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/storage"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	host "github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	lpmock "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bitswapDirect    = 0
+	graphsyncDirect  = 1
+	transportsDirect = 2
+)
+
+func TestDirectFetch(t *testing.T) {
+
+	testCases := []struct {
+		name       string
+		directPeer int
+	}{
+		{
+			name:       "direct bitswap peer",
+			directPeer: bitswapDirect,
+		},
+		{
+			name:       "direct graphsync peer",
+			directPeer: graphsyncDirect,
+		},
+		{
+			name:       "peer responding on transports protocol",
+			directPeer: transportsDirect,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := require.New(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			rndSeed := time.Now().UTC().UnixNano()
+			t.Logf("random seed: %d", rndSeed)
+			var rndReader io.Reader = rand.New(rand.NewSource(rndSeed))
+
+			// build two files of 4MiB random bytes, packaged into unixfs DAGs
+			// (rootCid1 & rootCid2) and the original source data retained
+			// (srcData1, srcData2)
+			mrn := mocknet.NewMockRetrievalNet()
+
+			mrn.SetupNet(ctx, t)
+			mrn.SetupRetrieval(ctx, t)
+			graphsyncAddr := peer.AddrInfo{
+				ID:    mrn.HostRemote.ID(),
+				Addrs: mrn.HostRemote.Addrs(),
+			}
+			graphsyncMAs, err := peer.AddrInfoToP2pAddrs(&graphsyncAddr)
+			req.NoError(err)
+			rootCid, srcBytes := unixfs.GenerateFile(t, &mrn.LinkSystemRemote, rndReader, 4<<20)
+			srcData := []unixfs.DirEntry{{Path: "", Cid: rootCid, Content: srcBytes}}
+			qr := testQueryResponse
+			qr.MinPricePerByte = abi.NewTokenAmount(0) // make it free so it's not filtered
+			mrn.SetupQuery(ctx, t, rootCid, qr)
+			testPeerGenerator := testpeer.NewTestPeerGenerator(ctx, t, mrn.MN, []bsnet.NetOpt{}, []server.Option{})
+			bitswapPeer := testPeerGenerator.Peers(1)[0]
+			ls := storeutil.LinkSystemForBlockstore(bitswapPeer.Blockstore())
+			rootCidBs, _ := unixfs.GenerateFile(t, &ls, bytes.NewReader(srcBytes), 4<<20)
+			req.Equal(rootCid, rootCidBs)
+			bitswapAddr := peer.AddrInfo{
+				ID:    bitswapPeer.Host.ID(),
+				Addrs: bitswapPeer.Host.Addrs(),
+			}
+			bitswapMAs, err := peer.AddrInfoToP2pAddrs(&bitswapAddr)
+			req.NoError(err)
+			transportsAddr, clear := handleTransports(t, mrn.MN, []lp2ptransports.Protocol{
+				{
+					Name:      "bitswap",
+					Addresses: bitswapMAs,
+				},
+				{
+					Name:      "libp2p",
+					Addresses: graphsyncMAs,
+				},
+			})
+			mrn.MN.LinkAll()
+			defer clear()
+			var addr peer.AddrInfo
+			switch testCase.directPeer {
+			case bitswapDirect:
+				addr = bitswapAddr
+			case graphsyncDirect:
+				addr = graphsyncAddr
+			case transportsDirect:
+				addr = transportsAddr
+			default:
+				req.FailNow("unrecognized direct peer test")
+			}
+			directFinder := retriever.NewDirectCandidateFinder(mrn.HostLocal, []peer.AddrInfo{addr})
+			lassie, err := lassie.NewLassie(ctx, lassie.WithFinder(directFinder), lassie.WithHost(mrn.HostLocal), lassie.WithGlobalTimeout(5*time.Second))
+			req.NoError(err)
+			outFile, err := os.CreateTemp(t.TempDir(), "lassie-test-")
+			req.NoError(err)
+			outCar, err := storage.NewReadableWritable(outFile, []cid.Cid{rootCid}, carv2.WriteAsCarV1(true))
+			req.NoError(err)
+			outLsys := cidlink.DefaultLinkSystem()
+			outLsys.SetReadStorage(outCar)
+			outLsys.SetWriteStorage(outCar)
+			outLsys.TrustedStorage = true
+			_, _, err = lassie.Fetch(ctx, rootCid, outLsys)
+			req.NoError(err)
+			err = outCar.Finalize()
+			req.NoError(err)
+			outFile.Seek(0, os.SEEK_SET)
+			// Open the CAR bytes as read-only storage
+			reader, err := storage.OpenReadable(outFile)
+			req.NoError(err)
+
+			// Load our UnixFS data and compare it to the original
+			linkSys := cidlink.DefaultLinkSystem()
+			linkSys.SetReadStorage(reader)
+			linkSys.NodeReifier = unixfsnode.Reify
+			linkSys.TrustedStorage = true
+			gotDir := unixfs.ToDirEntry(t, linkSys, rootCid)
+			unixfs.CompareDirEntries(t, srcData, gotDir)
+		})
+	}
+
+}
+
+type transportsListener struct {
+	t         *testing.T
+	host      host.Host
+	protocols []lp2ptransports.Protocol
+}
+
+func handleTransports(t *testing.T, mn lpmock.Mocknet, protocols []lp2ptransports.Protocol) (peer.AddrInfo, func()) {
+	h, err := mn.GenPeer()
+	require.NoError(t, err)
+
+	p := &transportsListener{t, h, protocols}
+	h.SetStreamHandler(lp2ptransports.TransportsProtocolID, p.handleNewQueryStream)
+	return peer.AddrInfo{
+			ID:    h.ID(),
+			Addrs: h.Addrs(),
+		}, func() {
+			h.RemoveStreamHandler(lp2ptransports.TransportsProtocolID)
+		}
+}
+
+// Called when the client opens a libp2p stream
+func (l *transportsListener) handleNewQueryStream(s network.Stream) {
+	defer s.Close()
+	response := lp2ptransports.QueryResponse{Protocols: l.protocols}
+	// Write the response to the client
+	err := lp2ptransports.BindnodeRegistry.TypeToWriter(&response, s, dagcbor.Encode)
+	require.NoError(l.t, err)
+}

--- a/pkg/internal/itest/direct_fetch_test.go
+++ b/pkg/internal/itest/direct_fetch_test.go
@@ -124,6 +124,9 @@ func TestDirectFetch(t *testing.T) {
 			req.NoError(err)
 			outFile, err := os.CreateTemp(t.TempDir(), "lassie-test-")
 			req.NoError(err)
+			defer func() {
+				req.NoError(outFile.Close())
+			}()
 			outCar, err := storage.NewReadableWritable(outFile, []cid.Cid{rootCid}, carv2.WriteAsCarV1(true))
 			req.NoError(err)
 			outLsys := cidlink.DefaultLinkSystem()

--- a/pkg/internal/lp2ptransports/lp2ptransports.go
+++ b/pkg/internal/lp2ptransports/lp2ptransports.go
@@ -18,7 +18,7 @@ var clog = logging.Logger("lassie:lp2p:tspt:client")
 // the Storage Provider supports (http, libp2p, etc)
 const TransportsProtocolID = protocol.ID("/fil/retrieval/transports/1.0.0")
 
-const streamReadDeadline = 30 * time.Second
+const streamReadDeadline = 5 * time.Second
 
 // TransportsClient sends retrieval queries over libp2p
 type TransportsClient struct {

--- a/pkg/internal/lp2ptransports/lp2ptransports.go
+++ b/pkg/internal/lp2ptransports/lp2ptransports.go
@@ -12,8 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 )
 
-var clog = logging.Logger("boost:lp2p:tspt:client")
-var slog = logging.Logger("boost:lp2p:tspt")
+var clog = logging.Logger("lassie:lp2p:tspt:client")
 
 // TransportsProtocolID is the protocol for querying which retrieval transports
 // the Storage Provider supports (http, libp2p, etc)

--- a/pkg/internal/lp2ptransports/lp2ptransports.go
+++ b/pkg/internal/lp2ptransports/lp2ptransports.go
@@ -1,0 +1,64 @@
+package lp2ptransports
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+var clog = logging.Logger("boost:lp2p:tspt:client")
+var slog = logging.Logger("boost:lp2p:tspt")
+
+// TransportsProtocolID is the protocol for querying which retrieval transports
+// the Storage Provider supports (http, libp2p, etc)
+const TransportsProtocolID = protocol.ID("/fil/retrieval/transports/1.0.0")
+
+const streamReadDeadline = 30 * time.Second
+const streamWriteDeadline = 30 * time.Second
+
+// TransportsClient sends retrieval queries over libp2p
+type TransportsClient struct {
+	h host.Host
+}
+
+// NewTransportsClient creates a new query over libp2p
+func NewTransportsClient(h host.Host) *TransportsClient {
+	c := &TransportsClient{
+		h: h,
+	}
+	return c
+}
+
+// SendQuery sends a retrieval query over a libp2p stream to the peer
+func (c *TransportsClient) SendQuery(ctx context.Context, id peer.ID) (*QueryResponse, error) {
+	clog.Debugw("query", "peer", id)
+
+	// Create a libp2p stream to the provider
+	s, err := c.h.NewStream(ctx, id, TransportsProtocolID)
+	if err != nil {
+		return nil, err
+	}
+
+	defer s.Close() // nolint
+
+	// Set a deadline on reading from the stream so it doesn't hang
+	_ = s.SetReadDeadline(time.Now().Add(streamReadDeadline))
+	defer s.SetReadDeadline(time.Time{}) // nolint
+
+	// Read the response from the stream
+	queryResponsei, err := BindnodeRegistry.TypeFromReader(s, (*QueryResponse)(nil), dagcbor.Decode)
+	if err != nil {
+		return nil, fmt.Errorf("reading query response: %w", err)
+	}
+	queryResponse := queryResponsei.(*QueryResponse)
+
+	clog.Debugw("response", "peer", id)
+
+	return queryResponse, nil
+}

--- a/pkg/internal/lp2ptransports/lp2ptransports.go
+++ b/pkg/internal/lp2ptransports/lp2ptransports.go
@@ -19,7 +19,6 @@ var clog = logging.Logger("lassie:lp2p:tspt:client")
 const TransportsProtocolID = protocol.ID("/fil/retrieval/transports/1.0.0")
 
 const streamReadDeadline = 30 * time.Second
-const streamWriteDeadline = 30 * time.Second
 
 // TransportsClient sends retrieval queries over libp2p
 type TransportsClient struct {

--- a/pkg/internal/lp2ptransports/types.go
+++ b/pkg/internal/lp2ptransports/types.go
@@ -1,0 +1,53 @@
+package lp2ptransports
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	bindnoderegistry "github.com/ipld/go-ipld-prime/node/bindnode/registry"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type Protocol struct {
+	// The name of the transport protocol eg "libp2p" or "http"
+	Name string
+	// The address of the endpoint in multiaddr format
+	Addresses []multiaddr.Multiaddr
+}
+
+type QueryResponse struct {
+	Protocols []Protocol
+}
+
+//go:embed types.ipldsch
+var embedSchema []byte
+
+func multiAddrFromBytes(b []byte) (interface{}, error) {
+	ma, err := multiaddr.NewMultiaddrBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	return &ma, err
+}
+
+func multiAddrToBytes(iface interface{}) ([]byte, error) {
+	ma, ok := iface.(*multiaddr.Multiaddr)
+	if !ok {
+		return nil, fmt.Errorf("expected *Multiaddr value")
+	}
+
+	return (*ma).Bytes(), nil
+}
+
+var BindnodeRegistry = bindnoderegistry.NewRegistry()
+
+func init() {
+	var dummyMa multiaddr.Multiaddr
+	var bindnodeOptions = []bindnode.Option{
+		bindnode.TypedBytesConverter(&dummyMa, multiAddrFromBytes, multiAddrToBytes),
+	}
+	if err := BindnodeRegistry.RegisterType((*QueryResponse)(nil), string(embedSchema), "QueryResponse", bindnodeOptions...); err != nil {
+		panic(err.Error())
+	}
+}

--- a/pkg/internal/lp2ptransports/types.ipldsch
+++ b/pkg/internal/lp2ptransports/types.ipldsch
@@ -1,0 +1,15 @@
+# Defines the response to a query asking which transport protocols a
+# Storage Provider supports
+type Multiaddr bytes
+
+type Protocol struct {
+  # The name of the transport protocol
+  # Known protocols: "libp2p", "http", "https", "bitswap"
+  Name String
+  # The addresses of the endpoint in multiaddr format
+  Addresses [Multiaddr]
+}
+
+type QueryResponse struct {
+  Protocols [Protocol]
+}

--- a/pkg/retriever/directcandidatefinder.go
+++ b/pkg/retriever/directcandidatefinder.go
@@ -1,0 +1,190 @@
+package retriever
+
+import (
+	"context"
+	"sync"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer/v2"
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/filecoin-project/lassie/pkg/internal/lp2ptransports"
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	bsnet "github.com/ipfs/go-libipfs/bitswap/network"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+var _ CandidateFinder = &DirectCandidateFinder{}
+
+// DirectCandidateFinder finds candidate protocols from a fixed set of peers
+type DirectCandidateFinder struct {
+	h         host.Host
+	providers []peer.AddrInfo
+}
+
+// NewDirectCandidateFinder returns a new DirectCandidateFinder for the given providers
+func NewDirectCandidateFinder(h host.Host, providers []peer.AddrInfo) *DirectCandidateFinder {
+	return &DirectCandidateFinder{
+		h:         h,
+		providers: providers,
+	}
+}
+
+type candidateSender struct {
+	ctx              context.Context
+	cancel           context.CancelFunc
+	rootCid          cid.Cid
+	candidateResults chan<- types.FindCandidatesResult
+}
+
+func (cs candidateSender) sendCandidate(addr peer.AddrInfo, protocols ...metadata.Protocol) error {
+	select {
+	case <-cs.ctx.Done():
+		return cs.ctx.Err()
+	case cs.candidateResults <- types.FindCandidatesResult{Candidate: types.RetrievalCandidate{
+		MinerPeer: addr,
+		RootCid:   cs.rootCid,
+		Metadata:  metadata.Default.New(protocols...),
+	}}:
+		return nil
+	}
+}
+
+func (cs candidateSender) sendError(err error) error {
+	select {
+	case <-cs.ctx.Done():
+		return cs.ctx.Err()
+	case cs.candidateResults <- types.FindCandidatesResult{Err: err}:
+		cs.cancel()
+		return nil
+	}
+}
+
+// FindCandidatesAsync finds supported protocols for each peer
+// TODO: Cache the results?
+func (d *DirectCandidateFinder) FindCandidatesAsync(ctx context.Context, c cid.Cid) (<-chan types.FindCandidatesResult, error) {
+	candidateResults := make(chan types.FindCandidatesResult)
+	ctx, cancel := context.WithCancel(ctx)
+	cs := candidateSender{ctx, cancel, c, candidateResults}
+	var wg sync.WaitGroup
+	for _, provider := range d.providers {
+		wg.Add(1)
+		provider := provider
+		go func() {
+			defer wg.Done()
+			err := d.h.Connect(ctx, provider)
+			// don't add peers that we can't connect to
+			if err != nil {
+				_ = cs.sendError(err)
+				return
+			}
+			// check for support for Boost libp2p transports protocol
+			supportedTransportsProtocol, err := d.h.Peerstore().FirstSupportedProtocol(provider.ID, lp2ptransports.TransportsProtocolID)
+			if err != nil {
+				return
+			}
+			if supportedTransportsProtocol == lp2ptransports.TransportsProtocolID {
+				// if present, construct metadata from Boost libp2p transports response
+				d.retrievalCandidatesFromTransportsProtocol(ctx, provider, cs)
+			} else {
+				// if not present, just make guesses based on list of supported libp2p
+				// protocols catalogued via identify protocol
+				d.retrievalCandidatesFromProtocolList(ctx, provider, cs)
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(candidateResults)
+	}()
+	return candidateResults, nil
+}
+
+func (d *DirectCandidateFinder) retrievalCandidatesFromProtocolList(ctx context.Context, provider peer.AddrInfo, cs candidateSender) {
+	var protocols []metadata.Protocol
+	bitswapProtocols, err := d.h.Peerstore().SupportsProtocols(provider.ID,
+		bsnet.ProtocolBitswap,
+		bsnet.ProtocolBitswapOneOne,
+		bsnet.ProtocolBitswapOneZero,
+		bsnet.ProtocolBitswapNoVers,
+	)
+	if err != nil {
+		_ = cs.sendError(err)
+		return
+	}
+	if len(bitswapProtocols) > 0 {
+		protocols = append(protocols, &metadata.Bitswap{})
+	}
+	graphsyncProtocols, err := d.h.Peerstore().SupportsProtocols(provider.ID,
+		gsnet.ProtocolGraphsync_2_0_0,
+		datatransfer.ProtocolDataTransfer1_2,
+	)
+	if err != nil {
+		_ = cs.sendError(err)
+		return
+	}
+	// must support both graphsync & data transfer to do graphsync filecoin v1 retrieval
+	if len(graphsyncProtocols) > 1 {
+		protocols = append(protocols, &metadata.GraphsyncFilecoinV1{})
+	}
+	_ = cs.sendCandidate(provider, protocols...)
+	return
+}
+
+func (d *DirectCandidateFinder) retrievalCandidatesFromTransportsProtocol(ctx context.Context, provider peer.AddrInfo, cs candidateSender) {
+	transportsClient := lp2ptransports.NewTransportsClient(d.h)
+	qr, err := transportsClient.SendQuery(ctx, provider.ID)
+	if err != nil {
+		_ = cs.sendError(err)
+		return
+	}
+	for _, protocol := range qr.Protocols {
+		// try to parse addr infos directly
+		addrs, err := peer.AddrInfosFromP2pAddrs(protocol.Addresses...)
+		// if no peer id is present, use provider's id
+		if err != nil {
+			addrs = []peer.AddrInfo{{
+				ID:    provider.ID,
+				Addrs: protocol.Addresses,
+			}}
+		}
+		switch protocol.Name {
+		case "libp2p":
+			for _, addr := range addrs {
+				if err := cs.sendCandidate(addr, &metadata.GraphsyncFilecoinV1{}); err != nil {
+					return
+				}
+			}
+		case "bitswap":
+			for _, addr := range addrs {
+				if err := cs.sendCandidate(addr, &metadata.Bitswap{}); err != nil {
+					return
+				}
+			}
+		default:
+		}
+	}
+}
+
+func (d *DirectCandidateFinder) FindCandidates(ctx context.Context, c cid.Cid) ([]types.RetrievalCandidate, error) {
+	var candidates []types.RetrievalCandidate
+	candidatesResults, err := d.FindCandidatesAsync(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case candidateResult, ok := <-candidatesResults:
+			if !ok {
+				return candidates, nil
+			}
+			if candidateResult.Err != nil {
+				return nil, candidateResult.Err
+			}
+			candidates = append(candidates, candidateResult.Candidate)
+		}
+	}
+}

--- a/pkg/retriever/directcandidatefinder.go
+++ b/pkg/retriever/directcandidatefinder.go
@@ -129,7 +129,6 @@ func (d *DirectCandidateFinder) retrievalCandidatesFromProtocolList(ctx context.
 		protocols = append(protocols, &metadata.GraphsyncFilecoinV1{})
 	}
 	_ = cs.sendCandidate(provider, protocols...)
-	return
 }
 
 func (d *DirectCandidateFinder) retrievalCandidatesFromTransportsProtocol(ctx context.Context, provider peer.AddrInfo, cs candidateSender) {

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -427,8 +427,11 @@ func logEvent(event types.RetrievalEvent) {
 			"queryResponse:UnsealPrice", tevent.QueryResponse().UnsealPrice)
 	case events.EventWithCandidates:
 		var cands = strings.Builder{}
-		for _, c := range tevent.Candidates() {
+		for i, c := range tevent.Candidates() {
 			cands.WriteString(c.MinerPeer.ID.String())
+			if i < len(tevent.Candidates())-1 {
+				cands.WriteString(", ")
+			}
 		}
 		logadd("candidates", cands.String())
 	case events.RetrievalEventFailed:


### PR DESCRIPTION
# Goals

fix #114 and improve direct candidate retrievals in general

# Implementation

#114 occurred cause now that we have multiple protocols, we don't have any mechanism for figuring out what protocols each peer we're talking to speaks

This PR resolves this by significantly improving the former `explicitCandidateFinder`, now the `DirectCandidateFinder`.

First, we now support more than one peer! (uses --providers, seperated by a comma)

Now, for each peer we want to do direct retrievals with, we:
1. Connect to the peer
2. Examine whether they support the libp2p retrieval transports protocol (a boost protocol that identifies how an SP provides retrieval, potentially on a DIFFERENT libp2p host). If so, we use this protocol to identify exact mechanisms for retrieving over this protocol
3. If the protocol is not supported, we simply use the list of supported protocols on the connected host to make smart guesses about supporting data transfer mechanism.

Also adds an integration test, and a client for using the libp2p transports protocol.