### PR TITLE
Sptracker: track by cid+selector

### DIFF
--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -204,7 +204,7 @@ func (retriever *Retriever) Retrieve(
 	if !retriever.eventManager.IsStarted() {
 		return nil, ErrRetrieverNotStarted
 	}
-	if !retriever.spTracker.RegisterRetrieval(request.RetrievalID, request.Cid) {
+	if !retriever.spTracker.RegisterRetrieval(request.RetrievalID, request.Cid, request.GetSelector()) {
 		return nil, fmt.Errorf("%w: %s", ErrRetrievalAlreadyRunning, request.Cid)
 	}
 	defer func() {


### PR DESCRIPTION
# Goals

Noticed this while working with cache list. I think two retrievals from the same root with different selectors are materially different, and we shouldn't dedup on them.

for example

/ipfs/cid1/?depthType=shallow
/ipfs/cid1/index.html

# Implementation

- Add serialized selectors as part of the uniqueness key for retrieval tracking