### PR TITLE
WIP: Boostrap IPFS nodes

### DIFF
--- a/pkg/retriever/bitswaphelpers/indexerrouting.go
+++ b/pkg/retriever/bitswaphelpers/indexerrouting.go
@@ -24,17 +24,26 @@ var _ routing.Routing = (*IndexerRouting)(nil)
 // top of the processing we're doing at a higher level with multiprotocol filtering
 type IndexerRouting struct {
 	routinghelpers.Null
-	providerSets   map[types.RetrievalID][]types.RetrievalCandidate
-	providerSetsLk sync.Mutex
-	toRetrievalIDs func(cid.Cid) []types.RetrievalID
+	providerSets       map[types.RetrievalID][]types.RetrievalCandidate
+	incomingRetrievals map[types.RetrievalID]chan struct{}
+	providerSetsLk     sync.Mutex
+	toRetrievalIDs     func(cid.Cid) []types.RetrievalID
 }
 
 // NewIndexerRouting makes a new indexer routing instance
 func NewIndexerRouting(toRetrievalID func(cid.Cid) []types.RetrievalID) *IndexerRouting {
 	return &IndexerRouting{
-		providerSets:   make(map[types.RetrievalID][]types.RetrievalCandidate),
-		toRetrievalIDs: toRetrievalID,
+		providerSets:       make(map[types.RetrievalID][]types.RetrievalCandidate),
+		incomingRetrievals: make(map[types.RetrievalID]chan struct{}),
+		toRetrievalIDs:     toRetrievalID,
 	}
+}
+
+// RemoveProviders removes all provider records for a given retrieval id
+func (ir *IndexerRouting) SignalIncomingRetrieval(retrievalID types.RetrievalID) {
+	ir.providerSetsLk.Lock()
+	defer ir.providerSetsLk.Unlock()
+	ir.incomingRetrievals[retrievalID] = make(chan struct{}, 1)
 }
 
 // RemoveProviders removes all provider records for a given retrieval id
@@ -42,6 +51,10 @@ func (ir *IndexerRouting) RemoveProviders(retrievalID types.RetrievalID) {
 	ir.providerSetsLk.Lock()
 	defer ir.providerSetsLk.Unlock()
 	delete(ir.providerSets, retrievalID)
+	if incomingRetrieval, ok := ir.incomingRetrievals[retrievalID]; ok {
+		close(incomingRetrieval)
+		delete(ir.incomingRetrievals, retrievalID)
+	}
 }
 
 // AddProviders adds provider records to the total list for a given retrieval id
@@ -58,6 +71,10 @@ func (ir *IndexerRouting) AddProviders(retrievalID types.RetrievalID, providers 
 	ir.providerSetsLk.Lock()
 	defer ir.providerSetsLk.Unlock()
 	ir.providerSets[retrievalID] = append(ir.providerSets[retrievalID], uniqueProviders...)
+	if incomingRetrieval, ok := ir.incomingRetrievals[retrievalID]; ok {
+		close(incomingRetrieval)
+		delete(ir.incomingRetrievals, retrievalID)
+	}
 }
 
 // FindProvidersAsync returns providers based on the retrieval id in a context key
@@ -75,6 +92,7 @@ func (ir *IndexerRouting) FindProvidersAsync(ctx context.Context, c cid.Cid, max
 		retrievalIDs := ir.toRetrievalIDs(c)
 		ir.providerSetsLk.Lock()
 		var providers []types.RetrievalCandidate
+		var incomingRetrievals []<-chan struct{}
 		for _, retrievalID := range retrievalIDs {
 			providers = append(providers, ir.providerSets[retrievalID]...)
 			if len(providers) > max {
@@ -84,8 +102,35 @@ func (ir *IndexerRouting) FindProvidersAsync(ctx context.Context, c cid.Cid, max
 			if len(ir.providerSets) == 0 {
 				delete(ir.providerSets, retrievalID)
 			}
+			if retrievalChan, ok := ir.incomingRetrievals[retrievalID]; ok {
+				incomingRetrievals = append(incomingRetrievals, retrievalChan)
+			}
 		}
 		ir.providerSetsLk.Unlock()
+		// if we have no providers but signals that more are incoming, wait for them, then try gathering
+		// providers again
+		if len(providers) == 0 && len(incomingRetrievals) > 0 {
+			for _, incomingRetrieval := range incomingRetrievals {
+				select {
+				case <-ctx.Done():
+					return
+				case <-incomingRetrieval:
+				}
+			}
+			// once all incoming retrievals have received a signal, regather candidates
+			ir.providerSetsLk.Lock()
+			for _, retrievalID := range retrievalIDs {
+				providers = append(providers, ir.providerSets[retrievalID]...)
+				if len(providers) > max {
+					providers, ir.providerSets[retrievalID] = providers[:max], providers[max:]
+					break
+				}
+				if len(ir.providerSets) == 0 {
+					delete(ir.providerSets, retrievalID)
+				}
+			}
+			ir.providerSetsLk.Unlock()
+		}
 		log.Debugw("provider records requested from bitswap, sending back indexer results", "providerCount", len(providers))
 		for _, p := range providers {
 			select {

--- a/pkg/retriever/combinators/retrieverwithcandidatefinder.go
+++ b/pkg/retriever/combinators/retrieverwithcandidatefinder.go
@@ -41,10 +41,10 @@ func (rcf RetrieverWithCandidateFinder) Retrieve(ctx context.Context, request ty
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case err := <-findErr:
-			if err != nil {
-				return nil, err
-			}
+		//case err := <-findErr:
+		//	if err != nil {
+		//		return nil, err
+		//	}
 		case result := <-resultChan:
 			return result.Stats, result.Err
 		}

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -204,7 +204,7 @@ func (retriever *Retriever) Retrieve(
 	if !retriever.eventManager.IsStarted() {
 		return nil, ErrRetrieverNotStarted
 	}
-	if !retriever.spTracker.RegisterRetrieval(request.RetrievalID, request.Cid) {
+	if !retriever.spTracker.RegisterRetrieval(request.RetrievalID, request.Cid, request.GetSelector()) {
 		return nil, fmt.Errorf("%w: %s", ErrRetrievalAlreadyRunning, request.Cid)
 	}
 	defer func() {


### PR DESCRIPTION
This is still very WIP, but looks like we're losing about 15% of requests through bitswap that have NO DHT results but come in in Kubo through the IPFS boostrap peers.

This adds an option to add boostrap peers, and also modifies bitswap fetching to not care if it gets no provider results. This is all still very WIP.