### PR TITLE
feat: add initial pause for queue to collect connected SPs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/multiformats/go-multicodec v0.8.1
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/rvagg/go-prioritywaitqueue v1.0.3
+	github.com/rvagg/go-prioritywaitqueue v1.0.4-0.20230403104805-d1352dc1a6ed
 	github.com/stretchr/testify v1.8.2
 	github.com/urfave/cli/v2 v2.24.4
 	go.opencensus.io v0.24.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/multiformats/go-multicodec v0.8.1
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/rvagg/go-prioritywaitqueue v1.0.4-0.20230403104805-d1352dc1a6ed
 	github.com/stretchr/testify v1.8.2
 	github.com/urfave/cli/v2 v2.24.4
 	go.opencensus.io v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/rvagg/go-prioritywaitqueue v1.0.4-0.20230403104805-d1352dc1a6ed h1:12b04DJyQfTog1O0s4jegwkE1rNPGCrrGH9+iLfLC0I=
-github.com/rvagg/go-prioritywaitqueue v1.0.4-0.20230403104805-d1352dc1a6ed/go.mod h1:KmbhnnMiF3YF1h1sILcXZvb2GVagg/lDUq22C6ZLquY=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/rvagg/go-prioritywaitqueue v1.0.3 h1:+YQwo80uQcUCDs1zkuLt0Frt+97ljghYjWq4WoZPdHs=
-github.com/rvagg/go-prioritywaitqueue v1.0.3/go.mod h1:fvzih7jz43jygRQKhaITNW3wLfUiWeA3qIH0rUTBhZI=
+github.com/rvagg/go-prioritywaitqueue v1.0.4-0.20230403104805-d1352dc1a6ed h1:12b04DJyQfTog1O0s4jegwkE1rNPGCrrGH9+iLfLC0I=
+github.com/rvagg/go-prioritywaitqueue v1.0.4-0.20230403104805-d1352dc1a6ed/go.mod h1:KmbhnnMiF3YF1h1sILcXZvb2GVagg/lDUq22C6ZLquY=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=

--- a/pkg/internal/testutil/collectingeventlsubscriber.go
+++ b/pkg/internal/testutil/collectingeventlsubscriber.go
@@ -76,8 +76,8 @@ func VerifyCollectedEventTimings(t *testing.T, events []types.RetrievalEvent) {
 	}
 }
 
-func VerifyContainsCollectedEvent(t *testing.T, actualList []types.RetrievalEvent, expected types.RetrievalEvent) {
-	for _, actual := range actualList {
+func VerifyContainsCollectedEvent(t *testing.T, expectedList []types.RetrievalEvent, actual types.RetrievalEvent) {
+	for _, expected := range expectedList {
 		// this matching might need to evolve to be more sophisticated, particularly SP ID
 		if actual.Code() == expected.Code() &&
 			actual.RetrievalId() == expected.RetrievalId() &&
@@ -89,7 +89,7 @@ func VerifyContainsCollectedEvent(t *testing.T, actualList []types.RetrievalEven
 			}
 		}
 	}
-	require.Fail(t, "event not found", expected.Code())
+	require.Fail(t, "event not found", actual.Code())
 }
 
 func VerifyCollectedEvent(t *testing.T, actual types.RetrievalEvent, expected types.RetrievalEvent) {

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -12,6 +12,7 @@ import (
 	retrievaltypes "github.com/filecoin-project/go-retrieval-types"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lassie/pkg/events"
+	"github.com/filecoin-project/lassie/pkg/retriever/prioritywaitqueue"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
@@ -19,7 +20,6 @@ import (
 	"github.com/ipni/go-libipni/metadata"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multicodec"
-	"github.com/rvagg/go-prioritywaitqueue"
 	"go.uber.org/multierr"
 )
 

--- a/pkg/retriever/graphsyncretriever_test.go
+++ b/pkg/retriever/graphsyncretriever_test.go
@@ -23,6 +23,8 @@ import (
 func TestRetrievalRacing(t *testing.T) {
 	retrievalID := types.RetrievalID(uuid.New())
 	startTime := time.Now().Add(time.Hour)
+	initialPause := 10 * time.Millisecond
+
 	testCases := []struct {
 		name              string
 		customMetadata    map[string]metadata.Protocol
@@ -55,19 +57,22 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 20,
-					ReceivedRetrievals: []peer.ID{"foo"},
+					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 40,
+					AfterStart:         time.Millisecond*20 + initialPause,
+					ReceivedRetrievals: []peer.ID{"foo"},
+				},
+				{
+					AfterStart: time.Millisecond*40 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*40), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Accepted(startTime.Add(time.Millisecond*40), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.FirstByte(startTime.Add(time.Millisecond*40), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Success(startTime.Add(time.Millisecond*40), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, 1, 0, 0, big.Zero(), 0),
+						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Accepted(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.FirstByte(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Success(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, 1, 0, 0, big.Zero(), 0),
 					},
 				},
 			},
@@ -96,26 +101,29 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 20,
-					ReceivedRetrievals: []peer.ID{"foo"},
+					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 50,
+					AfterStart:         time.Millisecond*20 + initialPause,
+					ReceivedRetrievals: []peer.ID{"foo"},
+				},
+				{
+					AfterStart: time.Millisecond*40 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*50), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
-						events.Connected(startTime.Add(time.Millisecond*50), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Connected(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Connected(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 520,
+					AfterStart: time.Millisecond*520 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*520), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Accepted(startTime.Add(time.Millisecond*520), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.FirstByte(startTime.Add(time.Millisecond*520), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Success(startTime.Add(time.Millisecond*520), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, 1, 0, 0, big.Zero(), 0),
+						events.Proposed(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Accepted(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.FirstByte(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Success(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, 1, 0, 0, big.Zero(), 0),
 					},
 				},
 			},
@@ -157,7 +165,7 @@ func TestRetrievalRacing(t *testing.T) {
 			name: "first retrieval failed",
 			connectReturns: map[string]testutil.DelayedConnectReturn{
 				"foo": {Err: nil, Delay: time.Millisecond * 20},
-				"bar": {Err: nil, Delay: time.Millisecond * 50},
+				"bar": {Err: nil, Delay: time.Millisecond * 60},
 				"baz": {Err: nil, Delay: time.Millisecond * 500},
 			},
 			retrievalReturns: map[string]testutil.DelayedClientReturn{
@@ -177,33 +185,36 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 20,
-					ReceivedRetrievals: []peer.ID{"foo"},
+					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 40,
+					AfterStart:         time.Millisecond*20 + initialPause,
+					ReceivedRetrievals: []peer.ID{"foo"},
+				},
+				{
+					AfterStart: time.Millisecond*40 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*40), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Failed(startTime.Add(time.Millisecond*40), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Failed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 50,
+					AfterStart:         time.Millisecond * 60,
 					ReceivedRetrievals: []peer.ID{"bar"},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*50), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Connected(startTime.Add(time.Millisecond*60), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 70,
+					AfterStart: time.Millisecond * 80,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*70), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
-						events.Accepted(startTime.Add(time.Millisecond*70), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
-						events.FirstByte(startTime.Add(time.Millisecond*70), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
-						events.Success(startTime.Add(time.Millisecond*70), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}, 2, 0, 0, big.Zero(), 0),
+						events.Proposed(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Accepted(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.FirstByte(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Success(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}, 2, 0, 0, big.Zero(), 0),
 					},
 				},
 			},
@@ -214,7 +225,7 @@ func TestRetrievalRacing(t *testing.T) {
 			connectReturns: map[string]testutil.DelayedConnectReturn{
 				"foo": {Err: nil, Delay: time.Millisecond * 20},
 				"bar": {Err: nil, Delay: time.Millisecond * 25},
-				"baz": {Err: nil, Delay: time.Millisecond * 30},
+				"baz": {Err: nil, Delay: time.Millisecond * 60},
 			},
 			retrievalReturns: map[string]testutil.DelayedClientReturn{
 				"foo": {ResultErr: errors.New("Nope"), Delay: time.Millisecond * 100},
@@ -232,8 +243,7 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 20,
-					ReceivedRetrievals: []peer.ID{"foo"},
+					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 					},
@@ -245,37 +255,42 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 30,
+					AfterStart:         time.Millisecond*20 + initialPause,
+					ReceivedRetrievals: []peer.ID{"foo"},
+				},
+				{
+					AfterStart: time.Millisecond * 60,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*30), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Connected(startTime.Add(time.Millisecond*60), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 120,
+					AfterStart:         time.Millisecond*120 + initialPause,
 					ReceivedRetrievals: []peer.ID{"bar"},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*120), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Failed(startTime.Add(time.Millisecond*120), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Failed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 220,
+					AfterStart:         time.Millisecond*220 + initialPause,
 					ReceivedRetrievals: []peer.ID{"baz"},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*220), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
-						events.Failed(startTime.Add(time.Millisecond*220), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*220+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Failed(startTime.Add(time.Millisecond*220+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}, "retrieval failed: Nope"),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 320,
+					AfterStart: time.Millisecond*320 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*320), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
-						events.Failed(startTime.Add(time.Millisecond*320), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*320+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Failed(startTime.Add(time.Millisecond*320+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}, "retrieval failed: Nope"),
 					},
 				},
 			},
 		},
-		// quickest query ("foo") fails retrieval, the other 3 line up in the queue,
+
+		// quickest ("foo") fails retrieval, the other 3 line up in the queue,
 		// it should choose the "best", which is the one that's fast retrieval/verified deal
 		{
 			name: "racing chooses best",
@@ -308,10 +323,70 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 1,
-					ReceivedRetrievals: []peer.ID{"foo"},
+					AfterStart: time.Millisecond * 1,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(time.Millisecond*1), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+					},
+				},
+				{
+					AfterStart:         time.Millisecond*1 + initialPause,
+					ReceivedRetrievals: []peer.ID{"foo"},
+				},
+				{
+					AfterStart: time.Millisecond * 100,
+					ExpectedEvents: []types.RetrievalEvent{
+						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
+					},
+				},
+				{
+					AfterStart:         time.Millisecond*201 + initialPause,
+					ReceivedRetrievals: []peer.ID{"baz"},
+					ExpectedEvents: []types.RetrievalEvent{
+						events.Proposed(startTime.Add(time.Millisecond*201+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Failed(startTime.Add(time.Millisecond*201+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+					},
+				},
+				{
+					AfterStart: time.Millisecond*221 + initialPause,
+					ExpectedEvents: []types.RetrievalEvent{
+						events.Proposed(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Accepted(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.FirstByte(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Success(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}, 2, 0, 0, big.Zero(), 0),
+					},
+				},
+			},
+		},
+
+		// same as above, but we don't have a failing "foo" to act as a gate for the
+		// others to line up; tests the prioritywaitqueue initial pause
+		{
+			name: "racing chooses best (same connect)",
+			customMetadata: map[string]metadata.Protocol{
+				"bar":  &metadata.GraphsyncFilecoinV1{FastRetrieval: true, VerifiedDeal: false},
+				"bang": &metadata.GraphsyncFilecoinV1{FastRetrieval: false, VerifiedDeal: true},
+			},
+			connectReturns: map[string]testutil.DelayedConnectReturn{
+				"bar":  {Err: nil, Delay: time.Millisecond * 100},
+				"baz":  {Err: nil, Delay: time.Millisecond * 100},
+				"bang": {Err: nil, Delay: time.Millisecond * 100},
+			},
+			retrievalReturns: map[string]testutil.DelayedClientReturn{
+				"bar":  {ResultStats: &types.RetrievalStats{StorageProviderId: peer.ID("bar"), Size: 3}, Delay: time.Millisecond * 20},
+				"baz":  {ResultStats: &types.RetrievalStats{StorageProviderId: peer.ID("baz"), Size: 2}, Delay: time.Millisecond * 20},
+				"bang": {ResultStats: &types.RetrievalStats{StorageProviderId: peer.ID("bang"), Size: 4}, Delay: time.Millisecond * 20},
+			},
+			expectedRetrieval: "baz",
+			expectSequence: []testutil.ExpectedActionsAtTime{
+				{
+					AfterStart:          0,
+					ReceivedConnections: []peer.ID{"bar", "baz", "bang"},
+					ExpectedEvents: []types.RetrievalEvent{
+						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
 					},
 				},
 				{
@@ -323,29 +398,26 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 201,
+					AfterStart:         time.Millisecond*100 + initialPause,
 					ReceivedRetrievals: []peer.ID{"baz"},
-					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*201), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Failed(startTime.Add(time.Millisecond*201), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
-					},
 				},
 				{
-					AfterStart: time.Millisecond * 221,
+					AfterStart: time.Millisecond*120 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*221), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
-						events.Accepted(startTime.Add(time.Millisecond*221), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
-						events.FirstByte(startTime.Add(time.Millisecond*221), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
-						events.Success(startTime.Add(time.Millisecond*221), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}, 2, 0, 0, big.Zero(), 0),
+						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Accepted(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.FirstByte(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+						events.Success(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}, 2, 0, 0, big.Zero(), 0),
 					},
 				},
 			},
 		},
-		// quickest query ("foo") fails retrieval, the other 3 line up in the queue,
-		// it should choose the "best", which in this case is the fastest to return
-		// from query (they are all free and the same size)
+
+		// quickest ("foo") fails retrieval, the other 3 line up in the queue,
+		// it should choose the "best", which in this case is the fastest to line
+		// up / connect (they are all free and the same size)
 		{
-			name: "racing chooses fastest query",
+			name: "racing chooses fastest connect",
 			connectReturns: map[string]testutil.DelayedConnectReturn{
 				"foo":  {Err: nil, Delay: time.Millisecond * 1},
 				"bar":  {Err: nil, Delay: time.Millisecond * 220},
@@ -371,11 +443,14 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 1,
-					ReceivedRetrievals: []peer.ID{"foo"},
+					AfterStart: time.Millisecond * 1,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(time.Millisecond*1), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 					},
+				},
+				{
+					AfterStart:         time.Millisecond*1 + initialPause,
+					ReceivedRetrievals: []peer.ID{"foo"},
 				},
 				{
 					AfterStart: time.Millisecond * 100,
@@ -396,20 +471,20 @@ func TestRetrievalRacing(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         time.Millisecond * 401,
+					AfterStart:         time.Millisecond*401 + initialPause,
 					ReceivedRetrievals: []peer.ID{"bang"},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*401), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-						events.Failed(startTime.Add(time.Millisecond*401), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*401+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+						events.Failed(startTime.Add(time.Millisecond*401+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
 					},
 				},
 				{
-					AfterStart: time.Millisecond * 421,
+					AfterStart: time.Millisecond*421 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*421), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
-						events.Accepted(startTime.Add(time.Millisecond*421), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
-						events.FirstByte(startTime.Add(time.Millisecond*421), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
-						events.Success(startTime.Add(time.Millisecond*421), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}, 4, 0, 0, big.Zero(), 0),
+						events.Proposed(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
+						events.Accepted(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
+						events.FirstByte(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}),
+						events.Success(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}}, 4, 0, 0, big.Zero(), 0),
 					},
 				},
 			},
@@ -434,7 +509,9 @@ func TestRetrievalRacing(t *testing.T) {
 				}
 				candidates = append(candidates, types.NewRetrievalCandidate(peer.ID(p), cid.Undef, protocol))
 			}
-			cfg := NewGraphsyncRetrieverWithClock(func(peer peer.ID) time.Duration { return time.Second }, mockClient, clock)
+			cfg := NewGraphsyncRetriever(func(peer peer.ID) time.Duration { return time.Second }, mockClient)
+			cfg.Clock = clock
+			cfg.QueueInitialPause = initialPause
 
 			rv := testutil.RetrievalVerifier{
 				ExpectedSequence: tc.expectSequence,
@@ -470,6 +547,7 @@ func TestMultipleRetrievals(t *testing.T) {
 	cid2 := cid.MustParse("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk")
 	startTime := time.Now().Add(time.Hour)
 	clock := clock.NewMock()
+	initialPause := 10 * time.Millisecond
 	clock.Set(startTime)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -498,7 +576,9 @@ func TestMultipleRetrievals(t *testing.T) {
 		clock,
 	)
 
-	cfg := NewGraphsyncRetrieverWithClock(func(peer peer.ID) time.Duration { return time.Second }, mockClient, clock)
+	cfg := NewGraphsyncRetriever(func(peer peer.ID) time.Duration { return time.Second }, mockClient)
+	cfg.Clock = clock
+	cfg.QueueInitialPause = initialPause
 
 	expectedSequence := []testutil.ExpectedActionsAtTime{
 		{
@@ -514,27 +594,37 @@ func TestMultipleRetrievals(t *testing.T) {
 			},
 		},
 		{
-			AfterStart:         time.Millisecond * 1,
-			ReceivedRetrievals: []peer.ID{"foo"},
+			AfterStart: time.Millisecond * 1,
 			ExpectedEvents: []types.RetrievalEvent{
 				events.Failed(startTime.Add(time.Millisecond*1), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("boom")}}, "unable to connect to provider: Nope"),
 				events.Connected(startTime.Add(time.Millisecond*1), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 			},
 		},
 		{
-			AfterStart: time.Millisecond * 2,
+			AfterStart:         time.Millisecond*1 + initialPause,
+			ReceivedRetrievals: []peer.ID{"foo"},
+		},
+		{
+			AfterStart: time.Millisecond*2 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*2), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-				events.Failed(startTime.Add(time.Millisecond*2), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+				events.Proposed(startTime.Add(time.Millisecond*2+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+				events.Failed(startTime.Add(time.Millisecond*2+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
 			},
 		},
 		{
-			AfterStart:         time.Millisecond * 100,
-			ReceivedRetrievals: []peer.ID{"bar", "bing"},
+			AfterStart: time.Millisecond * 100,
 			ExpectedEvents: []types.RetrievalEvent{
 				events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
 				events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
 			},
+		},
+		{
+			AfterStart:         time.Millisecond * 100,
+			ReceivedRetrievals: []peer.ID{"bar"},
+		},
+		{
+			AfterStart:         time.Millisecond*100 + initialPause,
+			ReceivedRetrievals: []peer.ID{"bing"},
 		},
 		{
 			AfterStart: time.Millisecond * 300,
@@ -546,12 +636,12 @@ func TestMultipleRetrievals(t *testing.T) {
 			},
 		},
 		{
-			AfterStart: time.Millisecond * 301,
+			AfterStart: time.Millisecond*301 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*301), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
-				events.Accepted(startTime.Add(time.Millisecond*301), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
-				events.FirstByte(startTime.Add(time.Millisecond*301), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
-				events.Success(startTime.Add(time.Millisecond*301), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}, 3, 0, 0, big.Zero(), 0),
+				events.Proposed(startTime.Add(time.Millisecond*301+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
+				events.Accepted(startTime.Add(time.Millisecond*301+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
+				events.FirstByte(startTime.Add(time.Millisecond*301+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}),
+				events.Success(startTime.Add(time.Millisecond*301+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}}, 3, 0, 0, big.Zero(), 0),
 			},
 		},
 	}

--- a/pkg/retriever/prioritywaitqueue/prioritywaitqueue.go
+++ b/pkg/retriever/prioritywaitqueue/prioritywaitqueue.go
@@ -1,0 +1,146 @@
+// Package prioritywaitqueue implements a blocking queue for prioritised
+// coordination of goroutine execution.
+package prioritywaitqueue
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// PriorityWaitQueue is a blocking queue for coordinating goroutines, providing
+// a gating mechanism such that only one goroutine may run at a time, where the
+// goroutine allowed to run is chosen based on a priority comparison function.
+type PriorityWaitQueue[T interface{}] interface {
+	// Wait is called with with a value that can be prioritised in comparison to
+	// other values of the same type. Returns a "done" function that MUST be
+	// called when the work to be performed. The call to Wait will block until
+	// there are other running goroutines that have also called Wait and not yet
+	// called their "done" function.
+	//
+	// It is up to the caller to handle context cancellation, goroutines should
+	// check for themselves when Wait() returns and immediately call done() if
+	// a context has cancelled in order to clean up all running goroutines.
+	Wait(waitWith T) func()
+}
+
+type Option[T interface{}] func(PriorityWaitQueue[T])
+
+// WithInitialPause sets an initial pause for the first call to Wait() on the
+// PriorityWaitQueue. This is useful if you want to allow goroutines to
+// queue up before any of them are allowed to run. A short pause will mean that
+// the initial first-in-first-run behaviour is overridden, where the first
+// goroutine may have to compete with others before getting to run.
+func WithInitialPause[T interface{}](duration time.Duration) Option[T] {
+	return func(q PriorityWaitQueue[T]) {
+		q.(*priorityWaitQueue[T]).initialPause = duration
+	}
+}
+
+// WithClock sets the clock to use for the PriorityWaitQueue. This is useful
+// for testing.
+func WithClock[T interface{}](clock clock.Clock) Option[T] {
+	return func(q PriorityWaitQueue[T]) {
+		q.(*priorityWaitQueue[T]).clock = clock
+	}
+}
+
+// ComparePriority should return true if a has a higher priority, and therefore
+// should run, BEFORE b.
+type ComparePriority[T interface{}] func(a T, b T) bool
+
+// New creates a new PriorityWaitQueue with the provided ComparePriority
+// function for type T.
+func New[T interface{}](cmp ComparePriority[T], options ...Option[T]) PriorityWaitQueue[T] {
+	pwq := &priorityWaitQueue[T]{
+		cmp:     cmp,
+		cond:    sync.NewCond(&sync.Mutex{}),
+		waiters: make([]*T, 0),
+		clock:   clock.New(),
+	}
+	for _, opt := range options {
+		opt(pwq)
+	}
+	return pwq
+}
+
+var _ PriorityWaitQueue[int] = &priorityWaitQueue[int]{}
+
+type priorityWaitQueue[T interface{}] struct {
+	cmp              ComparePriority[T]
+	cond             *sync.Cond
+	waiters          []*T
+	running          *T
+	clock            clock.Clock
+	initialPause     time.Duration
+	initialPauseDone bool
+	initialPauseLk   sync.Mutex
+}
+
+func (pwq *priorityWaitQueue[T]) Wait(waitWith T) func() {
+	waitWithPtr := &waitWith
+
+	pwq.cond.L.Lock()
+	defer pwq.cond.L.Unlock()
+
+	// register us as a waiter
+	pwq.waiters = append(pwq.waiters, waitWithPtr)
+
+	// if we have an initial pause, do it now and block any subsequent calls since
+	// we (the first caller) hold the lock
+	if pwq.initialPause > 0 {
+		pwq.cond.L.Unlock()
+		pwq.initialPauseLk.Lock()
+		if !pwq.initialPauseDone {
+			pwq.clock.Sleep(pwq.initialPause)
+			pwq.initialPauseDone = true
+		}
+		pwq.initialPauseLk.Unlock()
+		pwq.cond.L.Lock()
+	}
+
+	for {
+		if pwq.running == nil { // none currently running, check if we can
+			canRun := true
+			// is there another waiter in the queue with higher priority than us?
+			for _, waiter := range pwq.waiters {
+				if waiter != waitWithPtr && pwq.cmp(*waiter, waitWith) {
+					canRun = false
+				}
+			}
+			if canRun { // didn't find a higher-priority waiter, we can run
+				// remove us from the wait list
+				removed := false
+				for i, waiter := range pwq.waiters {
+					if waiter == waitWithPtr {
+						pwq.waiters = append(pwq.waiters[:i], pwq.waiters[i+1:]...)
+						removed = true
+						break
+					}
+				}
+				if !removed {
+					panic("didn't find current waiter in the wait list")
+				}
+				pwq.running = waitWithPtr
+				// done() must be called when the work is complete and another job
+				// can be run
+				done := func() {
+					pwq.cond.L.Lock()
+					defer pwq.cond.L.Unlock()
+					if pwq.running != waitWithPtr {
+						panic(fmt.Sprintf("Done() was called with a runner that was not expected to be running: %v <> %v", pwq.running, &waitWith))
+					}
+					pwq.running = nil
+					// notify all to check whether they are next to run
+					pwq.cond.Broadcast()
+				}
+				return done
+			}
+		}
+
+		// unlock and wait until we get a broadcast
+		pwq.cond.Wait()
+	}
+}

--- a/pkg/retriever/prioritywaitqueue/prioritywaitqueue_test.go
+++ b/pkg/retriever/prioritywaitqueue/prioritywaitqueue_test.go
@@ -1,0 +1,151 @@
+package prioritywaitqueue_test
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/retriever/prioritywaitqueue"
+)
+
+type worker struct {
+	wg     *sync.WaitGroup
+	id     int
+	sleep  int
+	work   int
+	queue  prioritywaitqueue.PriorityWaitQueue[*worker]
+	doneCb func(int)
+}
+
+func (w *worker) run() {
+	w.wg.Done()
+	w.wg.Wait()
+	time.Sleep(time.Duration(w.sleep) * time.Millisecond)
+	done := w.queue.Wait(w)
+	time.Sleep(time.Duration(w.work) * time.Millisecond)
+	w.doneCb(w.id)
+	done()
+}
+
+func runWorker(wg *sync.WaitGroup, id, sleep, work int, queue prioritywaitqueue.PriorityWaitQueue[*worker], doneCb func(int)) {
+	w := worker{wg, id, sleep, work, queue, doneCb}
+	go w.run()
+}
+
+var workerCmp prioritywaitqueue.ComparePriority[*worker] = func(a *worker, b *worker) bool {
+	return a.id < b.id
+}
+
+func TestPriorityWaitQueue(t *testing.T) {
+	tests := []struct {
+		name         string
+		sleeps       []int // how long to sleep before queueing
+		works        []int // how long the work takes
+		expected     []int // the order we expect them to be executed in
+		initialPause time.Duration
+	}{
+		{
+			// start one, block queue, then queue remaining at the same time and
+			// expect them to all be run in proper order
+			name:     "same start",
+			sleeps:   []int{00, 100, 100, 100, 100, 100, 100, 100, 100, 100},
+			works:    []int{500, 100, 100, 100, 100, 100, 100, 100, 100, 100},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// similar to above, but we pause to allow all the workers to queue
+			name:         "same start, initial pause",
+			sleeps:       []int{100, 100, 100, 100, 100, 100, 100, 100, 100, 100},
+			works:        []int{100, 100, 100, 100, 100, 100, 100, 100, 100, 100},
+			expected:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			initialPause: 10 * time.Millisecond,
+		},
+		{
+			// same as previous but with messy arrival order
+			name:     "same start, skewed",
+			sleeps:   []int{00, 100, 200, 100, 200, 100, 200, 100, 200, 100},
+			works:    []int{500, 100, 100, 100, 100, 100, 100, 100, 100, 100},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// same as previous but without the initial straight-through #1
+			name:         "same start, skewed, initial pause",
+			sleeps:       []int{100, 100, 200, 100, 200, 100, 200, 100, 200, 100},
+			works:        []int{100, 100, 100, 100, 100, 100, 100, 100, 100, 100},
+			expected:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			initialPause: 10 * time.Millisecond,
+		},
+		{
+			// start one, block queue, then queue 4, run them, with the final one
+			// blocking beyond when we add 5 more and expect them all to be run in
+			// proper order
+			name:     "batched start",
+			sleeps:   []int{00, 200, 200, 200, 200, 500, 500, 500, 500, 500},
+			works:    []int{250, 50, 50, 50, 500, 50, 50, 50, 50, 50},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// similar to above, but without the initial straight-through #1
+			name:         "batched start, initial pause",
+			sleeps:       []int{200, 200, 200, 200, 200, 500, 500, 500, 500, 500},
+			works:        []int{50, 50, 50, 50, 500, 50, 50, 50, 50, 50},
+			expected:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			initialPause: 10 * time.Millisecond,
+		},
+		{
+			// same as previous but with different batches
+			name:     "batched start reverse",
+			sleeps:   []int{00, 500, 500, 500, 500, 500, 200, 200, 200, 200},
+			works:    []int{250, 50, 50, 50, 50, 50, 50, 50, 50, 500},
+			expected: []int{0, 6, 7, 8, 9, 1, 2, 3, 4, 5},
+		},
+		{
+			// same as previous but without the initial straight-through #1
+			name:         "batched start reverse, initial pause",
+			sleeps:       []int{200, 500, 500, 500, 500, 500, 200, 200, 200, 200},
+			works:        []int{50, 50, 50, 50, 50, 50, 50, 50, 50, 500},
+			expected:     []int{0, 6, 7, 8, 9, 1, 2, 3, 4, 5},
+			initialPause: 10 * time.Millisecond,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// setup
+			opts := make([]prioritywaitqueue.Option[*worker], 0)
+			if tc.initialPause > 0 {
+				opts = append(opts, prioritywaitqueue.WithInitialPause[*worker](tc.initialPause))
+			}
+			queue := prioritywaitqueue.New(workerCmp, opts...)
+			out := make([]int, 0)
+			lk := sync.Mutex{}
+			doneWg := sync.WaitGroup{}
+			doneWg.Add(len(tc.sleeps))
+			doneCb := func(id int) {
+				lk.Lock()
+				defer lk.Unlock()
+				out = append(out, id)
+				doneWg.Done()
+			}
+
+			// run
+			startWg := sync.WaitGroup{}
+			startWg.Add(len(tc.sleeps))
+			for id := range tc.sleeps {
+				runWorker(&startWg, id, tc.sleeps[id], tc.works[id], queue, doneCb)
+			}
+
+			// verify
+			doneWg.Wait()
+			if len(out) != 10 {
+				t.Errorf("recorded %d outputs, expected 10", len(out))
+			}
+			if !reflect.DeepEqual(out, tc.expected) {
+				t.Errorf("did not get expected order of execution: %v <> %v", out, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -52,6 +52,7 @@ func TestRetriever(t *testing.T) {
 	cid1 := cid.MustParse("bafkqaalb")
 	peerA := peer.ID("A")
 	peerB := peer.ID("B")
+	initialPause := time.Millisecond * 5
 	blacklistedPeer := peer.ID("blacklisted")
 	startTime := time.Now().Add(time.Hour)
 	tc := []struct {
@@ -102,21 +103,23 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         20 * time.Millisecond,
-					ReceivedRetrievals: []peer.ID{peerA},
+					AfterStart: 20 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(20*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1)),
 					},
 				},
 				{
-					AfterStart: 25 * time.Millisecond,
+					AfterStart:         20*time.Millisecond + initialPause,
+					ReceivedRetrievals: []peer.ID{peerA},
+				},
+				{
+					AfterStart: 25*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-
-						events.Proposed(startTime.Add(25*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-						events.Accepted(startTime.Add(25*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-						events.FirstByte(startTime.Add(25*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-						events.Success(startTime.Add(25*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
-						events.Finished(startTime.Add(25*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+						events.Proposed(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+						events.Accepted(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+						events.FirstByte(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+						events.Success(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
+						events.Finished(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
 				},
 			},
 		},
@@ -165,20 +168,23 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         5 * time.Millisecond,
-					ReceivedRetrievals: []peer.ID{peerB},
+					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
 					},
 				},
 				{
-					AfterStart: 10 * time.Millisecond,
+					AfterStart:         5*time.Millisecond + initialPause,
+					ReceivedRetrievals: []peer.ID{peerB},
+				},
+				{
+					AfterStart: 10*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Accepted(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.FirstByte(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Success(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1), 10, 11, 12*time.Second, big.Zero(), 50),
-						events.Finished(startTime.Add(10*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Accepted(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1), 10, 11, 12*time.Second, big.Zero(), 50),
+						events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
 				},
 			},
 		},
@@ -227,20 +233,23 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         50 * time.Millisecond,
-					ReceivedRetrievals: []peer.ID{peerA},
+					AfterStart: 50 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(50*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1)),
 					},
 				},
 				{
-					AfterStart: 55 * time.Millisecond,
+					AfterStart:         50*time.Millisecond + initialPause,
+					ReceivedRetrievals: []peer.ID{peerA},
+				},
+				{
+					AfterStart: 55*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-						events.Accepted(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-						events.FirstByte(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-						events.Success(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
-						events.Finished(startTime.Add(55*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+						events.Proposed(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+						events.Accepted(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+						events.FirstByte(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+						events.Success(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
+						events.Finished(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
 				},
 			},
 		},
@@ -296,21 +305,23 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         50 * time.Millisecond,
-					ReceivedRetrievals: []peer.ID{peerB},
+					AfterStart: 50 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(50*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
 					},
 				},
-
 				{
-					AfterStart: 55 * time.Millisecond,
+					AfterStart:         50*time.Millisecond + initialPause,
+					ReceivedRetrievals: []peer.ID{peerB},
+				},
+				{
+					AfterStart: 55*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Accepted(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.FirstByte(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Success(startTime.Add(55*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
-						events.Finished(startTime.Add(55*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+						events.Proposed(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Accepted(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.FirstByte(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Success(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
+						events.Finished(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
 				},
 			},
 		},
@@ -361,17 +372,20 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         5 * time.Millisecond,
-					ReceivedRetrievals: []peer.ID{peerB},
+					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
 					},
 				},
 				{
-					AfterStart: 10 * time.Millisecond,
+					AfterStart:         5*time.Millisecond + initialPause,
+					ReceivedRetrievals: []peer.ID{peerB},
+				},
+				{
+					AfterStart: 10*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Failed(startTime.Add(10*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1), "retrieval failed: bork!"),
+						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Failed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1), "retrieval failed: bork!"),
 					},
 				},
 				{
@@ -449,11 +463,14 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         1 * time.Millisecond,
-					ReceivedRetrievals: []peer.ID{peerA},
+					AfterStart: 1 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Connected(startTime.Add(1*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1)),
 					},
+				},
+				{
+					AfterStart:         1*time.Millisecond + initialPause,
+					ReceivedRetrievals: []peer.ID{peerA},
 				},
 				{
 					AfterStart: 100 * time.Millisecond,
@@ -462,20 +479,20 @@ func TestRetriever(t *testing.T) {
 					},
 				},
 				{
-					AfterStart:         201 * time.Millisecond,
+					AfterStart:         201*time.Millisecond + initialPause,
 					ReceivedRetrievals: []peer.ID{peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Failed(startTime.Add(201*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1), "timeout after 200ms"),
+						events.Failed(startTime.Add(201*time.Millisecond+initialPause), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1), "timeout after 200ms"),
 					},
 				},
 				{
-					AfterStart: 202 * time.Millisecond,
+					AfterStart: 202*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(202*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Accepted(startTime.Add(202*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.FirstByte(startTime.Add(202*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
-						events.Success(startTime.Add(202*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerB, cid1), 20, 30, 40*time.Second, big.Zero(), 50),
-						events.Finished(startTime.Add(202*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+						events.Proposed(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Accepted(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.FirstByte(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1)),
+						events.Success(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, cid1), 20, 30, 40*time.Second, big.Zero(), 50),
+						events.Finished(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
 				},
 			},
 		},
@@ -554,7 +571,10 @@ func TestRetriever(t *testing.T) {
 				tc.setup(&config)
 			}
 			session := session.NewSession(config, true)
-			gsretriever := retriever.NewGraphsyncRetrieverWithClock(session.GetStorageProviderTimeout, client, clock)
+			gsretriever := retriever.NewGraphsyncRetriever(session.GetStorageProviderTimeout, client)
+			gsretriever.Clock = clock
+			gsretriever.QueueInitialPause = initialPause
+
 			// --- create ---
 			ret, err := retriever.NewRetrieverWithClock(context.Background(), session, candidateFinder, map[multicodec.Code]types.CandidateRetriever{
 				multicodec.TransportGraphsyncFilecoinv1: gsretriever,
@@ -601,6 +621,7 @@ func TestLinkSystemPerRequest(t *testing.T) {
 	startTime := time.Now().Add(5 * time.Hour)
 	clock := clock.NewMock()
 	clock.Set(startTime)
+	initialPause := time.Millisecond * 2
 	rid := types.RetrievalID(uuid.New())
 	cid1 := cid.MustParse("bafkqaalb")
 	peerA := peer.ID("A")
@@ -639,7 +660,9 @@ func TestLinkSystemPerRequest(t *testing.T) {
 	client := testutil.NewMockClient(returnsConnected, returnsRetrievals, clock)
 	config := session.Config{}
 	session := session.NewSession(config, true)
-	gsretriever := retriever.NewGraphsyncRetrieverWithClock(session.GetStorageProviderTimeout, client, clock)
+	gsretriever := retriever.NewGraphsyncRetriever(session.GetStorageProviderTimeout, client)
+	gsretriever.Clock = clock
+	gsretriever.QueueInitialPause = initialPause
 
 	// --- create ---
 	ret, err := retriever.NewRetrieverWithClock(context.Background(), session, candidateFinder, map[multicodec.Code]types.CandidateRetriever{
@@ -684,20 +707,23 @@ func TestLinkSystemPerRequest(t *testing.T) {
 				},
 			},
 			{
-				AfterStart:         5 * time.Millisecond,
-				ReceivedRetrievals: []peer.ID{peerA},
+				AfterStart: 5 * time.Millisecond,
 				ExpectedEvents: []types.RetrievalEvent{
 					events.Connected(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1)),
 				},
 			},
 			{
-				AfterStart: 10 * time.Millisecond,
+				AfterStart:         5*time.Millisecond + initialPause,
+				ReceivedRetrievals: []peer.ID{peerA},
+			},
+			{
+				AfterStart: 10*time.Millisecond + initialPause,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Proposed(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-					events.Accepted(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-					events.FirstByte(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
-					events.Success(startTime.Add(10*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
-					events.Finished(startTime.Add(10*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+					events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+					events.Accepted(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+					events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1)),
+					events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, cid1), 1, 2, 3*time.Second, big.Zero(), 55),
+					events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
 			},
 		},
 	}.RunWithVerification(ctx, t, clock, client, candidateFinder, []testutil.RunRetrieval{
@@ -738,29 +764,32 @@ func TestLinkSystemPerRequest(t *testing.T) {
 				},
 				ReceivedConnections: []peer.ID{peerA, peerB},
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Started(startTime.Add(10*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
-					events.Started(startTime.Add(10*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-					events.CandidatesFound(startTime.Add(10*time.Millisecond), rid, startTime.Add(10*time.Millisecond), cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
-					events.CandidatesFiltered(startTime.Add(10*time.Millisecond), rid, startTime.Add(10*time.Millisecond), cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
-					events.Started(startTime.Add(10*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1)),
-					events.Started(startTime.Add(10*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
+					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.FetchPhase, types.RetrievalCandidate{RootCid: cid1}),
+					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
+					events.CandidatesFound(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
+					events.CandidatesFiltered(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, cid1), types.NewRetrievalCandidate(peerB, cid1)}),
+					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalPhase, types.NewRetrievalCandidate(peerA, cid1)),
+					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
 				},
 			},
 			{
-				AfterStart:         5 * time.Millisecond,
+				AfterStart: 5 * time.Millisecond,
+				ExpectedEvents: []types.RetrievalEvent{
+					events.Connected(startTime.Add(15*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
+				},
+			},
+			{
+				AfterStart:         5*time.Millisecond + initialPause,
 				ReceivedRetrievals: []peer.ID{peerB},
-				ExpectedEvents: []types.RetrievalEvent{
-					events.Connected(startTime.Add(15*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.RetrievalPhase, types.NewRetrievalCandidate(peerB, cid1)),
-				},
 			},
 			{
-				AfterStart: 10 * time.Millisecond,
+				AfterStart: 10*time.Millisecond + initialPause,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Proposed(startTime.Add(20*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.NewRetrievalCandidate(peerB, cid1)),
-					events.Accepted(startTime.Add(20*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.NewRetrievalCandidate(peerB, cid1)),
-					events.FirstByte(startTime.Add(20*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.NewRetrievalCandidate(peerB, cid1)),
-					events.Success(startTime.Add(20*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.NewRetrievalCandidate(peerB, cid1), 10, 11, 12*time.Second, big.Zero(), 50),
-					events.Finished(startTime.Add(20*time.Millisecond), rid, startTime.Add(10*time.Millisecond), types.RetrievalCandidate{RootCid: cid1})},
+					events.Proposed(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, cid1)),
+					events.Accepted(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, cid1)),
+					events.FirstByte(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, cid1)),
+					events.Success(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, cid1), 10, 11, 12*time.Second, big.Zero(), 50),
+					events.Finished(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalCandidate{RootCid: cid1})},
 			},
 		},
 	}.RunWithVerification(ctx, t, clock, client, candidateFinder, []testutil.RunRetrieval{


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/lassie/issues/171
Depends on https://github.com/rvagg/go-prioritywaitqueue/pull/1 (need to tag)

There is only an **initial** pause, after the first one it won't pause any more. I think this makes sense because we should get all Graphsync SPs in one batch, then try to connect to them all at once and proceed to `Wait()` on each of them.

An alternative is to go with "if no others queueing, always wait X duration", but I'm not sure that makes sense?

Also, default of 2ms. Does that make sense for these, can we expect to see Connect's in that timeframe? I don't know because I'm on garbage internet with a >=120ms latency to anywhere but my country, so 2m feels awfully fast to me!