### PR TITLE
Resolve two vectors to expanding memory usage

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -60,6 +60,14 @@ var daemonFlags = []cli.Flag{
 		DefaultText: "libp2p default",
 		EnvVars:     []string{"LASSIE_LIBP2P_CONNECTIONS_HIGHWATER"},
 	},
+	&cli.UintFlag{
+		Name:        "concurrent-sp-retrievals",
+		Aliases:     []string{"hw"},
+		Usage:       "max number of simultaneous SP retrievals",
+		Value:       0,
+		DefaultText: "no limit",
+		EnvVars:     []string{"LASSIE_CONCURRENT_SP_RETRIEVALS"},
+	},
 	FlagEventRecorderAuth,
 	FlagEventRecorderInstanceId,
 	FlagEventRecorderUrl,
@@ -84,14 +92,14 @@ func daemonCommand(cctx *cli.Context) error {
 	libp2pLowWater := cctx.Int("libp2p-conns-lowwater")
 	libp2pHighWater := cctx.Int("libp2p-conns-highwater")
 	exposeMetrics := cctx.Bool("expose-metrics")
-
+	concurrentSPRetrievals := cctx.Uint("concurrent-sp-retrievals")
 	lassieOpts := []lassie.LassieOption{lassie.WithProviderTimeout(20 * time.Second)}
 	if libp2pHighWater != 0 || libp2pLowWater != 0 {
 		connManager, err := connmgr.NewConnManager(libp2pLowWater, libp2pHighWater)
 		if err != nil {
 			return err
 		}
-		lassieOpts = append(lassieOpts, lassie.WithLibp2pOpts(libp2p.ConnectionManager(connManager)))
+		lassieOpts = append(lassieOpts, lassie.WithLibp2pOpts(libp2p.ConnectionManager(connManager)), lassie.WithConcurrentSPRetrievals(concurrentSPRetrievals))
 	}
 	// create a lassie instance
 	lassie, err := lassie.NewLassie(cctx.Context, lassieOpts...)

--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -99,7 +99,11 @@ func daemonCommand(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		lassieOpts = append(lassieOpts, lassie.WithLibp2pOpts(libp2p.ConnectionManager(connManager)), lassie.WithConcurrentSPRetrievals(concurrentSPRetrievals))
+		lassieOpts = append(
+			lassieOpts,
+			lassie.WithLibp2pOpts(libp2p.ConnectionManager(connManager)),
+			lassie.WithConcurrentSPRetrievals(concurrentSPRetrievals),
+		)
 	}
 	// create a lassie instance
 	lassie, err := lassie.NewLassie(cctx.Context, lassieOpts...)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -406,7 +406,11 @@ func (rc *RetrievalClient) RetrieveFromPeer(
 		// We could fail before a successful proposal
 		return nil, fmt.Errorf("%w: %s", retriever.ErrDealProposalFailed, err)
 	}
-	defer rc.dataTransfer.CloseDataTransferChannel(ctx, chanid)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
+		rc.dataTransfer.CloseDataTransferChannel(ctx, chanid)
+	}()
 
 	// Wait for the retrieval to finish before exiting the function
 awaitfinished:

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -23,11 +23,12 @@ type Lassie struct {
 }
 
 type LassieConfig struct {
-	Finder          retriever.CandidateFinder
-	Host            host.Host
-	ProviderTimeout time.Duration
-	GlobalTimeout   time.Duration
-	Libp2pOptions   []libp2p.Option
+	Finder                 retriever.CandidateFinder
+	Host                   host.Host
+	ProviderTimeout        time.Duration
+	ConcurrentSPRetrievals uint
+	GlobalTimeout          time.Duration
+	Libp2pOptions          []libp2p.Option
 }
 
 type LassieOption func(cfg *LassieConfig)
@@ -73,7 +74,8 @@ func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error
 	})
 	retrieverCfg := retriever.RetrieverConfig{
 		DefaultMinerConfig: retriever.MinerConfig{
-			RetrievalTimeout: cfg.ProviderTimeout,
+			RetrievalTimeout:        cfg.ProviderTimeout,
+			MaxConcurrentRetrievals: cfg.ConcurrentSPRetrievals,
 		},
 	}
 
@@ -117,6 +119,12 @@ func WithHost(host host.Host) LassieOption {
 func WithLibp2pOpts(libp2pOptions ...libp2p.Option) LassieOption {
 	return func(cfg *LassieConfig) {
 		cfg.Libp2pOptions = libp2pOptions
+	}
+}
+
+func WithConcurrentSPRetrievals(maxConcurrentSPRtreievals uint) LassieOption {
+	return func(cfg *LassieConfig) {
+		cfg.ConcurrentSPRetrievals = maxConcurrentSPRtreievals
 	}
 }
 


### PR DESCRIPTION
# Goals

With Lassie deployed across Saturn, we're seeing memory and performance issues across both Saturn nodes and SPs.

This has raised the profile of needing to fix our cancellation logic. When the context gets cancelled at a higher level in the Lassie code, the call to CloseDataTransferChannel has no effect when passed a cancelled context. And when a data transfer doesn't close properly, it continues to consume memory -- there is a go routine and in memory state.  This is true on both the SP side AND the Lassie side. We need a proper fix for cancellation, but for now, let's just use the quick fix contained here to make sure retrievals get cancelled. A proper fix for cancellation logic will be a top priority after Async candidate retrieval is done.

Additionally even if there are lot of L1s, we should still be limiting concurrency on SP retrievals per node. We aren't currently.

# Implementation

- A temporary fix to insure context cancellations always properly shut down data transfer. Essentially, instead of using the passed in context, we use a global context with a 1 second timeout, so that the cancellation logic can run.
- adding a cli option to limit concurrent sp retrievals for the daemon 