### PR TITLE
Exposing metrics on daemon

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -63,6 +63,7 @@ var daemonFlags = []cli.Flag{
 	FlagEventRecorderAuth,
 	FlagEventRecorderInstanceId,
 	FlagEventRecorderUrl,
+	FlagExposeMetrics,
 	FlagVerbose,
 	FlagVeryVerbose,
 }
@@ -82,6 +83,7 @@ func daemonCommand(cctx *cli.Context) error {
 	maxBlocks := cctx.Uint64("maxblocks")
 	libp2pLowWater := cctx.Int("libp2p-conns-lowwater")
 	libp2pHighWater := cctx.Int("libp2p-conns-highwater")
+	exposeMetrics := cctx.Bool("expose-metrics")
 
 	lassieOpts := []lassie.LassieOption{lassie.WithProviderTimeout(20 * time.Second)}
 	if libp2pHighWater != 0 || libp2pLowWater != 0 {
@@ -105,6 +107,7 @@ func daemonCommand(cctx *cli.Context) error {
 		Port:                port,
 		TempDir:             tempDir,
 		MaxBlocksPerRequest: maxBlocks,
+		Metrics:             exposeMetrics,
 	})
 
 	if err != nil {

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -55,3 +55,11 @@ var FlagEventRecorderUrl = &cli.StringFlag{
 	Usage:   "the url of an event recorder API",
 	EnvVars: []string{"LASSIE_EVENT_RECORDER_URL"},
 }
+
+// FlagExposeMetrics exposes prometheus metrics at /metrics on the daemon http
+// server.
+var FlagExposeMetrics = &cli.BoolFlag{
+	Name:    "expose-metrics",
+	Usage:   "expose metrics at /metrics",
+	EnvVars: []string{"LASSIE_EXPOSE_METRICS"},
+}

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -6,6 +6,7 @@ import (
 	"contrib.go.opencensus.io/exporter/prometheus"
 	logging "github.com/ipfs/go-log/v2"
 	promclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opencensus.io/stats/view"
 )
 
@@ -24,6 +25,9 @@ func NewExporter(views ...*view.View) http.Handler {
 	if !ok {
 		logger.Warnf("failed to export default prometheus registry; some metrics will be unavailable; unexpected type: %T", promclient.DefaultRegisterer)
 	}
+
+	_ = registry.Register(collectors.NewGoCollector())
+	_ = registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
 	exp, err := prometheus.NewExporter(prometheus.Options{
 		Registry:  registry,

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/filecoin-project/lassie/pkg/lassie"
+	"github.com/filecoin-project/lassie/pkg/metrics"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -25,6 +26,7 @@ type HttpServerConfig struct {
 	Port                uint
 	TempDir             string
 	MaxBlocksPerRequest uint64
+	Metrics             bool
 }
 
 // NewHttpServer creates a new HttpServer
@@ -54,6 +56,9 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, cfg HttpServerCon
 
 	// Routes
 	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, cfg))
+	if cfg.Metrics {
+		mux.Handle("/metrics", metrics.NewExporter())
+	}
 
 	return httpServer, nil
 }


### PR DESCRIPTION
* add a flag to register the exporter on the daemon http server
* include golang and process metric collectors with the exporter