### PR TITLE
Add aggregate event recorder subscriber

### DIFF
--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -1,0 +1,206 @@
+package aggregateeventrecorder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/events"
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-log/v2"
+)
+
+var logging = log.Logger("aggregateeventrecorder")
+
+const httpTimeout = 5 * time.Second
+const parallelPosters = 5
+
+type tempData struct {
+	startTime time.Time
+	ttfb      int64
+	ttfbTime  time.Time
+}
+
+type AggregateEvent struct {
+	InstanceID        string    `json:"instanceId"`        // The ID of the Lassie instance generating the event
+	RetrievalID       string    `json:"retrievalId"`       // The unique ID of the retrieval
+	StorageProviderID string    `json:"storageProviderId"` // The ID of the storage provider that served the retrieval content
+	TimeToFirstByte   int64     `json:"timeToFirstByte"`   // The time it took to receive the first byte in seconds
+	Bandwidth         uint64    `json:"bandwidth"`         // The bandwidth of the retrieval in bytes per second
+	Success           bool      `json:"success"`           // Wether or not the retreival ended with a success event
+	StartTime         time.Time `json:"startTime"`         // The time the retrieval started
+	EndTime           time.Time `json:"endTime"`           // The time the retrieval ended
+}
+
+type batchedEvents struct {
+	Events []AggregateEvent `json:"events"`
+}
+
+type aggregateEventRecorder struct {
+	ctx                   context.Context
+	instanceID            string                    // The ID of the instance generating the event
+	endpointURL           string                    // The URL to POST the events to
+	endpointAuthorization string                    // The key to use in an Authorization header
+	disableIndexerEvents  bool                      // Whether or not to disable indexer events. Defaults to false.
+	ingestChan            chan types.RetrievalEvent // A channel for incoming events
+	postChan              chan []AggregateEvent     // A channel for posting events
+	eventTempMap          map[string]tempData       // Holds data about multiple events for aggregation
+}
+
+func NewAggregateEventRecorder(ctx context.Context, instanceID string, endpointURL string, endpointAuthorization string, disableIndexerEvents bool) *aggregateEventRecorder {
+	recorder := &aggregateEventRecorder{
+		ctx:                   ctx,
+		instanceID:            instanceID,
+		endpointURL:           endpointURL,
+		endpointAuthorization: endpointAuthorization,
+		disableIndexerEvents:  disableIndexerEvents,
+		ingestChan:            make(chan types.RetrievalEvent),
+		postChan:              make(chan []AggregateEvent),
+		eventTempMap:          make(map[string]tempData),
+	}
+
+	go recorder.ingestEvents()
+	for i := 0; i < parallelPosters; i++ {
+		go recorder.postEvents()
+	}
+
+	return recorder
+}
+
+// RetrievalEventSubsciber returns a RetrievalEventSubscriber that POSTs
+// a batch of aggregated retrieval events to an event recorder API endpoint
+func (a *aggregateEventRecorder) RetrievalEventSubscriber() types.RetrievalEventSubscriber {
+	return func(event types.RetrievalEvent) {
+		if a.disableIndexerEvents && event.Phase() == types.IndexerPhase {
+			return
+		}
+
+		// Process the incoming event
+		select {
+		case <-a.ctx.Done():
+		case a.ingestChan <- event:
+		}
+	}
+}
+
+// ingestEvents receives and stores event data from ingestChan
+// to generate an aggregated event upon receiving a finished event.
+func (a *aggregateEventRecorder) ingestEvents() {
+	var batchedData []AggregateEvent
+	var emptyGaurdChan chan []AggregateEvent = nil
+
+	for {
+		select {
+		case <-a.ctx.Done():
+		// read incoming data
+		case event := <-a.ingestChan:
+			id := event.RetrievalId().String()
+
+			switch event.Code() {
+			case types.StartedCode:
+				// Record when first phase starts to help calculate time to first byte later
+				if event.Phase() == types.IndexerPhase {
+					a.eventTempMap[id] = tempData{event.Time(), 0, time.Time{}}
+				}
+
+			case types.FirstByteCode:
+				// Calculate time to first byte
+				tempData := a.eventTempMap[id]
+				tempData.ttfbTime = event.Time()
+				tempData.ttfb = event.Time().Sub(tempData.startTime).Milliseconds()
+				a.eventTempMap[id] = tempData
+
+			case types.SuccessCode, types.FinishedCode:
+				// We will receive a finished code right after
+				// a success code, so ignore any event that we
+				// haven't saved or have already deleted
+				tempData, ok := a.eventTempMap[id]
+				if !ok {
+					continue
+				}
+
+				success := event.Code() == types.SuccessCode
+				spId := event.StorageProviderId().String()
+				endTime := event.Time()
+
+				var bandwidth uint64
+				if success {
+					receivedSize := event.(events.RetrievalEventSuccess).ReceivedSize()
+					duration := event.Time().Sub(tempData.ttfbTime)
+					bandwidth = uint64(float64(receivedSize) / duration.Seconds())
+				}
+
+				aggregatedEvent := AggregateEvent{
+					InstanceID:        a.instanceID,
+					RetrievalID:       id,
+					StorageProviderID: spId,
+					TimeToFirstByte:   tempData.ttfb,
+					Bandwidth:         bandwidth,
+					Success:           true,
+					StartTime:         tempData.startTime,
+					EndTime:           endTime,
+				}
+
+				// Delete the key when we're done with the data
+				delete(a.eventTempMap, id)
+
+				batchedData = append(batchedData, aggregatedEvent)
+				if emptyGaurdChan == nil {
+					emptyGaurdChan = a.postChan // emptyGuardChan is no longer nil when we add to the batch
+				}
+			}
+
+		case emptyGaurdChan <- batchedData: // won't execute while emptyGaurdChan is nil
+			batchedData = nil
+			emptyGaurdChan = nil
+		}
+	}
+}
+
+// postEvents receives batched aggregated events from postChan
+// and sends a POST request to the provided endpointURL. If an
+// endpointAuthorization is provided, it's used in the Authorization
+// header.
+func (a *aggregateEventRecorder) postEvents() {
+	client := http.Client{Timeout: httpTimeout}
+
+	for {
+		select {
+		case <-a.ctx.Done():
+			return
+		case batchedData := <-a.postChan:
+			byts, err := json.Marshal(batchedEvents{batchedData})
+			if err != nil {
+				logging.Errorf("Failed to JSONify and encode event: %w", err.Error())
+				continue
+			}
+
+			req, err := http.NewRequest("POST", a.endpointURL, bytes.NewBufferString(string(byts)))
+			if err != nil {
+				logging.Errorf("Failed to create POST request for [%s]: %w", a.endpointURL, err.Error())
+				continue
+			}
+
+			req.Header.Set("Content-Type", "application/json")
+
+			// set authorization header if configured
+			if a.endpointAuthorization != "" {
+				req.Header.Set("Authorization", fmt.Sprintf("Basic %s", a.endpointAuthorization))
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				logging.Errorf("Failed to POST event to [%s]: %w", a.endpointURL, err.Error())
+				continue
+			}
+
+			defer resp.Body.Close() // error not so important at this point
+			if resp.StatusCode < 200 || resp.StatusCode > 299 {
+				logging.Errorf("Expected success response code from server, got: %s", http.StatusText(resp.StatusCode))
+			}
+		}
+	}
+}

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -130,8 +130,10 @@ func (a *aggregateEventRecorder) ingestEvents() {
 
 				// Calculate bandwidth
 				receivedSize := event.(events.RetrievalEventSuccess).ReceivedSize()
-				duration := event.Time().Sub(tempData.firstByteTime)
-				tempData.bandwidth = uint64(float64(receivedSize) / duration.Seconds())
+				duration := event.Time().Sub(tempData.firstByteTime).Seconds()
+				if duration != 0 {
+					tempData.bandwidth = uint64(float64(receivedSize) / duration)
+				}
 
 				a.eventTempMap[id] = tempData
 

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -1,0 +1,209 @@
+package aggregateeventrecorder_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
+	"github.com/filecoin-project/lassie/pkg/events"
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+var testCid1 = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
+
+func TestAggregateEventRecorder(t *testing.T) {
+	var req datamodel.Node
+	var path string
+	receivedChan := make(chan bool, 1)
+	authHeaderValue := "applesauce"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+		require.NoError(t, err)
+		path = r.URL.Path
+		require.Equal(t, "Basic applesauce", r.Header.Get("Authorization"))
+		receivedChan <- true
+	}))
+	defer ts.Close()
+
+	tests := []struct {
+		name string
+		exec func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID, etime, ptime time.Time, spid peer.ID)
+	}{
+		{
+			name: "Retrieval Success",
+			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID, etime, ptime time.Time, spid peer.ID) {
+				fetchPhaseStartTime := ptime.Add(-10 * time.Second)
+
+				subscriber(events.Started(id, fetchPhaseStartTime, types.FetchPhase, types.RetrievalCandidate{RootCid: testCid1}))
+				subscriber(events.FirstByte(id, ptime, types.RetrievalCandidate{RootCid: testCid1}))
+				time.Sleep(50 * time.Millisecond) // Add artificial wait to get
+				subscriber(events.Success(id, ptime, types.NewRetrievalCandidate(spid, testCid1), uint64(2020), 3030, 4*time.Second, big.Zero()))
+				subscriber(events.Finished(id, fetchPhaseStartTime, types.RetrievalCandidate{RootCid: testCid1}))
+
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-receivedChan:
+				}
+
+				require.Equal(t, int64(1), req.Length())
+				eventList := verifyListNode(t, req, "events", 1)
+				event := verifyListElement(t, eventList, 0)
+				// require.Equal(t, int64(8), event.Length())
+				verifyStringNode(t, event, "instanceId", "test-instance")
+				verifyStringNode(t, event, "retrievalId", id.String())
+				verifyStringNode(t, event, "storageProviderId", spid.String())
+				// verifyIntNode(t, event, "timeToFirstByte", 0)
+				// verifyIntNode(t, event, "bandwidth", 0)
+				verifyBoolNode(t, event, "success", true)
+				// verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				// verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+			},
+		},
+		{
+			name: "Retrieval Failure, Never Reached First Byte",
+			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID, etime, ptime time.Time, spid peer.ID) {
+				fetchPhaseStartTime := ptime.Add(-10 * time.Second)
+
+				subscriber(events.Started(id, fetchPhaseStartTime, types.FetchPhase, types.RetrievalCandidate{RootCid: testCid1}))
+				subscriber(events.Finished(id, fetchPhaseStartTime, types.RetrievalCandidate{RootCid: testCid1}))
+
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-receivedChan:
+				}
+
+				require.Equal(t, int64(1), req.Length())
+				eventList := verifyListNode(t, req, "events", 1)
+				event := verifyListElement(t, eventList, 0)
+				require.Equal(t, int64(5), event.Length())
+				verifyStringNode(t, event, "instanceId", "test-instance")
+				verifyStringNode(t, event, "retrievalId", id.String())
+				verifyBoolNode(t, event, "success", false)
+				// verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				// verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			subscriber := aggregateeventrecorder.NewAggregateEventRecorder(
+				ctx,
+				"test-instance",
+				fmt.Sprintf("%s/test-path/here", ts.URL),
+				authHeaderValue,
+				false,
+			).RetrievalEventSubscriber()
+			id, err := types.NewRetrievalID()
+			require.NoError(t, err)
+			etime := time.Now()
+			ptime := time.Now().Add(time.Hour * -1)
+			spid := peer.ID("A")
+			test.exec(t, ctx, subscriber, id, etime, ptime, spid)
+			require.NotNil(t, req)
+			require.Equal(t, "/test-path/here", path)
+		})
+	}
+}
+
+func verifyListNode(t *testing.T, node datamodel.Node, key string, expectedLength int64) datamodel.Node {
+	subNode, err := node.LookupByString(key)
+	require.NoError(t, err)
+	require.Equal(t, datamodel.Kind_List, subNode.Kind())
+	require.Equal(t, int64(expectedLength), subNode.Length())
+	return subNode
+}
+
+func verifyListElement(t *testing.T, node datamodel.Node, index int64) datamodel.Node {
+	element, err := node.LookupByIndex(index)
+	require.NoError(t, err)
+	return element
+}
+
+func verifyStringNode(t *testing.T, node datamodel.Node, key string, expected string) {
+	str := nodeToString(t, node, key)
+	require.Equal(t, expected, str)
+}
+
+func nodeToString(t *testing.T, node datamodel.Node, key string) string {
+	subNode, err := node.LookupByString(key)
+	require.NoError(t, err)
+	str, err := subNode.AsString()
+	require.NoError(t, err)
+	return str
+}
+
+func verifyBoolNode(t *testing.T, node datamodel.Node, key string, expected bool) {
+	subNode, err := node.LookupByString(key)
+	require.NoError(t, err)
+	ii, err := subNode.AsBool()
+	require.NoError(t, err)
+	require.Equal(t, expected, ii)
+}
+
+func mustCid(cstr string) cid.Cid {
+	c, err := cid.Decode(cstr)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+var result bool
+
+func BenchmarkAggregateEventRecorderSubscriber(b *testing.B) {
+	receivedChan := make(chan bool, 1)
+	authHeaderValue := "applesauce"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedChan <- true
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	subscriber := aggregateeventrecorder.NewAggregateEventRecorder(
+		ctx,
+		"test-instance",
+		fmt.Sprintf("%s/test-path/here", ts.URL),
+		authHeaderValue,
+		false,
+	).RetrievalEventSubscriber()
+	id, _ := types.NewRetrievalID()
+	fetchStartTime := time.Now()
+	ptime := time.Now().Add(time.Hour * -1)
+	spid := peer.ID("A")
+
+	var success bool
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		subscriber(events.Started(id, fetchStartTime, types.FetchPhase, types.NewRetrievalCandidate(spid, testCid1)))
+		subscriber(events.FirstByte(id, ptime, types.NewRetrievalCandidate(spid, testCid1)))
+		subscriber(events.Success(id, ptime, types.NewRetrievalCandidate(spid, testCid1), uint64(2020), 3030, 4*time.Second, big.Zero()))
+		subscriber(events.Finished(id, fetchStartTime, types.RetrievalCandidate{RootCid: testCid1}))
+		b.StopTimer()
+
+		select {
+		case <-ctx.Done():
+			b.Fatal(ctx.Err())
+		case result := <-receivedChan:
+			success = result
+		}
+	}
+	result = success
+}

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -81,6 +81,7 @@ func TestRetriever(t *testing.T) {
 				}, Delay: time.Millisecond * 5},
 			},
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, ist, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1)}),
 				events.CandidatesFiltered(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1)}),
@@ -93,6 +94,7 @@ func TestRetriever(t *testing.T) {
 				events.Accepted(rid, rst, types.NewRetrievalCandidate(peerA, cid1)),
 				events.FirstByte(rid, rst, types.NewRetrievalCandidate(peerA, cid1)),
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero()),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 
@@ -118,6 +120,7 @@ func TestRetriever(t *testing.T) {
 				}, Delay: time.Millisecond * 5},
 			},
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, qst, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
 				events.CandidatesFiltered(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
@@ -131,6 +134,7 @@ func TestRetriever(t *testing.T) {
 				events.Accepted(rid, rst, types.NewRetrievalCandidate(peerB, cid1)),
 				events.FirstByte(rid, rst, types.NewRetrievalCandidate(peerB, cid1)),
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerB, cid1), 10, 11, 12*time.Second, big.Zero()),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 
@@ -157,6 +161,7 @@ func TestRetriever(t *testing.T) {
 				}, Delay: time.Millisecond * 5},
 			},
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, rst, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(blacklistedPeer, cid1), types.NewRetrievalCandidate(peerA, cid1)}),
 				events.CandidatesFiltered(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1)}),
@@ -169,6 +174,7 @@ func TestRetriever(t *testing.T) {
 				events.Accepted(rid, rst, types.NewRetrievalCandidate(peerA, cid1)),
 				events.FirstByte(rid, rst, types.NewRetrievalCandidate(peerA, cid1)),
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero()),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 
@@ -194,6 +200,7 @@ func TestRetriever(t *testing.T) {
 				}, Delay: time.Millisecond * 5},
 			},
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, rst, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
 				events.CandidatesFiltered(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
@@ -208,6 +215,7 @@ func TestRetriever(t *testing.T) {
 				events.Accepted(rid, rst, types.NewRetrievalCandidate(peerB, cid1)),
 				events.FirstByte(rid, rst, types.NewRetrievalCandidate(peerB, cid1)),
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerB, cid1), 1, 2, 3*time.Second, big.Zero()),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 
@@ -234,6 +242,7 @@ func TestRetriever(t *testing.T) {
 				string(peerB): {ResultStats: nil, ResultErr: errors.New("bork!"), Delay: time.Millisecond * 5},
 			},
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, rst, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
 				events.CandidatesFiltered(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
@@ -253,6 +262,7 @@ func TestRetriever(t *testing.T) {
 				events.Accepted(rid, rst, types.NewRetrievalCandidate(peerA, cid1)),
 				events.FirstByte(rid, rst, types.NewRetrievalCandidate(peerA, cid1)),
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerA, cid1), 10, 20, 30*time.Second, big.Zero()),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 
@@ -289,6 +299,7 @@ func TestRetriever(t *testing.T) {
 			},
 			successfulPeer: peerB,
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, ist, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
 				events.CandidatesFiltered(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
@@ -308,6 +319,7 @@ func TestRetriever(t *testing.T) {
 				events.Accepted(rid, rst, types.NewRetrievalCandidate(peerB, cid1)),
 				events.FirstByte(rid, rst, types.NewRetrievalCandidate(peerB, cid1)),
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerB, cid1), 20, 30, 40*time.Second, big.Zero()),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 		{
@@ -321,8 +333,10 @@ func TestRetriever(t *testing.T) {
 			successfulPeer:     peer.ID(""),
 			err:                retriever.ErrNoCandidates,
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, ist, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Failed(rid, rst, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}, "no candidates"),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 		{
@@ -338,9 +352,11 @@ func TestRetriever(t *testing.T) {
 			successfulPeer:     peer.ID(""),
 			err:                retriever.ErrNoCandidates,
 			expectedEvents: []types.RetrievalEvent{
+				events.Started(rid, ist, types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.Started(rid, ist, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
 				events.CandidatesFound(rid, ist, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(blacklistedPeer, cid1)}),
 				events.Failed(rid, rst, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}, "no candidates"),
+				events.Finished(rid, rst, types.RetrievalCandidate{RootCid: cid1}),
 			},
 		},
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -162,6 +162,8 @@ const (
 type Phase string
 
 const (
+	// FetchPhase encompasses the entire process from start to end, involves the finished event
+	FetchPhase Phase = "fetch"
 	// IndexerPhase involves a candidates-found|failure
 	IndexerPhase Phase = "indexer"
 	// QueryPhase involves a connect, query-asked|failure
@@ -184,6 +186,7 @@ const (
 	FirstByteCode          EventCode = "first-byte-received"
 	FailedCode             EventCode = "failure"
 	SuccessCode            EventCode = "success"
+	FinishedCode           EventCode = "finished"
 )
 
 type RetrievalEvent interface {


### PR DESCRIPTION
## Overview
Adds an aggregate event recorder subscriber that aggregates retrieval events before POSTing to the event recorder endpoint.

## Updates
- Adds a new AggregateEvent that is emitted to the configured event recorder endpoint instead of the single events
- Adds a new phase, `FetchPhase`, which encompasses the idea of the entire fetch from start to end.
- Adds a new event, `Finished`, which represents the end of the `FetchPhase`

#### AggregateEvent
```golang
type AggregatedEvent struct {
	InstanceID        string    `json:"instanceId"`        // The ID of the Lassie instance generating the event
	RetrievalID       string    `json:"retrievalId"`       // The unique ID of the retrieval
	StorageProviderID string    `json:"storageProviderId"` // The ID of the storage provider that served the retrieval content
	TimeToFirstByte   float64   `json:"timeToFirstByte"`   // The time it took to receive the first byte in seconds
	Bandwidth         float64   `json:"bandwidth"`         // The bandwidth of the retrieval in bytes per second
	Success           bool      `json:"success"`           // Wether or not the retreival ended with a success event
	StartTime         time.Time `json:"startTime"`         // The time the retrieval started
	EndTime           time.Time `json:"endTime"`           // The time the retrieval ended
}
```