### PR TITLE
Global option to disable graphsync retrievals

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -74,6 +74,7 @@ var daemonFlags = []cli.Flag{
 	FlagExposeMetrics,
 	FlagVerbose,
 	FlagVeryVerbose,
+	FlagDisableGraphsync,
 }
 
 var daemonCmd = &cli.Command{
@@ -93,6 +94,7 @@ func daemonCommand(cctx *cli.Context) error {
 	libp2pHighWater := cctx.Int("libp2p-conns-highwater")
 	exposeMetrics := cctx.Bool("expose-metrics")
 	concurrentSPRetrievals := cctx.Uint("concurrent-sp-retrievals")
+	disableGraphsync := cctx.Bool("disable-graphsync")
 	lassieOpts := []lassie.LassieOption{lassie.WithProviderTimeout(20 * time.Second)}
 	if libp2pHighWater != 0 || libp2pLowWater != 0 {
 		connManager, err := connmgr.NewConnManager(libp2pLowWater, libp2pHighWater)
@@ -104,6 +106,9 @@ func daemonCommand(cctx *cli.Context) error {
 			lassie.WithLibp2pOpts(libp2p.ConnectionManager(connManager)),
 			lassie.WithConcurrentSPRetrievals(concurrentSPRetrievals),
 		)
+	}
+	if disableGraphsync {
+		lassieOpts = append(lassieOpts, lassie.WithGraphsyncDisabled())
 	}
 	// create a lassie instance
 	lassie, err := lassie.NewLassie(cctx.Context, lassieOpts...)

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -74,6 +74,7 @@ var fetchCmd = &cli.Command{
 		FlagEventRecorderUrl,
 		FlagVerbose,
 		FlagVeryVerbose,
+		FlagDisableGraphsync,
 	},
 }
 
@@ -104,7 +105,10 @@ func Fetch(c *cli.Context) error {
 		finderOpt := lassie.WithFinder(retriever.NewDirectCandidateFinder(host, fetchProviderAddrInfos))
 		opts = append(opts, finderOpt)
 	}
-
+	disableGraphsync := c.Bool("disable-graphsync")
+	if disableGraphsync {
+		opts = append(opts, lassie.WithGraphsyncDisabled())
+	}
 	lassie, err := lassie.NewLassie(c.Context, opts...)
 	if err != nil {
 		return err

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -63,3 +63,10 @@ var FlagExposeMetrics = &cli.BoolFlag{
 	Usage:   "expose metrics at /metrics",
 	EnvVars: []string{"LASSIE_EXPOSE_METRICS"},
 }
+
+// FlagDisableGraphsync turns off all retrievals over the graphsync protocol
+var FlagDisableGraphsync = &cli.BoolFlag{
+	Name:    "disable-graphsync",
+	Usage:   "turn off graphsync retrievals",
+	EnvVars: []string{"LASSIE_DISABLE_GRAPHSYNC"},
+}

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -29,6 +29,7 @@ type LassieConfig struct {
 	ConcurrentSPRetrievals uint
 	GlobalTimeout          time.Duration
 	Libp2pOptions          []libp2p.Option
+	DisableGraphsync       bool
 }
 
 type LassieOption func(cfg *LassieConfig)
@@ -80,6 +81,7 @@ func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error
 			RetrievalTimeout:        cfg.ProviderTimeout,
 			MaxConcurrentRetrievals: cfg.ConcurrentSPRetrievals,
 		},
+		DisableGraphsync: cfg.DisableGraphsync,
 	}
 
 	retriever, err := retriever.NewRetriever(ctx, retrieverCfg, retrievalClient, cfg.Finder, bitswapRetriever)
@@ -140,6 +142,12 @@ func WithLibp2pOpts(libp2pOptions ...libp2p.Option) LassieOption {
 func WithConcurrentSPRetrievals(maxConcurrentSPRtreievals uint) LassieOption {
 	return func(cfg *LassieConfig) {
 		cfg.ConcurrentSPRetrievals = maxConcurrentSPRtreievals
+	}
+}
+
+func WithGraphsyncDisabled() LassieOption {
+	return func(cfg *LassieConfig) {
+		cfg.DisableGraphsync = true
 	}
 }
 

--- a/pkg/retriever/coordinators/race.go
+++ b/pkg/retriever/coordinators/race.go
@@ -36,7 +36,7 @@ func collectResults(ctx context.Context, resultChan <-chan types.RetrievalResult
 	var totalErr error
 	finishedCount := 0
 	if totalRetrievers == 0 {
-		return nil, errors.New("No elibible retrievers")
+		return nil, errors.New("no elibible retrievers")
 	}
 	for {
 		select {

--- a/pkg/retriever/coordinators/race.go
+++ b/pkg/retriever/coordinators/race.go
@@ -2,6 +2,7 @@ package coordinators
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/filecoin-project/lassie/pkg/types"
@@ -34,6 +35,9 @@ func Race(ctx context.Context, retrievalCalls []types.CandidateRetrievalCall) (*
 func collectResults(ctx context.Context, resultChan <-chan types.RetrievalResult, totalRetrievers int) (*types.RetrievalStats, error) {
 	var totalErr error
 	finishedCount := 0
+	if totalRetrievers == 0 {
+		return nil, errors.New("No elibible retrievers")
+	}
 	for {
 		select {
 		case result := <-resultChan:

--- a/pkg/retriever/coordinators/race.go
+++ b/pkg/retriever/coordinators/race.go
@@ -36,7 +36,7 @@ func collectResults(ctx context.Context, resultChan <-chan types.RetrievalResult
 	var totalErr error
 	finishedCount := 0
 	if totalRetrievers == 0 {
-		return nil, errors.New("no elibible retrievers")
+		return nil, errors.New("no eligible retrievers")
 	}
 	for {
 		select {


### PR DESCRIPTION
# Goals

Turn off the graphsync retrievals in Rhea to reduce burden on SPs

# Implementation

- global option to disable graphsync retrievals in Lassie struct, supported at CLI, and passed through the retriever
- when passed, we skip building graphsync
- we should probably also add a protocol filter to the assignable candidate finder at some point, but that is a tomorrow problem
- realized there was a small bug in the racer where if you didn't have any retrievers it just ran forever
- add integration test to verify functionality.
- left as 504 for now to indicate it's not an indexer fail.