### PR TITLE
Fix async not found behavior

### DIFF
--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -129,7 +129,9 @@ func (idxf *IndexerCandidateFinder) FindCandidatesAsync(ctx context.Context, c c
 	case http.StatusOK:
 		return idxf.decodeProviderResultStream(ctx, c, resp.Body)
 	case http.StatusNotFound:
-		return nil, nil
+		returned := make(chan types.FindCandidatesResult)
+		close(returned)
+		return returned, nil
 	default:
 		return nil, fmt.Errorf("batch find query failed: %v", http.StatusText(resp.StatusCode))
 	}

--- a/pkg/indexerlookup/candidatefinder_test.go
+++ b/pkg/indexerlookup/candidatefinder_test.go
@@ -92,7 +92,7 @@ func TestCandidateFinder(t *testing.T) {
 				err := mockIndexer.Start()
 				closeErr <- err
 			}()
-			indexerURL, err := url.Parse(mockIndexer.Addr())
+			indexerURL, err := url.Parse("http://" + mockIndexer.Addr())
 			req.NoError(err)
 			candidateFinder, err := indexerlookup.NewCandidateFinder(indexerlookup.WithHttpEndpoint(indexerURL))
 			req.NoError(err)

--- a/pkg/indexerlookup/candidatefinder_test.go
+++ b/pkg/indexerlookup/candidatefinder_test.go
@@ -1,0 +1,147 @@
+package indexerlookup_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/filecoin-project/lassie/pkg/indexerlookup"
+	"github.com/filecoin-project/lassie/pkg/internal/mockindexer"
+	"github.com/filecoin-project/lassie/pkg/internal/testutil"
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipni/storetheindex/api/v0/finder/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCandidateFinder(t *testing.T) {
+	cids := make([]cid.Cid, 0, 10)
+	candidates := make(map[cid.Cid][]types.RetrievalCandidate, 10)
+	binaryMetadata := make(map[cid.Cid][][]byte, 10)
+	for i := 0; i < 10; i++ {
+		next := testutil.GenerateRetrievalCandidates(t, 2)
+		cids = append(cids, next[0].RootCid)
+		candidates[next[0].RootCid] = next
+		for _, candidate := range next {
+			binaryMetadatum, err := candidate.Metadata.MarshalBinary()
+			require.NoError(t, err)
+			binaryMetadata[next[0].RootCid] = append(binaryMetadata[next[0].RootCid], binaryMetadatum)
+		}
+	}
+	testCases := []struct {
+		name            string
+		cidReturns      map[cid.Cid][]model.ProviderResult
+		expectedReturns map[cid.Cid][]types.RetrievalCandidate
+		async           bool
+	}{
+		{
+			name: "basic fetch",
+			cidReturns: map[cid.Cid][]model.ProviderResult{
+				cids[0]: {
+					{
+						Metadata:  binaryMetadata[cids[0]][0],
+						ContextID: testutil.RandomBytes(100),
+						Provider:  candidates[cids[0]][0].MinerPeer,
+					},
+					{
+						Metadata:  binaryMetadata[cids[0]][1],
+						ContextID: testutil.RandomBytes(100),
+						Provider:  candidates[cids[0]][1].MinerPeer,
+					},
+				},
+				cids[1]: {
+					{
+						Metadata:  binaryMetadata[cids[1]][0],
+						ContextID: testutil.RandomBytes(100),
+						Provider:  candidates[cids[1]][0].MinerPeer,
+					},
+					{
+						Metadata:  binaryMetadata[cids[1]][1],
+						ContextID: testutil.RandomBytes(100),
+						Provider:  candidates[cids[1]][1].MinerPeer,
+					},
+				},
+			},
+			expectedReturns: map[cid.Cid][]types.RetrievalCandidate{
+				cids[0]: candidates[cids[0]],
+				cids[1]: candidates[cids[1]],
+			},
+		},
+		{
+			name:       "not found",
+			cidReturns: map[cid.Cid][]model.ProviderResult{},
+			expectedReturns: map[cid.Cid][]types.RetrievalCandidate{
+				cids[0]: {},
+				cids[1]: {},
+			},
+		},
+	}
+	ctx := context.Background()
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			req := require.New(t)
+			clock := clock.NewMock()
+			mockIndexer, err := mockindexer.NewMockIndexer(ctx, "127.0.0.1", 7575, testCase.cidReturns, clock)
+			req.NoError(err)
+			closeErr := make(chan error, 1)
+			go func() {
+				err := mockIndexer.Start()
+				closeErr <- err
+			}()
+			indexerURL, err := url.Parse("http://127.0.0.1:7575")
+			req.NoError(err)
+			candidateFinder, err := indexerlookup.NewCandidateFinder(indexerlookup.WithHttpEndpoint(indexerURL))
+			req.NoError(err)
+			for cid, expectedReturns := range testCase.expectedReturns {
+				syncCandidates, err := candidateFinder.FindCandidates(ctx, cid)
+				req.NoError(err)
+				if syncCandidates == nil {
+					syncCandidates = []types.RetrievalCandidate{}
+				}
+				req.Equal(expectedReturns, syncCandidates)
+				asyncCandidatesChan := make(chan (<-chan types.FindCandidatesResult), 1)
+				go func() {
+					asyncCandidates, err := candidateFinder.FindCandidatesAsync(ctx, cid)
+					req.NoError(err)
+					asyncCandidatesChan <- asyncCandidates
+				}()
+				for range expectedReturns {
+					clock.Add(time.Minute)
+				}
+				var asyncCandidates <-chan types.FindCandidatesResult
+				select {
+				case <-ctx.Done():
+					req.FailNow("did not receive results")
+				case asyncCandidates = <-asyncCandidatesChan:
+				}
+				gatheredCandidates := []types.RetrievalCandidate{}
+			gatherCandidates:
+				for {
+					select {
+					case <-ctx.Done():
+						req.FailNow("did not receive async candidates")
+					case next, ok := <-asyncCandidates:
+						if !ok {
+							break gatherCandidates
+						}
+						req.NoError(next.Err)
+						gatheredCandidates = append(gatheredCandidates, next.Candidate)
+					}
+				}
+				req.Equal(expectedReturns, gatheredCandidates)
+			}
+			err = mockIndexer.Close()
+			req.NoError(err)
+			select {
+			case <-ctx.Done():
+				req.FailNow("did not close server")
+			case err := <-closeErr:
+				req.NoError(err)
+			}
+		})
+	}
+}

--- a/pkg/indexerlookup/candidatefinder_test.go
+++ b/pkg/indexerlookup/candidatefinder_test.go
@@ -85,7 +85,7 @@ func TestCandidateFinder(t *testing.T) {
 			defer cancel()
 			req := require.New(t)
 			clock := clock.NewMock()
-			mockIndexer, err := mockindexer.NewMockIndexer(ctx, "127.0.0.1", 7575, testCase.cidReturns, clock)
+			mockIndexer, err := mockindexer.NewMockIndexer(ctx, "127.0.0.1", 0, testCase.cidReturns, clock)
 			req.NoError(err)
 			closeErr := make(chan error, 1)
 			go func() {

--- a/pkg/indexerlookup/candidatefinder_test.go
+++ b/pkg/indexerlookup/candidatefinder_test.go
@@ -92,7 +92,7 @@ func TestCandidateFinder(t *testing.T) {
 				err := mockIndexer.Start()
 				closeErr <- err
 			}()
-			indexerURL, err := url.Parse("http://127.0.0.1:7575")
+			indexerURL, err := url.Parse(mockIndexer.Addr())
 			req.NoError(err)
 			candidateFinder, err := indexerlookup.NewCandidateFinder(indexerlookup.WithHttpEndpoint(indexerURL))
 			req.NoError(err)

--- a/pkg/internal/candidatebuffer/candidatebuffer_test.go
+++ b/pkg/internal/candidatebuffer/candidatebuffer_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestCandidateBuffer(t *testing.T) {
 	ctx := context.Background()
-	candidates := testutil.GenerateRetrievalCandidates(10)
+	candidates := testutil.GenerateRetrievalCandidates(t, 10)
 
 	type candidateResultAt struct {
 		timeDelta time.Duration

--- a/pkg/internal/mockindexer/mockindexer.go
+++ b/pkg/internal/mockindexer/mockindexer.go
@@ -1,0 +1,143 @@
+package mockindexer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/ipfs/go-cid"
+	"github.com/ipni/storetheindex/api/v0/finder/model"
+	"github.com/multiformats/go-multihash"
+)
+
+type MockIndexer struct {
+	returnedValues map[string][]model.ProviderResult
+	cancel         context.CancelFunc
+	ctx            context.Context
+	listener       net.Listener
+	server         *http.Server
+	clock          clock.Clock
+}
+
+func NewMockIndexer(ctx context.Context, address string, port uint64, cidProviders map[cid.Cid][]model.ProviderResult, clock clock.Clock) (*MockIndexer, error) {
+	addr := fmt.Sprintf("%s:%d", address, port)
+	listener, err := net.Listen("tcp", addr) // assigns a port if port is 0
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	// create server
+	mux := http.NewServeMux()
+	server := &http.Server{
+		Addr:        fmt.Sprintf(":%d", port),
+		BaseContext: func(listener net.Listener) context.Context { return ctx },
+		Handler:     mux,
+	}
+
+	returnedValues := make(map[string][]model.ProviderResult, len(cidProviders))
+	for c, providers := range cidProviders {
+		returnedValues[string(c.Hash())] = providers
+	}
+	httpServer := &MockIndexer{
+		cancel:         cancel,
+		ctx:            ctx,
+		listener:       listener,
+		server:         server,
+		returnedValues: returnedValues,
+		clock:          clock,
+	}
+
+	// Routes
+	mux.HandleFunc("/multihash/", httpServer.handleMultihash)
+
+	return httpServer, nil
+}
+
+// Addr returns the listening address of the server
+func (s *MockIndexer) Addr() string {
+	return s.listener.Addr().String()
+}
+
+// Start starts the http server, returning an error if the server failed to start
+func (s *MockIndexer) Start() error {
+	err := s.server.Serve(s.listener)
+	if err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+// Close shutsdown the server and cancels the server context
+func (s *MockIndexer) Close() error {
+	s.cancel()
+	return s.server.Shutdown(context.Background())
+}
+
+func (s *MockIndexer) handleMultihash(res http.ResponseWriter, req *http.Request) {
+	urlPath := strings.Split(req.URL.Path, "/")[1:]
+
+	// check if CID path param is missing
+	if len(urlPath) < 2 {
+		// not a valid path to hit
+		res.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// validate CID path parameter
+	mhStr := urlPath[1]
+	mh, err := multihash.FromB58String(mhStr)
+	if err != nil {
+		http.Error(res, "Failed to parse multihash parameter", http.StatusInternalServerError)
+		return
+	}
+
+	returnResults := s.returnedValues[string(mh)]
+	if len(returnResults) == 0 {
+		http.NotFound(res, req)
+		return
+	}
+
+	// check if Accept header includes applica
+	isNDJson := false
+	hasAccept := req.Header.Get("Accept") != ""
+	acceptTypes := strings.Split(req.Header.Get("Accept"), ",")
+	if hasAccept {
+		for _, acceptType := range acceptTypes {
+			if acceptType == "application/x-ndjson" {
+				isNDJson = true
+				break
+			}
+		}
+	}
+
+	if !isNDJson {
+
+		err := json.NewEncoder(res).Encode(model.FindResponse{
+			MultihashResults: []model.MultihashResult{
+				{
+					Multihash:       mh,
+					ProviderResults: returnResults,
+				},
+			},
+		})
+		if err != nil {
+			http.Error(res, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+
+	encoder := json.NewEncoder(res)
+	for _, result := range returnResults {
+		encoder.Encode(result)
+		res.Write([]byte("\n"))
+		s.clock.Sleep(1 * time.Second)
+	}
+}

--- a/pkg/internal/testutil/gen.go
+++ b/pkg/internal/testutil/gen.go
@@ -56,8 +56,6 @@ func GenerateCids(n int) []cid.Cid {
 	return cids
 }
 
-var peerSeq int
-
 // GeneratePeers creates n peer ids.
 func GeneratePeers(t *testing.T, n int) []peer.ID {
 	src := rand.NewSource(seedSeq)

--- a/pkg/retriever/bitswaphelpers/indexerrouting_test.go
+++ b/pkg/retriever/bitswaphelpers/indexerrouting_test.go
@@ -38,9 +38,9 @@ func TestIndexerRouting(t *testing.T) {
 	verifyCandidates(ctx, t, nil, ir.FindProvidersAsync(ctx, cids[0], 5))
 	verifyCandidates(ctx, t, nil, ir.FindProvidersAsync(ctx, cids[1], 5))
 	verifyCandidates(ctx, t, nil, ir.FindProvidersAsync(ctx, cids[2], 5))
-	candidates1 := testutil.GenerateRetrievalCandidates(10)
-	candidates2 := testutil.GenerateRetrievalCandidates(10)
-	candidates3 := testutil.GenerateRetrievalCandidates(10)
+	candidates1 := testutil.GenerateRetrievalCandidates(t, 10)
+	candidates2 := testutil.GenerateRetrievalCandidates(t, 10)
+	candidates3 := testutil.GenerateRetrievalCandidates(t, 10)
 	ir.AddProviders(id1, candidates1)
 	ir.AddProviders(id2, candidates2)
 	ir.AddProviders(id3, candidates3)
@@ -48,7 +48,7 @@ func TestIndexerRouting(t *testing.T) {
 	verifyCandidates(ctx, t, candidates2[:5], ir.FindProvidersAsync(ctx, cids[1], 5))
 	verifyCandidates(ctx, t, candidates3[:5], ir.FindProvidersAsync(ctx, cids[2], 5))
 	// add more to one retrieval
-	extraCandidates := testutil.GenerateRetrievalCandidates(5)
+	extraCandidates := testutil.GenerateRetrievalCandidates(t, 5)
 	ir.AddProviders(id1, extraCandidates)
 	// remove another retrieval
 	ir.RemoveProviders(id2)

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -74,8 +74,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: makeLsys(tbc2.AllBlocks()),
 			},
 			expectedCandidates: map[cid.Cid][]types.RetrievalCandidate{
-				cid1: testutil.GenerateRetrievalCandidates(5),
-				cid2: testutil.GenerateRetrievalCandidates(7),
+				cid1: testutil.GenerateRetrievalCandidates(t, 5),
+				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
 				cid1: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
@@ -114,8 +114,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: makeLsys(append(tbc2.Blocks(0, 25), tbc2.Blocks(45, 75)...)),
 			},
 			expectedCandidates: map[cid.Cid][]types.RetrievalCandidate{
-				cid1: testutil.GenerateRetrievalCandidates(5),
-				cid2: testutil.GenerateRetrievalCandidates(7),
+				cid1: testutil.GenerateRetrievalCandidates(t, 5),
+				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
 				cid1: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
@@ -154,8 +154,8 @@ func TestBitswapRetriever(t *testing.T) {
 			// i.e. two jumps per block
 			selector: []ipld.Node{depth10Selector, depth10Selector},
 			expectedCandidates: map[cid.Cid][]types.RetrievalCandidate{
-				cid1: testutil.GenerateRetrievalCandidates(5),
-				cid2: testutil.GenerateRetrievalCandidates(7),
+				cid1: testutil.GenerateRetrievalCandidates(t, 5),
+				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
 				cid1: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
@@ -190,8 +190,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: makeLsys(tbc2.Blocks(0, 50)),
 			},
 			expectedCandidates: map[cid.Cid][]types.RetrievalCandidate{
-				cid1: testutil.GenerateRetrievalCandidates(5),
-				cid2: testutil.GenerateRetrievalCandidates(7),
+				cid1: testutil.GenerateRetrievalCandidates(t, 5),
+				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
 				cid1: {types.StartedCode, types.FirstByteCode, types.FailedCode},
@@ -209,8 +209,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: makeLsys(tbc2.Blocks(0, 50)),
 			},
 			expectedCandidates: map[cid.Cid][]types.RetrievalCandidate{
-				cid1: testutil.GenerateRetrievalCandidates(5),
-				cid2: testutil.GenerateRetrievalCandidates(7),
+				cid1: testutil.GenerateRetrievalCandidates(t, 5),
+				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
 				cid1: {types.StartedCode, types.FailedCode},
@@ -228,8 +228,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: makeLsys(tbc2.AllBlocks()),
 			},
 			expectedCandidates: map[cid.Cid][]types.RetrievalCandidate{
-				cid1: testutil.GenerateRetrievalCandidates(5),
-				cid2: testutil.GenerateRetrievalCandidates(7),
+				cid1: testutil.GenerateRetrievalCandidates(t, 5),
+				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
 				cid1: {types.StartedCode, types.FirstByteCode, types.FailedCode},

--- a/pkg/retriever/combinators/asyncsplitter_test.go
+++ b/pkg/retriever/combinators/asyncsplitter_test.go
@@ -16,7 +16,7 @@ func TestAsyncCandidateSplitter(t *testing.T) {
 	ctx := context.Background()
 	candidateSets := make([][]types.RetrievalCandidate, 0, 3)
 	for i := 0; i < 3; i++ {
-		candidateSets = append(candidateSets, testutil.GenerateRetrievalCandidates((i+1)*2))
+		candidateSets = append(candidateSets, testutil.GenerateRetrievalCandidates(t, (i+1)*2))
 	}
 	testCases := []struct {
 		name                 string

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipni/index-provider/metadata"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multicodec"
 )
 
@@ -21,7 +22,7 @@ type RetrievalCandidate struct {
 func NewRetrievalCandidate(pid peer.ID, rootCid cid.Cid, protocols ...metadata.Protocol) RetrievalCandidate {
 	md := metadata.Default.New(protocols...)
 	return RetrievalCandidate{
-		MinerPeer: peer.AddrInfo{ID: pid},
+		MinerPeer: peer.AddrInfo{ID: pid, Addrs: []multiaddr.Multiaddr{}},
 		RootCid:   rootCid,
 		Metadata:  md,
 	}


### PR DESCRIPTION
# Goals

Previously, if we get a 404 from the indexer, we return nil for a channel, which will hang forever

# Implementation

- the fix is three lines in candidatesfinder.go
- at the same time, I felt it was important to start testing the indexer finding code against what we believe the indexer to return. As a result, I've added a "mock" indexer server that can be spun up and added unit tests for the indexer.
- we could also incorporate this into integration tests with mocknet if we like, to make them "more integration-ey"