### PR TITLE
Don't set default addresses

### DIFF
--- a/pkg/net/host/host.go
+++ b/pkg/net/host/host.go
@@ -21,28 +21,11 @@ import (
 const yamuxID = "/yamux/1.0.0"
 const mplexID = "/mplex/6.7.0"
 
-var defaultAddrs = []string{"/ip4/0.0.0.0/tcp/4001",
-	"/ip6/::/tcp/4001",
-	"/ip4/0.0.0.0/udp/4001/quic",
-	"/ip4/0.0.0.0/udp/4001/quic-v1",
-	"/ip4/0.0.0.0/udp/4001/quic-v1/webtransport",
-	"/ip6/::/udp/4001/quic",
-	"/ip6/::/udp/4001/quic-v1",
-	"/ip6/::/udp/4001/quic-v1/webtransport",
-}
-
 func InitHost(ctx context.Context, opts []libp2p.Option, listenAddrs ...multiaddr.Multiaddr) (Host, error) {
 	opts = append([]libp2p.Option{libp2p.Identity(nil), libp2p.ResourceManager(&network.NullResourceManager{})}, opts...)
 	if len(listenAddrs) > 0 {
 		opts = append([]libp2p.Option{libp2p.ListenAddrs(listenAddrs...)}, opts...)
-	} else {
-		addrs, err := listenAddresses(defaultAddrs)
-		if err != nil {
-			return nil, err
-		}
-		opts = append([]libp2p.Option{libp2p.ListenAddrs(addrs...)}, opts...)
 	}
-
 	// add transports
 	opts = append([]libp2p.Option{libp2p.Transport(tcp.NewTCPTransport, tcp.WithMetrics()), libp2p.Transport(websocket.New), libp2p.Transport(quic.NewTransport), libp2p.Transport(webtransport.New)}, opts...)
 	// add security

--- a/pkg/net/host/host.go
+++ b/pkg/net/host/host.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -40,19 +39,6 @@ func yamuxTransport() network.Multiplexer {
 	tpt := *yamux.DefaultTransport
 	tpt.AcceptBacklog = 512
 	return &tpt
-}
-
-func listenAddresses(addresses []string) ([]multiaddr.Multiaddr, error) {
-	listen := make([]multiaddr.Multiaddr, len(addresses))
-	for i, addr := range addresses {
-		maddr, err := multiaddr.NewMultiaddr(addr)
-		if err != nil {
-			return nil, fmt.Errorf("failure to parse config.Addresses.Swarm: %s", addresses)
-		}
-		listen[i] = maddr
-	}
-
-	return listen, nil
 }
 
 // Host is a type alias for libp2p host


### PR DESCRIPTION
# Goal

Fix #160

# Implementation

Let libp2p setup the addresses, based on transports.