### PR TITLE
fix: add yamux and mplex

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -11,6 +11,7 @@ import (
 	cmdinternal "github.com/filecoin-project/lassie/cmd/lassie/internal"
 	"github.com/filecoin-project/lassie/pkg/events"
 	"github.com/filecoin-project/lassie/pkg/lassie"
+	lassielp2p "github.com/filecoin-project/lassie/pkg/libp2p"
 	"github.com/filecoin-project/lassie/pkg/retriever"
 	"github.com/filecoin-project/lassie/pkg/streamingstore"
 	"github.com/filecoin-project/lassie/pkg/types"
@@ -18,7 +19,6 @@ import (
 	carv2 "github.com/ipld/go-car/v2"
 	carstore "github.com/ipld/go-car/v2/storage"
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/urfave/cli/v2"
 )
@@ -103,7 +103,7 @@ func Fetch(c *cli.Context) error {
 	providerTimeout := c.Duration("provider-timeout")
 	providerTimeoutOpt := lassie.WithProviderTimeout(providerTimeout)
 
-	host, err := libp2p.New(libp2p.ResourceManager(&network.NullResourceManager{}))
+	host, err := lassielp2p.InitHost(c.Context, []libp2p.Option{})
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,8 @@ require (
 	golang.org/x/net v0.7.0
 )
 
+require github.com/libp2p/go-mplex v0.7.0 // indirect
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,8 @@ github.com/libp2p/go-libp2p-routing-helpers v0.6.1 h1:tI3rHOf/FDQsxC2pHBaOZiqPJ0
 github.com/libp2p/go-libp2p-routing-helpers v0.6.1/go.mod h1:R289GUxUMzRXIbWGSuUUTPrlVJZ3Y/pPz495+qgXJX8=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
+github.com/libp2p/go-mplex v0.7.0 h1:BDhFZdlk5tbr0oyFq/xv/NPGfjbnrsDam1EvutpBDbY=
+github.com/libp2p/go-mplex v0.7.0/go.mod h1:rW8ThnRcYWft/Jb2jeORBmPd6xuG3dGxWN/W168L9EU=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.1.0 h1:MfVsH6DLcpa04Xr+p8hmVRG4juse0s3J8HyNWYHffXg=

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/filecoin-project/lassie/pkg/client"
 	"github.com/filecoin-project/lassie/pkg/indexerlookup"
-	"github.com/filecoin-project/lassie/pkg/internal"
+	lassielp2p "github.com/filecoin-project/lassie/pkg/libp2p"
 	"github.com/filecoin-project/lassie/pkg/retriever"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-datastore"
@@ -62,7 +62,7 @@ func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error
 
 	if cfg.Host == nil {
 		var err error
-		cfg.Host, err = internal.InitHost(ctx, cfg.Libp2pOptions)
+		cfg.Host, err = lassielp2p.InitHost(ctx, cfg.Libp2pOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/libp2p/libp2p.go
+++ b/pkg/libp2p/libp2p.go
@@ -1,4 +1,4 @@
-package internal
+package libp2p
 
 import (
 	"context"
@@ -6,13 +6,26 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/muxer/mplex"
+	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"github.com/multiformats/go-multiaddr"
 )
+
+const yamuxID = "/yamux/1.0.0"
+const mplexID = "/mplex/6.7.0"
 
 func InitHost(ctx context.Context, opts []libp2p.Option, listenAddrs ...multiaddr.Multiaddr) (host.Host, error) {
 	opts = append([]libp2p.Option{libp2p.Identity(nil), libp2p.ResourceManager(&network.NullResourceManager{})}, opts...)
 	if len(listenAddrs) > 0 {
 		opts = append([]libp2p.Option{libp2p.ListenAddrs(listenAddrs...)}, opts...)
 	}
+	opts = append(opts, libp2p.Muxer(yamuxID, yamuxTransport()))
+	opts = append(opts, libp2p.Muxer(mplexID, mplex.DefaultTransport))
 	return libp2p.New(opts...)
+}
+
+func yamuxTransport() network.Multiplexer {
+	tpt := *yamux.DefaultTransport
+	tpt.AcceptBacklog = 512
+	return &tpt
 }


### PR DESCRIPTION
I don't know what I'm doing here but this makes me move beyond this error in talking to E-IPFS:

```
  * [/ip4/104.18.21.126/tcp/443/tls/sni/elastic.dag.house/ws] failed to negotiate stream multiplexer: protocols not supported: [/yamux/1.0.0]
  * [/ip4/104.18.20.126/tcp/443/tls/sni/elastic.dag.house/ws] failed to negotiate stream multiplexer: protocols not supported: [/yamux/1.0.0]
```

to this:

```
  * [/ip4/104.18.20.126/tcp/443/tls/sni/elastic.dag.house/ws] failed to negotiate stream multiplexer: failed to get reader: received close frame: status = StatusNoStatusRcvd and reason = ""
  * [/ip4/104.18.21.126/tcp/443/tls/sni/elastic.dag.house/ws] failed to negotiate stream multiplexer: failed to get reader: received close frame: status = StatusNoStatusRcvd and reason = ""
 ```

🤷 