### PR TITLE
Add retrieval attempt stats

### DIFF
--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -7,20 +7,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
 	"github.com/filecoin-project/lassie/pkg/events"
+	"github.com/filecoin-project/lassie/pkg/internal/testutil"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipni/go-libipni/metadata"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
-
-var testCid1 = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
 
 func TestAggregateEventRecorder(t *testing.T) {
 	var req datamodel.Node
@@ -37,19 +39,40 @@ func TestAggregateEventRecorder(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	testCid1 := testutil.GenerateCid()
+	bitswapCandidates := testutil.GenerateRetrievalCandidatesForCID(t, 2, testCid1, &metadata.Bitswap{})
+	graphsyncCandidates := testutil.GenerateRetrievalCandidatesForCID(t, 3, testCid1, &metadata.GraphsyncFilecoinV1{})
+
 	tests := []struct {
 		name string
-		exec func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID, etime, ptime time.Time, spid peer.ID)
+		exec func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID)
 	}{
 		{
 			name: "Retrieval Success",
-			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID, etime, ptime time.Time, spid peer.ID) {
-				fetchPhaseStartTime := ptime.Add(-10 * time.Second)
+			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID) {
+				clock := clock.NewMock()
 
-				subscriber(events.Started(time.Now(), id, fetchPhaseStartTime, types.FetchPhase, types.RetrievalCandidate{RootCid: testCid1}))
-				subscriber(events.FirstByte(time.Now(), id, ptime, types.RetrievalCandidate{RootCid: testCid1}))
-				subscriber(events.Success(time.Now().Add(50*time.Millisecond), id, ptime, types.NewRetrievalCandidate(spid, testCid1), uint64(2020), 3030, 4*time.Second, big.Zero(), 55))
-				subscriber(events.Finished(time.Now().Add(50*time.Millisecond), id, fetchPhaseStartTime, types.RetrievalCandidate{RootCid: testCid1}))
+				subscriber(events.Started(clock.Now(), id, clock.Now(), types.FetchPhase, types.RetrievalCandidate{RootCid: testCid1}, multicodec.TransportGraphsyncFilecoinv1, multicodec.TransportBitswap))
+				fetchPhaseStartTime := clock.Now()
+				indexerStartTime := clock.Now()
+				clock.Add(10 * time.Millisecond)
+				subscriber(events.CandidatesFound(clock.Now(), id, indexerStartTime, testCid1, graphsyncCandidates))
+				subscriber(events.CandidatesFiltered(clock.Now(), id, indexerStartTime, testCid1, graphsyncCandidates[:2]))
+				subscriber(events.Started(clock.Now(), id, clock.Now(), types.RetrievalPhase, graphsyncCandidates[0]))
+				subscriber(events.Started(clock.Now(), id, clock.Now(), types.RetrievalPhase, graphsyncCandidates[1]))
+				graphsyncCandidateStartTime := clock.Now()
+				clock.Add(10 * time.Millisecond)
+				subscriber(events.CandidatesFound(clock.Now(), id, indexerStartTime, testCid1, bitswapCandidates[:2]))
+				subscriber(events.CandidatesFiltered(clock.Now(), id, indexerStartTime, testCid1, bitswapCandidates[:1]))
+				bitswapPeer := types.NewRetrievalCandidate(peer.ID(""), testCid1, &metadata.Bitswap{})
+				subscriber(events.Started(clock.Now(), id, clock.Now(), types.RetrievalPhase, bitswapPeer))
+				bitswapCandidateStartTime := clock.Now()
+				clock.Add(20 * time.Millisecond)
+				subscriber(events.FirstByte(clock.Now(), id, bitswapCandidateStartTime, bitswapPeer))
+				subscriber(events.Failed(clock.Now(), id, graphsyncCandidateStartTime, types.RetrievalPhase, graphsyncCandidates[0], "failed to dial"))
+				clock.Add(50 * time.Millisecond)
+				subscriber(events.Success(clock.Now(), id, bitswapCandidateStartTime, bitswapPeer, uint64(10000), 3030, 4*time.Second, big.Zero(), 55))
+				subscriber(events.Finished(clock.Now(), id, fetchPhaseStartTime, bitswapPeer))
 
 				select {
 				case <-ctx.Done():
@@ -60,24 +83,45 @@ func TestAggregateEventRecorder(t *testing.T) {
 				require.Equal(t, int64(1), req.Length())
 				eventList := verifyListNode(t, req, "events", 1)
 				event := verifyListElement(t, eventList, 0)
-				// require.Equal(t, int64(8), event.Length())
+				require.Equal(t, int64(14), event.Length())
 				verifyStringNode(t, event, "instanceId", "test-instance")
 				verifyStringNode(t, event, "retrievalId", id.String())
-				verifyStringNode(t, event, "storageProviderId", spid.String())
-				// verifyIntNode(t, event, "timeToFirstByte", 0)
-				// verifyIntNode(t, event, "bandwidth", 0)
+				verifyStringNode(t, event, "storageProviderId", types.BitswapIndentifier)
+				verifyStringNode(t, event, "timeToFirstByte", "40ms")
+				verifyStringNode(t, event, "timeToFirstIndexerResult", "10ms")
+				verifyIntNode(t, event, "bandwidth", 200000)
 				verifyBoolNode(t, event, "success", true)
-				// verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
-				// verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Add(90*time.Millisecond).Format(time.RFC3339Nano))
+
+				verifyIntNode(t, event, "indexerCandidatesReceived", 5)
+				verifyIntNode(t, event, "indexerCandidatesFiltered", 3)
+				protocolsAllowed := verifyListNode(t, event, "protocolsAllowed", 2)
+				verifyStringListElementsMatch(t, protocolsAllowed, []string{"transport-graphsync-filecoinv1", "transport-bitswap"})
+				protocolsAttempted := verifyListNode(t, event, "protocolsAttempted", 2)
+				verifyStringListElementsMatch(t, protocolsAttempted, []string{"transport-graphsync-filecoinv1", "transport-bitswap"})
+				retrievalAttempts, err := event.LookupByString("retrievalAttempts")
+				require.NoError(t, err)
+				require.Equal(t, int64(3), retrievalAttempts.Length())
+				sp1Attempt, err := retrievalAttempts.LookupByString(graphsyncCandidates[0].MinerPeer.ID.String())
+				require.NoError(t, err)
+				require.Equal(t, int64(1), sp1Attempt.Length())
+				verifyStringNode(t, sp1Attempt, "error", "failed to dial")
+				sp2Attempt, err := retrievalAttempts.LookupByString(graphsyncCandidates[1].MinerPeer.ID.String())
+				require.NoError(t, err)
+				require.Equal(t, int64(0), sp2Attempt.Length())
+				bitswapAttempt, err := retrievalAttempts.LookupByString(types.BitswapIndentifier)
+				require.NoError(t, err)
+				require.Equal(t, int64(0), bitswapAttempt.Length())
 			},
 		},
 		{
 			name: "Retrieval Failure, Never Reached First Byte",
-			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID, etime, ptime time.Time, spid peer.ID) {
-				fetchPhaseStartTime := ptime.Add(-10 * time.Second)
-
-				subscriber(events.Started(time.Now(), id, fetchPhaseStartTime, types.FetchPhase, types.RetrievalCandidate{RootCid: testCid1}))
-				subscriber(events.Finished(time.Now(), id, fetchPhaseStartTime, types.RetrievalCandidate{RootCid: testCid1}))
+			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID) {
+				clock := clock.NewMock()
+				fetchPhaseStartTime := clock.Now()
+				subscriber(events.Started(clock.Now(), id, fetchPhaseStartTime, types.FetchPhase, types.RetrievalCandidate{RootCid: testCid1}))
+				subscriber(events.Finished(clock.Now(), id, fetchPhaseStartTime, types.RetrievalCandidate{RootCid: testCid1}))
 
 				select {
 				case <-ctx.Done():
@@ -88,12 +132,12 @@ func TestAggregateEventRecorder(t *testing.T) {
 				require.Equal(t, int64(1), req.Length())
 				eventList := verifyListNode(t, req, "events", 1)
 				event := verifyListElement(t, eventList, 0)
-				require.Equal(t, int64(8), event.Length())
+				require.Equal(t, int64(7), event.Length())
 				verifyStringNode(t, event, "instanceId", "test-instance")
 				verifyStringNode(t, event, "retrievalId", id.String())
 				verifyBoolNode(t, event, "success", false)
-				// verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
-				// verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
 			},
 		},
 	}
@@ -110,10 +154,7 @@ func TestAggregateEventRecorder(t *testing.T) {
 			).RetrievalEventSubscriber()
 			id, err := types.NewRetrievalID()
 			require.NoError(t, err)
-			etime := time.Now()
-			ptime := time.Now().Add(time.Hour * -1)
-			spid := peer.ID("A")
-			test.exec(t, ctx, subscriber, id, etime, ptime, spid)
+			test.exec(t, ctx, subscriber, id)
 			require.NotNil(t, req)
 			require.Equal(t, "/test-path/here", path)
 		})
@@ -134,6 +175,19 @@ func verifyListElement(t *testing.T, node datamodel.Node, index int64) datamodel
 	return element
 }
 
+func verifyStringListElementsMatch(t *testing.T, node datamodel.Node, expected []string) {
+	iter := node.ListIterator()
+	var received []string
+	for !iter.Done() {
+		_, element, err := iter.Next()
+		require.NoError(t, err)
+		str, err := element.AsString()
+		require.NoError(t, err)
+		received = append(received, str)
+	}
+	require.ElementsMatch(t, expected, received)
+}
+
 func verifyStringNode(t *testing.T, node datamodel.Node, key string, expected string) {
 	str := nodeToString(t, node, key)
 	require.Equal(t, expected, str)
@@ -151,6 +205,14 @@ func verifyBoolNode(t *testing.T, node datamodel.Node, key string, expected bool
 	subNode, err := node.LookupByString(key)
 	require.NoError(t, err)
 	ii, err := subNode.AsBool()
+	require.NoError(t, err)
+	require.Equal(t, expected, ii)
+}
+
+func verifyIntNode(t *testing.T, node datamodel.Node, key string, expected int64) {
+	subNode, err := node.LookupByString(key)
+	require.NoError(t, err)
+	ii, err := subNode.AsInt()
 	require.NoError(t, err)
 	require.Equal(t, expected, ii)
 }
@@ -184,7 +246,7 @@ func BenchmarkAggregateEventRecorderSubscriber(b *testing.B) {
 	fetchStartTime := time.Now()
 	ptime := time.Now().Add(time.Hour * -1)
 	spid := peer.ID("A")
-
+	testCid1 := testutil.GenerateCid()
 	var success bool
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -88,7 +88,7 @@ func TestAggregateEventRecorder(t *testing.T) {
 				require.Equal(t, int64(1), req.Length())
 				eventList := verifyListNode(t, req, "events", 1)
 				event := verifyListElement(t, eventList, 0)
-				require.Equal(t, int64(5), event.Length())
+				require.Equal(t, int64(8), event.Length())
 				verifyStringNode(t, event, "instanceId", "test-instance")
 				verifyStringNode(t, event, "retrievalId", id.String())
 				verifyBoolNode(t, event, "success", false)

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -107,7 +107,6 @@ func TestAggregateEventRecorder(t *testing.T) {
 				"test-instance",
 				fmt.Sprintf("%s/test-path/here", ts.URL),
 				authHeaderValue,
-				false,
 			).RetrievalEventSubscriber()
 			id, err := types.NewRetrievalID()
 			require.NoError(t, err)
@@ -180,7 +179,6 @@ func BenchmarkAggregateEventRecorderSubscriber(b *testing.B) {
 		"test-instance",
 		fmt.Sprintf("%s/test-path/here", ts.URL),
 		authHeaderValue,
-		false,
 	).RetrievalEventSubscriber()
 	id, _ := types.NewRetrievalID()
 	fetchStartTime := time.Now()

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -69,7 +69,9 @@ func TestAggregateEventRecorder(t *testing.T) {
 				clock.Add(20 * time.Millisecond)
 				subscriber(events.FirstByte(clock.Now(), id, bitswapCandidateStartTime, bitswapPeer))
 				subscriber(events.Failed(clock.Now(), id, graphsyncCandidateStartTime, types.RetrievalPhase, graphsyncCandidates[0], "failed to dial"))
-				clock.Add(50 * time.Millisecond)
+				clock.Add(20 * time.Millisecond)
+				subscriber(events.FirstByte(clock.Now(), id, graphsyncCandidateStartTime, graphsyncCandidates[1]))
+				clock.Add(30 * time.Millisecond)
 				subscriber(events.Success(clock.Now(), id, bitswapCandidateStartTime, bitswapPeer, uint64(10000), 3030, 4*time.Second, big.Zero(), 55))
 				subscriber(events.Finished(clock.Now(), id, fetchPhaseStartTime, bitswapPeer))
 
@@ -108,10 +110,13 @@ func TestAggregateEventRecorder(t *testing.T) {
 				verifyStringNode(t, sp1Attempt, "error", "failed to dial")
 				sp2Attempt, err := retrievalAttempts.LookupByString(graphsyncCandidates[1].MinerPeer.ID.String())
 				require.NoError(t, err)
-				require.Equal(t, int64(0), sp2Attempt.Length())
+				require.Equal(t, int64(1), sp2Attempt.Length())
+				verifyStringNode(t, sp2Attempt, "timeToFirstByte", "60ms")
 				bitswapAttempt, err := retrievalAttempts.LookupByString(types.BitswapIndentifier)
 				require.NoError(t, err)
-				require.Equal(t, int64(0), bitswapAttempt.Length())
+				require.Equal(t, int64(1), bitswapAttempt.Length())
+				verifyStringNode(t, bitswapAttempt, "timeToFirstByte", "40ms")
+
 			},
 		},
 		{

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/filecoin-project/lassie/pkg/events"
 	"github.com/filecoin-project/lassie/pkg/internal/testutil"
 	"github.com/filecoin-project/lassie/pkg/types"
-	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
@@ -215,14 +214,6 @@ func verifyIntNode(t *testing.T, node datamodel.Node, key string, expected int64
 	ii, err := subNode.AsInt()
 	require.NoError(t, err)
 	require.Equal(t, expected, ii)
-}
-
-func mustCid(cstr string) cid.Cid {
-	c, err := cid.Decode(cstr)
-	if err != nil {
-		panic(err)
-	}
-	return c
 }
 
 var result bool

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -97,7 +97,6 @@ type RetrievalEventConnected struct {
 func (r spBaseEvent) StorageProviderId() peer.ID { return r.storageProviderId }
 
 func Connected(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, phase types.Phase, candidate types.RetrievalCandidate) RetrievalEventConnected {
-	candidate.Metadata.Protocols()
 	return RetrievalEventConnected{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}, phase}
 }
 
@@ -116,8 +115,11 @@ type RetrievalEventStarted struct {
 	phase types.Phase
 }
 
-func Started(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, phase types.Phase, candidate types.RetrievalCandidate) RetrievalEventStarted {
-	return RetrievalEventStarted{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}, phase}
+func Started(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, phase types.Phase, candidate types.RetrievalCandidate, protocols ...multicodec.Code) RetrievalEventStarted {
+	if len(protocols) == 0 {
+		protocols = candidate.Metadata.Protocols()
+	}
+	return RetrievalEventStarted{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, protocols}, candidate.MinerPeer.ID}, phase}
 }
 
 // RetrievalEventFirstByte describes when the first byte of data was received during the RetrievalPhase

--- a/pkg/internal/testutil/gen.go
+++ b/pkg/internal/testutil/gen.go
@@ -88,12 +88,20 @@ func GenerateRetrievalRequests(t *testing.T, n int) []types.RetrievalRequest {
 }
 
 // GenerateRetrievalCandidates produces n retrieval candidates
-func GenerateRetrievalCandidates(t *testing.T, n int) []types.RetrievalCandidate {
-	candidates := make([]types.RetrievalCandidate, 0, n)
+func GenerateRetrievalCandidates(t *testing.T, n int, protocols ...metadata.Protocol) []types.RetrievalCandidate {
 	c := GenerateCid()
+	return GenerateRetrievalCandidatesForCID(t, n, c, protocols...)
+}
+
+// GenerateRetrievalCandidates produces n retrieval candidates
+func GenerateRetrievalCandidatesForCID(t *testing.T, n int, c cid.Cid, protocols ...metadata.Protocol) []types.RetrievalCandidate {
+	candidates := make([]types.RetrievalCandidate, 0, n)
 	peers := GeneratePeers(t, n)
+	if len(protocols) == 0 {
+		protocols = []metadata.Protocol{&metadata.Bitswap{}}
+	}
 	for i := 0; i < n; i++ {
-		candidates = append(candidates, types.NewRetrievalCandidate(peers[i], c, &metadata.Bitswap{}))
+		candidates = append(candidates, types.NewRetrievalCandidate(peers[i], c, protocols...))
 	}
 	return candidates
 }


### PR DESCRIPTION
# Goal
Adds data about retrieval attempts to the events emitted by the aggregated event recorder to be able to compile metrics for the stats listed in #152.

# Implementation
Adds a new `RetrievalAttempt` struct for recording individual retrieval attempts
```golang
type RetrievalAttempt struct {
	StorageProviderID string `json:"storageProviderId,omitempty"`
	Error             string `json:"error"`
}
```
Adds the following properties to the `AggregatedEvent` struct:
```golang
type AggregateEvent struct {
	...
        TimeToFirstIndexerResult  int64              `json:"timeToFirstIndexerResult,omitempty"` // Time we received our first "CandidateFound" event
	IndexerCandidatesReceived uint64             `json:"indexerCandidatesReceived"`          // The number of candidates received from the indexer
	IndexerCandidatesFiltered uint64             `json:"indexerCandidatesFiltered"`          // The number of candidates that made it through the filtering stage
	ProtocolsAllowed          []string           `json:"protocolsAllowed,omitempty"`         // The available protocols that could be used for this retrieval
	ProtocolsAttempted        []string           `json:"protocolsAttempted,omitempty"`       // The protocols that were used to attempt this retrieval
	RetrievalAttempts         []RetrievalAttempt `json:"retrievalAttempts,omitempty"`        // All of the retrieval attempts
}
```

- Attempts are initialized during the Retrieval phase Started event, indexed via storage provider ID. Attempt errors are recorded from Failed events.
- `ProtocolsAttempted` are compiled from the Retrieval phase Started event's `Protocols()` method. This moreso behaves like protocols _observed_ rather than protocols attempted since there is no way to easily determine from the recorder if a given retrieval protocol was actually attempted due to the slice of protocols coming from the indexer candidate, not the Retrieval phase Started event.
- 

# Remaining Tasks
- [x] Implement recording of retrieval attempt data
- [ ] Implement recording of indexer related data
- [ ] Update tests to check for correct property values for added properties

Closes #152 