### PR TITLE
Use aggregate event recorder

### DIFF
--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -65,6 +65,7 @@ func before(cctx *cli.Context) error {
 		"lassie/httpserver",
 		"indexerlookup",
 		"lassie/bitswap",
+		"lassie/aggregateeventrecorder",
 	}
 
 	level := "WARN"


### PR DESCRIPTION
### Overview
This replaces the use of the `EventRecorder` with the `AggregateEventRecorder`. When providing the `--event-recorder-url` option, the events being sent will now be aggregate events instead of individual retrieval events.