### PR TITLE
Drop fetch phase on old recorder

### DIFF
--- a/pkg/eventrecorder/eventrecorder.go
+++ b/pkg/eventrecorder/eventrecorder.go
@@ -100,8 +100,7 @@ func toStrings(protocols []multicodec.Code) []string {
 
 func (er *EventRecorder) RecordEvent(event types.RetrievalEvent) {
 	if event.Phase() == types.FetchPhase {
-		// ignore indexer events for now, it can get very chatty in the autoretrieve
-		// case where every request results in an indexer lookup
+		// ignored for now because it's not recognized upstream
 		return
 	}
 	if er.cfg.DisableIndexerEvents && event.Phase() == types.IndexerPhase {

--- a/pkg/eventrecorder/eventrecorder.go
+++ b/pkg/eventrecorder/eventrecorder.go
@@ -99,6 +99,11 @@ func toStrings(protocols []multicodec.Code) []string {
 }
 
 func (er *EventRecorder) RecordEvent(event types.RetrievalEvent) {
+	if event.Phase() == types.FetchPhase {
+		// ignore indexer events for now, it can get very chatty in the autoretrieve
+		// case where every request results in an indexer lookup
+		return
+	}
 	if er.cfg.DisableIndexerEvents && event.Phase() == types.IndexerPhase {
 		// ignore indexer events for now, it can get very chatty in the autoretrieve
 		// case where every request results in an indexer lookup


### PR DESCRIPTION
# Goals

Maintain compatibility with current recorder schema until it changes. We want to cut an interim lassie release and currently many of the event posts fail whenever a fetch is included (and writes of batches are all or nothing I think)

# Implementation

Just ignore the fetch phase on the old recorder for now. We can put it back in once the schema on the other side supports it.