### PR TITLE
Remove Bitswap concurrency limits

### DIFF
--- a/pkg/retriever/assignablecandidatefinder_test.go
+++ b/pkg/retriever/assignablecandidatefinder_test.go
@@ -124,13 +124,13 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				allCandidateResults[c] = candidateResults
 			}
 			candidateFinder := &testutil.MockCandidateFinder{Error: testCase.candidateError, Candidates: allCandidateResults}
-			isAcceptableStorageProvider := func(testPeer peer.ID) bool {
+			isAcceptableStorageProvider := func(candidate types.RetrievalCandidate) (bool, types.RetrievalCandidate) {
 				for _, filteredPeer := range testCase.filteredPeers {
-					if testPeer == peer.ID(filteredPeer) {
-						return false
+					if candidate.MinerPeer.ID == peer.ID(filteredPeer) {
+						return false, types.RetrievalCandidate{}
 					}
 				}
-				return true
+				return true, candidate
 			}
 			receivedCandidates := make(map[cid.Cid][]string)
 			appendCandidates := func(cid cid.Cid, candidates []types.RetrievalCandidate) {

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -25,7 +25,6 @@ type CandidateCallback func(types.RetrievalCandidate) error
 type CandidateErrorCallback func(types.RetrievalCandidate, error)
 
 type GetStorageProviderTimeout func(peer peer.ID) time.Duration
-type IsAcceptableStorageProvider func(peer peer.ID) bool
 type IsAcceptableQueryResponse func(peer peer.ID, req types.RetrievalRequest, queryResponse *retrievaltypes.QueryResponse) bool
 
 type queryCandidate struct {

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -151,7 +151,7 @@ func (retriever *Retriever) getStorageProviderTimeout(storageProviderId peer.ID)
 // is acceptable as a retrieval candidate. It checks the blacklists and
 // whitelists, the miner monitor for failures and whether we are already at
 // concurrency limit for this SP.
-func (retriever *Retriever) filderIndexerCandidate(candidate types.RetrievalCandidate) (bool, types.RetrievalCandidate) {
+func (retriever *Retriever) filterIndexerCandidate(candidate types.RetrievalCandidate) (bool, types.RetrievalCandidate) {
 	protocols := candidate.Metadata.Protocols()
 	newProtocolMetadata := make([]metadata.Protocol, 0, len(protocols))
 	for _, protocol := range protocols {

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -114,7 +114,7 @@ func NewRetriever(
 		protocols = append(protocols, multicodec.TransportBitswap)
 	}
 	retriever.executor = combinators.RetrieverWithCandidateFinder{
-		CandidateFinder: NewAssignableCandidateFinder(candidateFinder, retriever.filderIndexerCandidate),
+		CandidateFinder: NewAssignableCandidateFinder(candidateFinder, retriever.filterIndexerCandidate),
 		CandidateRetriever: combinators.SplitRetriever[multicodec.Code]{
 			AsyncCandidateSplitter: combinators.NewAsyncCandidateSplitter(protocols, NewProtocolSplitter),
 			CandidateRetrievers:    candidateRetrievers,

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -171,7 +171,6 @@ func TestRetriever(t *testing.T) {
 				events.Success(rid, rst, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero()),
 			},
 		},
-
 		{
 			name: "two candidates, fast one fails query, slow wins",
 			candidates: []types.RetrievalCandidate{


### PR DESCRIPTION
# Goals

We're filtering a ton of requests on Saturn cause they're getting hit by concurrency limits and miner suspensions. Let's not do that. 

# Implementation

- Change "IsAcceptableIndexerCandidate" to "FiltererIndexerCandidate" that can remove 1 or more protocols from a candidate if now is not a reasonable time to use those protocols for those candidates.
- Modify Assignable candidate finder to work with it
- Move the type from graphsync retriever since... yea it's a bit absurd it lives there

# For discussion

It's pretty tough to test this with the retriever test the way it is -- I'm gonna take that on next and see if I can't clean it up.