### PR TITLE
Fix performance bug

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lassie/pkg/lassie"
+	"github.com/filecoin-project/lassie/pkg/metrics"
 	httpserver "github.com/filecoin-project/lassie/pkg/server/http"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
@@ -86,6 +87,8 @@ var daemonFlags = []cli.Flag{
 	FlagEventRecorderInstanceId,
 	FlagEventRecorderUrl,
 	FlagExposeMetrics,
+	FlagMetricsPort,
+	FlagMetricsAddress,
 	FlagVerbose,
 	FlagVeryVerbose,
 	FlagDisableGraphsync,
@@ -107,6 +110,8 @@ func daemonCommand(cctx *cli.Context) error {
 	libp2pLowWater := cctx.Int("libp2p-conns-lowwater")
 	libp2pHighWater := cctx.Int("libp2p-conns-highwater")
 	exposeMetrics := cctx.Bool("expose-metrics")
+	metricsPort := cctx.Uint("metrics-port")
+	metricsAddress := cctx.String("metrics-address")
 	concurrentSPRetrievals := cctx.Uint("concurrent-sp-retrievals")
 	disableGraphsync := cctx.Bool("disable-graphsync")
 	providerTimeout := cctx.Duration("provider-timeout")
@@ -144,7 +149,6 @@ func daemonCommand(cctx *cli.Context) error {
 		Port:                port,
 		TempDir:             tempDir,
 		MaxBlocksPerRequest: maxBlocks,
-		Metrics:             exposeMetrics,
 	})
 
 	if err != nil {
@@ -153,21 +157,47 @@ func daemonCommand(cctx *cli.Context) error {
 	}
 
 	serverErrChan := make(chan error, 1)
+	metricsServerErrChan := make(chan error, 1)
 	go func() {
 		fmt.Printf("Lassie daemon listening on address %s\n", httpServer.Addr())
 		fmt.Println("Hit CTRL-C to stop the daemon")
 		serverErrChan <- httpServer.Start()
 	}()
 
+	var metricsServer *metrics.MetricsServer
+	if exposeMetrics {
+		metricsServer, err = metrics.NewHttpServer(cctx.Context, metricsAddress, metricsPort)
+
+		if err != nil {
+			log.Errorw("failed to create metrics server", "err", err)
+			return err
+		}
+
+		go func() {
+			fmt.Printf("Lassie metrics listening on address %s\n", metricsServer.Addr())
+			fmt.Println("Hit CTRL-C to stop the server")
+			metricsServerErrChan <- metricsServer.Start()
+		}()
+	}
+
 	select {
 	case <-cctx.Done(): // command was cancelled
 	case err = <-serverErrChan: // error from server
 		log.Errorw("failed to start http server", "err", err)
+	case err = <-metricsServerErrChan: // error from server
+		log.Errorw("failed to start metrics server", "err", err)
 	}
 
 	fmt.Println("Shutting down Lassie daemon")
 	if err = httpServer.Close(); err != nil {
 		log.Errorw("failed to close http server", "err", err)
+	}
+
+	if exposeMetrics {
+		fmt.Println("Shutting down Lassie daemon")
+		if err = metricsServer.Close(); err != nil {
+			log.Errorw("failed to close http server", "err", err)
+		}
 	}
 
 	fmt.Println("Lassie daemon stopped")

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -64,6 +64,24 @@ var FlagExposeMetrics = &cli.BoolFlag{
 	EnvVars: []string{"LASSIE_EXPOSE_METRICS"},
 }
 
+// FlagMetricsAddress sets the address on which to expose metrics and pprof information
+var FlagMetricsAddress = &cli.StringFlag{
+	Name:        "metrics-address",
+	Usage:       "the address to expose metrics for prometheus and pprof when expose metrics is true",
+	Value:       "127.0.0.1",
+	DefaultText: "127.0.0.1",
+	EnvVars:     []string{"LASSIE_METRICS_ADDRESS"},
+}
+
+// FlagMetricsPort sets the port on which to expose metrics and pprof information
+var FlagMetricsPort = &cli.UintFlag{
+	Name:        "metrics-port",
+	Usage:       "the port to expose metrics for prometheus and pprof when expose metrics is true",
+	Value:       0,
+	DefaultText: "random",
+	EnvVars:     []string{"LASSIE_METRICS_PORT"},
+}
+
 // FlagDisableGraphsync turns off all retrievals over the graphsync protocol
 var FlagDisableGraphsync = &cli.BoolFlag{
 	Name:    "disable-graphsync",

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	// expose default metrics
+	_ "net/http/pprof"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("lassie/metrics")
+
+// MetricsServer simply exposes prometheus and pprof metrics via HTTP
+type MetricsServer struct {
+	cancel   context.CancelFunc
+	ctx      context.Context
+	listener net.Listener
+	server   *http.Server
+}
+
+// NewHttpServer creates a new HttpServer
+func NewHttpServer(ctx context.Context, address string, port uint) (*MetricsServer, error) {
+	addr := fmt.Sprintf("%s:%d", address, port)
+	listener, err := net.Listen("tcp", addr) // assigns a port if port is 0
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	// create server
+	server := &http.Server{
+		Addr:        fmt.Sprintf(":%d", port),
+		BaseContext: func(listener net.Listener) context.Context { return ctx },
+		Handler:     http.DefaultServeMux,
+	}
+
+	metricsServer := &MetricsServer{
+		cancel:   cancel,
+		ctx:      ctx,
+		listener: listener,
+		server:   server,
+	}
+
+	// Routes
+	http.Handle("/metrics", NewExporter())
+
+	return metricsServer, nil
+}
+
+// Addr returns the listening address of the server
+func (s MetricsServer) Addr() string {
+	return s.listener.Addr().String()
+}
+
+// Start starts the metrics http server, returning an error if the server failed to start
+func (s *MetricsServer) Start() error {
+	log.Infow("starting metrics server", "listen_addr", s.listener.Addr())
+	err := s.server.Serve(s.listener)
+	if err != http.ErrServerClosed {
+		log.Errorw("failed to start metrics server", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+// Close shutsdown the server and cancels the server context
+func (s *MetricsServer) Close() error {
+	log.Info("closing http server")
+	s.cancel()
+	return s.server.Shutdown(context.Background())
+}

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/filecoin-project/lassie/pkg/lassie"
-	"github.com/filecoin-project/lassie/pkg/metrics"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -26,7 +25,6 @@ type HttpServerConfig struct {
 	Port                uint
 	TempDir             string
 	MaxBlocksPerRequest uint64
-	Metrics             bool
 }
 
 // NewHttpServer creates a new HttpServer
@@ -56,9 +54,6 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, cfg HttpServerCon
 
 	// Routes
 	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, cfg))
-	if cfg.Metrics {
-		mux.Handle("/metrics", metrics.NewExporter())
-	}
 
 	return httpServer, nil
 }


### PR DESCRIPTION
# Goals

Find the performance bug in 0.6.4

# Implementation

First, I expanded metrics setup, so it runs on its own port and also exposes pprof there.

This is important so it can be exposed on Saturn for the future.

Second, I ran a load test and collected CPU profile at the same time.

The results showed a terrible CPU loop in retrievalwithcandidatefinder.go.

Looking at the loop, here's what's happening -- it commits a great sin of a for/select loop: make sure the select blocks until you really have relevant new data.

Look at this: https://github.com/filecoin-project/lassie/blob/main/pkg/retriever/combinators/retrieverwithcandidatefinder.go#L44

Basically, it reads the candidate finding error- if there's no error, the loop continues. But now the candidate finding error channel is closed which means... it can be read again (cause closed channel always reads nil immediately)... so instead of blocking, it reads, and loops, and reads, and loops, etc, as fast as your CPU can do it.

The solution is to set the findErr channel to nil afterward, so that it can't be read again. One line, 400% CPU usage to 25% on my machine.

Here are the dumps:

Before:
![lassie-pre](https://user-images.githubusercontent.com/1450680/224201400-89f07496-35fd-4492-b8d2-f65a97b402d2.png)
After:
![lassie-post](https://user-images.githubusercontent.com/1450680/224201426-b4c5620e-537f-467e-bd6e-6fecd1223e28.png)

