### PR TITLE
Dedupe graphsync candidates

### DIFF
--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -29,38 +29,6 @@ type CandidateErrorCallback func(types.RetrievalCandidate, error)
 
 type GetStorageProviderTimeout func(peer peer.ID) time.Duration
 
-type connectCandidate struct {
-	types.RetrievalCandidate
-	Duration time.Duration
-}
-
-// queryCompare compares two QueryResponses and returns true if the first is
-// preferable to the second. This is used for the PriorityWaitQueue that will
-// prioritise execution of retrievals if two queries are available to compare
-// at the same time.
-var candidateCompare prioritywaitqueue.ComparePriority[connectCandidate] = func(a, b connectCandidate) bool {
-	mdA, ok := a.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
-	if !ok {
-		return false
-	}
-	mdB, ok := b.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
-	if !ok {
-		return true
-	}
-
-	// prioritize verified deals over not verified deals
-	if mdA.VerifiedDeal != mdB.VerifiedDeal {
-		return mdA.VerifiedDeal
-	}
-
-	// prioritize fast retrievel over not fast retrieval
-	if mdA.FastRetrieval && !mdB.FastRetrieval {
-		return true
-	}
-
-	return a.Duration < b.Duration
-}
-
 type GraphSyncRetriever struct {
 	GetStorageProviderTimeout GetStorageProviderTimeout
 	Client                    RetrievalClient
@@ -77,6 +45,21 @@ func NewGraphsyncRetriever(getStorageProviderTimeout GetStorageProviderTimeout, 
 	}
 }
 
+// metadataCompare compares two metadata.GraphsyncFilecoinV1s and returns true if the first is preferable to the second.
+func metadataCompare(a, b *metadata.GraphsyncFilecoinV1) bool {
+	// prioritize verified deals over not verified deals
+	if a.VerifiedDeal != b.VerifiedDeal {
+		return a.VerifiedDeal
+	}
+
+	// prioritize fast retrievel over not fast retrieval
+	if a.FastRetrieval && !b.FastRetrieval {
+		return true
+	}
+
+	return false
+}
+
 type retrievalResult struct {
 	PeerID     peer.ID
 	PhaseStart time.Time
@@ -88,9 +71,16 @@ type retrievalResult struct {
 // retrieval handles state on a per-retrieval (across multiple candidates) basis
 type graphsyncRetrieval struct {
 	*GraphSyncRetriever
-	ctx            context.Context
-	request        types.RetrievalRequest
-	eventsCallback func(types.RetrievalEvent)
+	ctx                 context.Context
+	request             types.RetrievalRequest
+	eventsCallback      func(types.RetrievalEvent)
+	candidateMetadata   map[peer.ID]*metadata.GraphsyncFilecoinV1
+	candidateMetdataMut *sync.RWMutex
+}
+
+type connectCandidate struct {
+	PeerID   peer.ID
+	Duration time.Duration
 }
 
 type graphsyncCandidateRetrieval struct {
@@ -117,11 +107,39 @@ func (cfg *GraphSyncRetriever) Retrieve(
 
 	// state local to this CID's retrieval
 	return &graphsyncRetrieval{
-		GraphSyncRetriever: cfg,
-		ctx:                ctx,
-		request:            retrievalRequest,
-		eventsCallback:     eventsCallback,
+		GraphSyncRetriever:  cfg,
+		ctx:                 ctx,
+		request:             retrievalRequest,
+		eventsCallback:      eventsCallback,
+		candidateMetadata:   make(map[peer.ID]*metadata.GraphsyncFilecoinV1),
+		candidateMetdataMut: &sync.RWMutex{},
 	}
+}
+
+// candidateCompare compares two connectCandidates and returns true if the first is
+// preferable to the second. This is used for the PriorityWaitQueue that will
+// prioritise execution of retrievals if two candidates are available to compare
+// at the same time.
+func (r *graphsyncRetrieval) candidateCompare(a, b connectCandidate) bool {
+	r.candidateMetdataMut.RLock()
+	mdA, ok := r.candidateMetadata[a.PeerID]
+	if !ok {
+		r.candidateMetdataMut.RUnlock()
+		return false
+	}
+
+	mdB, ok := r.candidateMetadata[b.PeerID]
+	if !ok {
+		r.candidateMetdataMut.RUnlock()
+		return true
+	}
+	r.candidateMetdataMut.RUnlock()
+
+	if metadataCompare(mdA, mdB) {
+		return true
+	}
+
+	return a.Duration < b.Duration
 }
 
 func (r *graphsyncRetrieval) RetrieveFromAsyncCandidates(asyncCandidates types.InboundAsyncCandidates) (*types.RetrievalStats, error) {
@@ -131,7 +149,7 @@ func (r *graphsyncRetrieval) RetrieveFromAsyncCandidates(asyncCandidates types.I
 		resultChan: make(chan retrievalResult),
 		finishChan: make(chan struct{}),
 		waitQueue: prioritywaitqueue.New(
-			candidateCompare,
+			r.candidateCompare,
 			prioritywaitqueue.WithInitialPause[connectCandidate](r.QueueInitialPause),
 			prioritywaitqueue.WithClock[connectCandidate](r.Clock),
 		),
@@ -149,12 +167,32 @@ func (r *graphsyncRetrieval) RetrieveFromAsyncCandidates(asyncCandidates types.I
 				return
 			}
 			for _, candidate := range candidates {
-				candidate := candidate
-				waitGroup.Add(1)
-				go func() {
-					defer waitGroup.Done()
-					runRetrievalCandidate(ctx, r.GraphSyncRetriever, r.request, r.Client, r.request.LinkSystem, retrieval, phaseStartTime, candidate)
-				}()
+				// Check if we already started a retrieval for this candidate
+				r.candidateMetdataMut.RLock()
+				currMetadata, seenCandidate := r.candidateMetadata[candidate.MinerPeer.ID]
+				r.candidateMetdataMut.RUnlock()
+				if seenCandidate {
+					// Don't start a new retrieval, but update the metadata if it's more favorable
+					newMetadata := candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
+					if metadataCompare(newMetadata, currMetadata) {
+						r.candidateMetdataMut.Lock()
+						r.candidateMetadata[candidate.MinerPeer.ID] = newMetadata
+						r.candidateMetdataMut.Unlock()
+					}
+				} else {
+					// Track the candidate metadata
+					r.candidateMetdataMut.Lock()
+					r.candidateMetadata[candidate.MinerPeer.ID] = candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
+					r.candidateMetdataMut.Unlock()
+
+					// Start the retrieval with the candidate
+					candidate := candidate
+					waitGroup.Add(1)
+					go func() {
+						defer waitGroup.Done()
+						runRetrievalCandidate(ctx, r.GraphSyncRetriever, r.request, r.Client, r.request.LinkSystem, retrieval, phaseStartTime, candidate)
+					}()
+				}
 			}
 		}
 	}()
@@ -251,8 +289,8 @@ func runRetrievalCandidate(
 		retrieval.sendEvent(events.Connected(cfg.Clock.Now(), req.RetrievalID, phaseStartTime, types.RetrievalPhase, candidate))
 		// if query is successful, then wait for priority and execute retrieval
 		done = retrieval.waitQueue.Wait(connectCandidate{
-			Duration:           cfg.Clock.Now().Sub(phaseStartTime),
-			RetrievalCandidate: candidate,
+			PeerID:   candidate.MinerPeer.ID,
+			Duration: cfg.Clock.Now().Sub(phaseStartTime),
 		})
 
 		if retrieval.canSendResult() { // move on to retrieval phase

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -46,7 +46,7 @@ func NewGraphsyncRetriever(getStorageProviderTimeout GetStorageProviderTimeout, 
 }
 
 // metadataCompare compares two metadata.GraphsyncFilecoinV1s and returns true if the first is preferable to the second.
-func metadataCompare(a, b *metadata.GraphsyncFilecoinV1) bool {
+func metadataCompare(a, b metadata.GraphsyncFilecoinV1) bool {
 	// prioritize verified deals over not verified deals
 	if a.VerifiedDeal != b.VerifiedDeal {
 		return a.VerifiedDeal
@@ -74,7 +74,7 @@ type graphsyncRetrieval struct {
 	ctx                context.Context
 	request            types.RetrievalRequest
 	eventsCallback     func(types.RetrievalEvent)
-	candidateMetadata  map[peer.ID]*metadata.GraphsyncFilecoinV1
+	candidateMetadata  map[peer.ID]metadata.GraphsyncFilecoinV1
 	candidateMetdataLk sync.RWMutex
 }
 
@@ -111,7 +111,7 @@ func (cfg *GraphSyncRetriever) Retrieve(
 		ctx:                ctx,
 		request:            retrievalRequest,
 		eventsCallback:     eventsCallback,
-		candidateMetadata:  make(map[peer.ID]*metadata.GraphsyncFilecoinV1),
+		candidateMetadata:  make(map[peer.ID]metadata.GraphsyncFilecoinV1),
 	}
 }
 
@@ -170,12 +170,24 @@ func (r *graphsyncRetrieval) RetrieveFromAsyncCandidates(asyncCandidates types.I
 				currMetadata, seenCandidate := r.candidateMetadata[candidate.MinerPeer.ID]
 				r.candidateMetdataLk.RUnlock()
 
-				// Don't start a new retrieval if we've seen this candidate before, but update the metadata if it's more favorable
+				// Grab the current candidate's metadata, adding the piece cid to the metadata if the type assertion failed
+				candidateMetadata, ok := candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
+				if !ok {
+					candidateMetadata = &metadata.GraphsyncFilecoinV1{PieceCID: r.request.Cid}
+				}
+
+				// Don't start a new retrieval if we've seen this candidate before,
+				// but update the metadata if it's more favorable
 				if seenCandidate {
-					newMetadata := candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
-					if metadataCompare(newMetadata, currMetadata) {
+					// We know the metadata is not as favorable if the type assertion failed
+					// since the metadata will be the zero value of graphsync metadata
+					if !ok {
+						continue
+					}
+
+					if metadataCompare(*candidateMetadata, currMetadata) {
 						r.candidateMetdataLk.Lock()
-						r.candidateMetadata[candidate.MinerPeer.ID] = newMetadata
+						r.candidateMetadata[candidate.MinerPeer.ID] = *candidateMetadata
 						r.candidateMetdataLk.Unlock()
 					}
 					continue
@@ -183,7 +195,7 @@ func (r *graphsyncRetrieval) RetrieveFromAsyncCandidates(asyncCandidates types.I
 
 				// Track the candidate metadata
 				r.candidateMetdataLk.Lock()
-				r.candidateMetadata[candidate.MinerPeer.ID] = candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
+				r.candidateMetadata[candidate.MinerPeer.ID] = *candidateMetadata
 				r.candidateMetdataLk.Unlock()
 
 				// Start the retrieval with the candidate

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -121,18 +121,17 @@ func (cfg *GraphSyncRetriever) Retrieve(
 // at the same time.
 func (r *graphsyncRetrieval) candidateCompare(a, b connectCandidate) bool {
 	r.candidateMetdataLk.RLock()
+	defer r.candidateMetdataLk.RUnlock()
+
 	mdA, ok := r.candidateMetadata[a.PeerID]
 	if !ok {
-		r.candidateMetdataLk.RUnlock()
 		return false
 	}
 
 	mdB, ok := r.candidateMetadata[b.PeerID]
 	if !ok {
-		r.candidateMetdataLk.RUnlock()
 		return true
 	}
-	r.candidateMetdataLk.RUnlock()
 
 	if metadataCompare(mdA, mdB) {
 		return true

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -71,11 +71,11 @@ type retrievalResult struct {
 // retrieval handles state on a per-retrieval (across multiple candidates) basis
 type graphsyncRetrieval struct {
 	*GraphSyncRetriever
-	ctx                 context.Context
-	request             types.RetrievalRequest
-	eventsCallback      func(types.RetrievalEvent)
-	candidateMetadata   map[peer.ID]*metadata.GraphsyncFilecoinV1
-	candidateMetdataMut *sync.RWMutex
+	ctx                context.Context
+	request            types.RetrievalRequest
+	eventsCallback     func(types.RetrievalEvent)
+	candidateMetadata  map[peer.ID]*metadata.GraphsyncFilecoinV1
+	candidateMetdataLk sync.RWMutex
 }
 
 type connectCandidate struct {
@@ -107,12 +107,11 @@ func (cfg *GraphSyncRetriever) Retrieve(
 
 	// state local to this CID's retrieval
 	return &graphsyncRetrieval{
-		GraphSyncRetriever:  cfg,
-		ctx:                 ctx,
-		request:             retrievalRequest,
-		eventsCallback:      eventsCallback,
-		candidateMetadata:   make(map[peer.ID]*metadata.GraphsyncFilecoinV1),
-		candidateMetdataMut: &sync.RWMutex{},
+		GraphSyncRetriever: cfg,
+		ctx:                ctx,
+		request:            retrievalRequest,
+		eventsCallback:     eventsCallback,
+		candidateMetadata:  make(map[peer.ID]*metadata.GraphsyncFilecoinV1),
 	}
 }
 
@@ -121,19 +120,19 @@ func (cfg *GraphSyncRetriever) Retrieve(
 // prioritise execution of retrievals if two candidates are available to compare
 // at the same time.
 func (r *graphsyncRetrieval) candidateCompare(a, b connectCandidate) bool {
-	r.candidateMetdataMut.RLock()
+	r.candidateMetdataLk.RLock()
 	mdA, ok := r.candidateMetadata[a.PeerID]
 	if !ok {
-		r.candidateMetdataMut.RUnlock()
+		r.candidateMetdataLk.RUnlock()
 		return false
 	}
 
 	mdB, ok := r.candidateMetadata[b.PeerID]
 	if !ok {
-		r.candidateMetdataMut.RUnlock()
+		r.candidateMetdataLk.RUnlock()
 		return true
 	}
-	r.candidateMetdataMut.RUnlock()
+	r.candidateMetdataLk.RUnlock()
 
 	if metadataCompare(mdA, mdB) {
 		return true
@@ -168,22 +167,22 @@ func (r *graphsyncRetrieval) RetrieveFromAsyncCandidates(asyncCandidates types.I
 			}
 			for _, candidate := range candidates {
 				// Check if we already started a retrieval for this candidate
-				r.candidateMetdataMut.RLock()
+				r.candidateMetdataLk.RLock()
 				currMetadata, seenCandidate := r.candidateMetadata[candidate.MinerPeer.ID]
-				r.candidateMetdataMut.RUnlock()
+				r.candidateMetdataLk.RUnlock()
 				if seenCandidate {
 					// Don't start a new retrieval, but update the metadata if it's more favorable
 					newMetadata := candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
 					if metadataCompare(newMetadata, currMetadata) {
-						r.candidateMetdataMut.Lock()
+						r.candidateMetdataLk.Lock()
 						r.candidateMetadata[candidate.MinerPeer.ID] = newMetadata
-						r.candidateMetdataMut.Unlock()
+						r.candidateMetdataLk.Unlock()
 					}
 				} else {
 					// Track the candidate metadata
-					r.candidateMetdataMut.Lock()
+					r.candidateMetdataLk.Lock()
 					r.candidateMetadata[candidate.MinerPeer.ID] = candidate.Metadata.Get(multicodec.TransportGraphsyncFilecoinv1).(*metadata.GraphsyncFilecoinV1)
-					r.candidateMetdataMut.Unlock()
+					r.candidateMetdataLk.Unlock()
 
 					// Start the retrieval with the candidate
 					candidate := candidate

--- a/pkg/retriever/graphsyncretriever_test.go
+++ b/pkg/retriever/graphsyncretriever_test.go
@@ -723,6 +723,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 	startTime := time.Now().Add(time.Hour)
 	clock := clock.NewMock()
 	clock.Set(startTime)
+	initialPause := 10 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -740,7 +741,9 @@ func TestDuplicateRetreivals(t *testing.T) {
 		clock,
 	)
 
-	cfg := NewGraphsyncRetrieverWithClock(func(peer peer.ID) time.Duration { return time.Second }, mockClient, clock)
+	cfg := NewGraphsyncRetriever(func(peer peer.ID) time.Duration { return time.Second }, mockClient)
+	cfg.Clock = clock
+	cfg.QueueInitialPause = initialPause
 
 	expectedSequence := []testutil.ExpectedActionsAtTime{
 		{
@@ -753,11 +756,14 @@ func TestDuplicateRetreivals(t *testing.T) {
 			},
 		},
 		{
-			AfterStart:         time.Millisecond * 50,
-			ReceivedRetrievals: []peer.ID{"foo"},
+			AfterStart: time.Millisecond * 50,
 			ExpectedEvents: []types.RetrievalEvent{
 				events.Connected(startTime.Add(time.Millisecond*50), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
 			},
+		},
+		{
+			AfterStart:         time.Millisecond*50 + initialPause,
+			ReceivedRetrievals: []peer.ID{"foo"},
 		},
 		{
 			AfterStart: time.Millisecond * 75,
@@ -772,20 +778,20 @@ func TestDuplicateRetreivals(t *testing.T) {
 			},
 		},
 		{
-			AfterStart:         time.Millisecond * 200,
+			AfterStart:         time.Millisecond*200 + initialPause,
 			ReceivedRetrievals: []peer.ID{"bar"},
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*200), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
-				events.Failed(startTime.Add(time.Millisecond*200), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+				events.Proposed(startTime.Add(time.Millisecond*200+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+				events.Failed(startTime.Add(time.Millisecond*200+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
 			},
 		},
 		{
-			AfterStart: time.Millisecond * 400,
+			AfterStart: time.Millisecond*400 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
-				events.Accepted(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
-				events.FirstByte(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
-				events.Success(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), 2, 0, 0, big.Zero(), 0),
+				events.Proposed(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.Accepted(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.FirstByte(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.Success(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), 2, 0, 0, big.Zero(), 0),
 			},
 		},
 	}

--- a/pkg/retriever/graphsyncretriever_test.go
+++ b/pkg/retriever/graphsyncretriever_test.go
@@ -654,9 +654,9 @@ func TestMultipleRetrievals(t *testing.T) {
 				RetrievalID: retrievalID,
 				LinkSystem:  cidlink.DefaultLinkSystem(),
 			}, cb).RetrieveFromAsyncCandidates(MakeAsyncCandidates(t, []types.RetrievalCandidate{
-				{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}},
-				{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}},
-				{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}},
+				types.NewRetrievalCandidate(peer.ID("foo"), cid.Undef, &metadata.GraphsyncFilecoinV1{}),
+				types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{}),
+				types.NewRetrievalCandidate(peer.ID("baz"), cid.Undef, &metadata.GraphsyncFilecoinV1{}),
 			}))
 		},
 		func(cb func(types.RetrievalEvent)) (*types.RetrievalStats, error) {
@@ -665,9 +665,9 @@ func TestMultipleRetrievals(t *testing.T) {
 				RetrievalID: retrievalID,
 				LinkSystem:  cidlink.DefaultLinkSystem(),
 			}, cb).RetrieveFromAsyncCandidates(MakeAsyncCandidates(t, []types.RetrievalCandidate{
-				{MinerPeer: peer.AddrInfo{ID: peer.ID("bang")}},
-				{MinerPeer: peer.AddrInfo{ID: peer.ID("boom")}},
-				{MinerPeer: peer.AddrInfo{ID: peer.ID("bing")}},
+				types.NewRetrievalCandidate(peer.ID("bang"), cid.Undef, &metadata.GraphsyncFilecoinV1{}),
+				types.NewRetrievalCandidate(peer.ID("boom"), cid.Undef, &metadata.GraphsyncFilecoinV1{}),
+				types.NewRetrievalCandidate(peer.ID("bing"), cid.Undef, &metadata.GraphsyncFilecoinV1{}),
 			}))
 		}})
 	require.Len(t, results, 2)
@@ -706,7 +706,7 @@ func TestRetrievalSelector(t *testing.T) {
 		LinkSystem:  cidlink.DefaultLinkSystem(),
 		Selector:    selector,
 	}, nil)
-	stats, err := retrieval.RetrieveFromAsyncCandidates(MakeAsyncCandidates(t, []types.RetrievalCandidate{{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}}))
+	stats, err := retrieval.RetrieveFromAsyncCandidates(MakeAsyncCandidates(t, []types.RetrievalCandidate{types.NewRetrievalCandidate(peer.ID("foo"), cid.Undef, &metadata.GraphsyncFilecoinV1{})}))
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 	require.Equal(t, mockClient.GetRetrievalReturns()["foo"].ResultStats, stats)

--- a/pkg/retriever/graphsyncretriever_test.go
+++ b/pkg/retriever/graphsyncretriever_test.go
@@ -717,6 +717,103 @@ func TestRetrievalSelector(t *testing.T) {
 	require.Same(t, selector, rr.Selector)
 }
 
+func TestDuplicateRetreivals(t *testing.T) {
+	retrievalID := types.RetrievalID(uuid.New())
+	cid1 := cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+	startTime := time.Now().Add(time.Hour)
+	clock := clock.NewMock()
+	clock.Set(startTime)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	mockClient := testutil.NewMockClient(
+		map[string]testutil.DelayedConnectReturn{
+			"foo": {Err: nil, Delay: time.Millisecond * 50},
+			"baz": {Err: nil, Delay: time.Millisecond * 75},
+			"bar": {Err: nil, Delay: time.Millisecond * 100},
+		},
+		map[string]testutil.DelayedClientReturn{
+			"foo": {ResultErr: errors.New("Nope"), Delay: time.Millisecond * 150},
+			"bar": {ResultStats: &types.RetrievalStats{StorageProviderId: peer.ID("bar"), Size: 2}, Delay: time.Millisecond * 200},
+			"baz": {ResultStats: &types.RetrievalStats{StorageProviderId: peer.ID("baz"), Size: 2}, Delay: time.Millisecond * 200},
+		},
+		clock,
+	)
+
+	cfg := NewGraphsyncRetrieverWithClock(func(peer peer.ID) time.Duration { return time.Second }, mockClient, clock)
+
+	expectedSequence := []testutil.ExpectedActionsAtTime{
+		{
+			AfterStart:          0,
+			ReceivedConnections: []peer.ID{"foo", "bar", "baz"},
+			ExpectedEvents: []types.RetrievalEvent{
+				events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+				events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+				events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+			},
+		},
+		{
+			AfterStart:         time.Millisecond * 50,
+			ReceivedRetrievals: []peer.ID{"foo"},
+			ExpectedEvents: []types.RetrievalEvent{
+				events.Connected(startTime.Add(time.Millisecond*50), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+			},
+		},
+		{
+			AfterStart: time.Millisecond * 75,
+			ExpectedEvents: []types.RetrievalEvent{
+				events.Connected(startTime.Add(time.Millisecond*75), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("baz")}}),
+			},
+		},
+		{
+			AfterStart: time.Millisecond * 100,
+			ExpectedEvents: []types.RetrievalEvent{
+				events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("bar")}}),
+			},
+		},
+		{
+			AfterStart:         time.Millisecond * 200,
+			ReceivedRetrievals: []peer.ID{"bar"},
+			ExpectedEvents: []types.RetrievalEvent{
+				events.Proposed(startTime.Add(time.Millisecond*200), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}),
+				events.Failed(startTime.Add(time.Millisecond*200), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID("foo")}}, "retrieval failed: Nope"),
+			},
+		},
+		{
+			AfterStart: time.Millisecond * 400,
+			ExpectedEvents: []types.RetrievalEvent{
+				events.Proposed(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.Accepted(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.FirstByte(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.Success(startTime.Add(time.Millisecond*400), retrievalID, startTime, types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), 2, 0, 0, big.Zero(), 0),
+			},
+		},
+	}
+	results := testutil.RetrievalVerifier{
+		ExpectedSequence: expectedSequence,
+	}.RunWithVerification(ctx, t, clock, mockClient, nil, []testutil.RunRetrieval{
+		func(cb func(types.RetrievalEvent)) (*types.RetrievalStats, error) {
+			return cfg.Retrieve(context.Background(), types.RetrievalRequest{
+				Cid:         cid1,
+				RetrievalID: retrievalID,
+				LinkSystem:  cidlink.DefaultLinkSystem(),
+			}, cb).RetrieveFromAsyncCandidates(MakeAsyncCandidates(t, []types.RetrievalCandidate{
+				types.NewRetrievalCandidate(peer.ID("foo"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: false, FastRetrieval: false}),
+				types.NewRetrievalCandidate(peer.ID("baz"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: false, FastRetrieval: false}),
+				types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: false, FastRetrieval: false}),
+				types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: false, FastRetrieval: true}),
+				types.NewRetrievalCandidate(peer.ID("bar"), cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}),
+			}))
+		},
+	})
+	require.Len(t, results, 1)
+	stats, err := results[0].Stats, results[0].Err
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	// make sure we got the final retrieval we wanted
+	require.Equal(t, mockClient.GetRetrievalReturns()["bar"].ResultStats, stats)
+}
+
 func MakeAsyncCandidates(t *testing.T, candidates []types.RetrievalCandidate) types.InboundAsyncCandidates {
 	incoming, outgoing := types.MakeAsyncCandidates(len(candidates))
 	for _, candidate := range candidates {


### PR DESCRIPTION
Deduplicates candidates in the graphsync retriever by storing a map of peer IDs we've started retrievals for to candidate metadata. If we've stored metadata about a candidate before, we don't start another retrieval. Metadata is then referenced in the wait queue's compare function so that priority is based on the best metadata for a given candidate.

Fixes #55 