### PR TITLE
fix: pass actual selector to proposal

### DIFF
--- a/pkg/internal/itest/client_retrieval_test.go
+++ b/pkg/internal/itest/client_retrieval_test.go
@@ -119,6 +119,7 @@ func runRetrieval(t *testing.T, ctx context.Context, mrn *mocknet.MockRetrievalN
 		Params: retrievaltypes.Params{
 			PricePerByte: big.Zero(),
 			UnsealPrice:  big.Zero(),
+			Selector:     retrievaltypes.CborGenCompatibleNode{Node: selectorparse.CommonSelector_ExploreAllRecursively},
 		},
 	}
 	paymentAddress := address.TestAddress2

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -452,7 +452,7 @@ func retrievalPhase(
 		ss,
 	)
 
-	proposal, err := RetrievalProposalForAsk(queryResponse, candidate.RootCid, nil)
+	proposal, err := RetrievalProposalForAsk(queryResponse, candidate.RootCid, selector)
 	if err != nil {
 		return nil, multierr.Append(multierr.Append(ErrRetrievalFailed, ErrProposalCreationFailed), err)
 	}

--- a/pkg/retriever/proposal.go
+++ b/pkg/retriever/proposal.go
@@ -7,7 +7,6 @@ import (
 	retrievaltypes "github.com/filecoin-project/go-retrieval-types"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 )
 
 var dealIdGen = NewTimeCounter()
@@ -27,16 +26,12 @@ func (tc *TimeCounter) Next() uint64 {
 	return counter
 }
 
-func RetrievalProposalForAsk(ask *retrievaltypes.QueryResponse, c cid.Cid, optionalSelector ipld.Node) (*retrievaltypes.DealProposal, error) {
-	if optionalSelector == nil {
-		optionalSelector = selectorparse.CommonSelector_ExploreAllRecursively
-	}
-
+func RetrievalProposalForAsk(ask *retrievaltypes.QueryResponse, c cid.Cid, selector ipld.Node) (*retrievaltypes.DealProposal, error) {
 	params, err := retrievaltypes.NewParamsV1(
 		ask.MinPricePerByte,
 		ask.MaxPaymentInterval,
 		ask.MaxPaymentIntervalIncrease,
-		optionalSelector,
+		selector,
 		nil,
 		ask.UnsealPrice,
 	)

--- a/pkg/retriever/proposal_test.go
+++ b/pkg/retriever/proposal_test.go
@@ -18,7 +18,7 @@ func TestRetrievalProposalForAsk(t *testing.T) {
 		MaxPaymentIntervalIncrease: 3,
 		UnsealPrice:                abi.NewTokenAmount(4),
 	}
-	proposal, err := RetrievalProposalForAsk(ask, cid1, nil)
+	proposal, err := RetrievalProposalForAsk(ask, cid1, selectorparse.CommonSelector_ExploreAllRecursively)
 	require.NoError(t, err)
 	require.NotZero(t, proposal.ID)
 	require.Equal(t, cid1, proposal.PayloadCID)


### PR DESCRIPTION
From `#boost-help` on Filecoin Slack:

<img width="1001" alt="Screenshot 2023-03-23 at 12 03 06 am" src="https://user-images.githubusercontent.com/495647/226912854-495c84bb-d7c1-4467-8e32-813fa3995abb.png">

Not sure if this is Lassie or not, but it turns out that it could be if you're doing anything other than the default selector. We only ever send ExploreAllRecursively, which isn't right if you have a path or change the depth type.