### PR TITLE
Return 404 when cid path param is missing

### DIFF
--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -55,7 +55,7 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, cfg HttpServerCon
 	}
 
 	// Routes
-	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, cfg))
+	mux.HandleFunc("/ipfs", ipfsHandler(lassie, cfg))
 	if cfg.Metrics {
 		mux.Handle("/metrics", metrics.NewExporter())
 	}


### PR DESCRIPTION
Fixes a bug where _not_ including the CID in the path param would incorrectly not return a 404, and instead return a 500 after the empty CID string would try to be parsed and the parser returned that the CID was too short.

The trailing `/` on the `/ipfs` handler function registration was [causing a 301 redirect](https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/net/http/server.go;l=2455-2459) to `/ipfs/` when trying to make requests to `/ipfs`. Thanks @rvagg for the find. The fix is to remove the trailing `/` when registering the handler function.