### PR TITLE
feat(test): file/dir name generator that's more realistic

### DIFF
--- a/pkg/internal/itest/client_retrieval_test.go
+++ b/pkg/internal/itest/client_retrieval_test.go
@@ -66,7 +66,7 @@ func TestRetrieval(t *testing.T) {
 			mrn.MN.LinkAll()
 
 			// Generate source data on the remote
-			srcData := tt.generate(t, mrn.Remotes[0].LinkSystem)
+			srcData := tt.generate(t, *mrn.Remotes[0].LinkSystem)
 
 			// Perform retrieval
 			linkSystemLocal := runRetrieval(t, ctx, mrn, srcData.Root, finishedChan)

--- a/pkg/internal/itest/direct_fetch_test.go
+++ b/pkg/internal/itest/direct_fetch_test.go
@@ -72,11 +72,11 @@ func TestDirectFetch(t *testing.T) {
 			// graphsync peer (0)
 			graphsyncMAs, err := peer.AddrInfoToP2pAddrs(mrn.Remotes[0].AddrInfo())
 			req.NoError(err)
-			srcData1 := unixfs.GenerateFile(t, &mrn.Remotes[0].LinkSystem, rndReader, 4<<20)
+			srcData1 := unixfs.GenerateFile(t, mrn.Remotes[0].LinkSystem, rndReader, 4<<20)
 			mocknet.SetupRetrieval(t, mrn.Remotes[0])
 
 			// bitswap peer (1)
-			srcData2 := unixfs.GenerateFile(t, &mrn.Remotes[1].LinkSystem, bytes.NewReader(srcData1.Content), 4<<20)
+			srcData2 := unixfs.GenerateFile(t, mrn.Remotes[1].LinkSystem, bytes.NewReader(srcData1.Content), 4<<20)
 			req.Equal(srcData2.Root, srcData2.Root)
 			bitswapMAs, err := peer.AddrInfoToP2pAddrs(mrn.Remotes[1].AddrInfo())
 			req.NoError(err)

--- a/pkg/internal/itest/testpeer/generator.go
+++ b/pkg/internal/itest/testpeer/generator.go
@@ -129,7 +129,7 @@ type TestPeer struct {
 	blockstore         blockstore.Blockstore
 	Host               host.Host
 	blockstoreDelay    delay.D
-	LinkSystem         linking.LinkSystem
+	LinkSystem         *linking.LinkSystem
 	Cids               map[cid.Cid]struct{}
 }
 
@@ -182,7 +182,7 @@ func NewTestGraphsyncPeer(ctx context.Context, mn mocknet.Mocknet, p tnet.Identi
 	// Setup remote data transfer
 	gsNetRemote := gsnet.NewFromLibp2pHost(peer.Host)
 	dtNetRemote := dtnet.NewFromLibp2pHost(peer.Host, dtnet.RetryParameters(0, 0, 0, 0))
-	gsRemote := gsimpl.New(ctx, gsNetRemote, peer.LinkSystem)
+	gsRemote := gsimpl.New(ctx, gsNetRemote, *peer.LinkSystem)
 	gstpRemote := gstransport.NewTransport(peer.Host.ID(), gsRemote)
 	dtRemote, err := dtimpl.NewDataTransfer(dstore, dtNetRemote, gstpRemote)
 	if err != nil {
@@ -215,12 +215,13 @@ func newTestPeer(ctx context.Context, mn mocknet.Mocknet, p tnet.Identity) (Test
 	if err != nil {
 		return TestPeer{}, nil, err
 	}
+	lsys := storeutil.LinkSystemForBlockstore(bstore)
 	tp := TestPeer{
 		Host:            client,
 		ID:              p.ID(),
 		blockstore:      bstore,
 		blockstoreDelay: bsdelay,
-		LinkSystem:      storeutil.LinkSystemForBlockstore(bstore),
+		LinkSystem:      &lsys,
 		Cids:            make(map[cid.Cid]struct{}),
 	}
 

--- a/pkg/internal/itest/unixfs/directory.go
+++ b/pkg/internal/itest/unixfs/directory.go
@@ -102,6 +102,7 @@ func toDirEntryRecursive(t *testing.T, linkSys linking.LinkSystem, rootCid cid.C
 }
 
 func CompareDirEntries(t *testing.T, a, b DirEntry) {
+	t.Log("CompareDirEntries", a.Path, b.Path) // TODO: remove this
 	require.Equal(t, a.Path, b.Path)
 	require.Equal(t, a.Content, b.Content, a.Path+" content mismatch")
 	require.Equal(t, a.Root, b.Root, a.Path+" root mismatch")

--- a/pkg/internal/itest/unixfs/directory.go
+++ b/pkg/internal/itest/unixfs/directory.go
@@ -2,6 +2,8 @@ package unixfs
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"testing"
@@ -102,10 +104,12 @@ func toDirEntryRecursive(t *testing.T, linkSys linking.LinkSystem, rootCid cid.C
 }
 
 func CompareDirEntries(t *testing.T, a, b DirEntry) {
-	t.Log("CompareDirEntries", a.Path, b.Path) // TODO: remove this
+	// t.Log("CompareDirEntries", a.Path, b.Path) // TODO: remove this
 	require.Equal(t, a.Path, b.Path)
-	require.Equal(t, a.Content, b.Content, a.Path+" content mismatch")
-	require.Equal(t, a.Root, b.Root, a.Path+" root mismatch")
+	require.Equal(t, a.Root.String(), b.Root.String(), a.Path+" root mismatch")
+	hashA := sha256.Sum256(a.Content)
+	hashB := sha256.Sum256(b.Content)
+	require.Equal(t, hex.EncodeToString(hashA[:]), hex.EncodeToString(hashB[:]), a.Path+"content hash mismatch")
 	require.Equal(t, len(a.Children), len(b.Children), fmt.Sprintf("%s child length mismatch %d <> %d", a.Path, len(a.Children), len(b.Children)))
 	for i := range a.Children {
 		// not necessarily in order

--- a/pkg/internal/itest/unixfs/generator.go
+++ b/pkg/internal/itest/unixfs/generator.go
@@ -3,12 +3,12 @@ package unixfs
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/base64"
 	"io"
 	"math/big"
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/lassie/pkg/internal/itest/unixfs/namegen"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-unixfsnode/data/builder"
 	dagpb "github.com/ipld/go-codec-dagpb"
@@ -60,25 +60,6 @@ func GenerateFile(t *testing.T, linkSys *linking.LinkSystem, randReader io.Reade
 	}
 }
 
-func fileName(randReader io.Reader) (string, error) {
-	for {
-		length, err := rand.Int(randReader, big.NewInt(63))
-		if err != nil {
-			return "", err
-		}
-		name := make([]byte, length.Int64()+1)
-		_, err = randReader.Read(name)
-		if err != nil {
-			return "", err
-		}
-
-		nameStr := strings.Replace(base64.RawStdEncoding.EncodeToString(name), "/", "", -1)
-		if len(nameStr) > 0 {
-			return nameStr, nil
-		}
-	}
-}
-
 func rndInt(randReader io.Reader, max int) int {
 	coin, err := rand.Int(randReader, big.NewInt(int64(max)))
 	if err != nil {
@@ -111,7 +92,7 @@ func GenerateDirectoryFrom(t *testing.T,
 			if targetSize-curSize <= 1024 { // don't make tiny directories
 				continue
 			}
-			newDir, err := fileName(randReader)
+			newDir, err := namegen.RandomDirectoryName(randReader)
 			require.NoError(t, err)
 			child := GenerateDirectoryFrom(t, linkSys, randReader, targetSize-curSize, dir+"/"+newDir, false)
 			children = append(children, child)
@@ -127,7 +108,7 @@ func GenerateDirectoryFrom(t *testing.T,
 				}
 			}
 			entry := GenerateFile(t, linkSys, randReader, size)
-			name, err := fileName(randReader)
+			name, err := namegen.RandomFileName(randReader)
 			require.NoError(t, err)
 			entry.Path = dir + "/" + name
 			curSize += size

--- a/pkg/internal/itest/unixfs/namegen/namegen.go
+++ b/pkg/internal/itest/unixfs/namegen/namegen.go
@@ -1,0 +1,106 @@
+package namegen
+
+import (
+	"encoding/binary"
+	"io"
+	"strings"
+)
+
+var words = strings.Fields(wordData)
+var extensions = []string{"", ".txt", ".pdf", ".docx", ".png", ".jpg", ".csv", ".json", ".xml"}
+
+func getRandomIndex(r io.Reader, max int) (int, error) {
+	var n uint32
+	err := binary.Read(r, binary.BigEndian, &n)
+	if err != nil {
+		return 0, err
+	}
+	return int(n % uint32(max)), nil
+}
+
+// RandomDirectoryName returns a random directory name from the provided word list.
+func RandomDirectoryName(r io.Reader) (string, error) {
+	index, err := getRandomIndex(r, len(words))
+	if err != nil {
+		return "", err
+	}
+	return words[index], nil
+}
+
+// RandomFileName returns a random file name with an extension from the provided word list and common extensions.
+func RandomFileName(r io.Reader) (string, error) {
+	wordIndex, err := getRandomIndex(r, len(words))
+	if err != nil {
+		return "", err
+	}
+	extIndex, err := getRandomIndex(r, len(extensions))
+	if err != nil {
+		return "", err
+	}
+	return words[wordIndex] + extensions[extIndex], nil
+}
+
+const wordData = `jabberwocky Snark whiffling borogoves mome raths brillig slithy toves outgrabe
+Tumtum Frabjous Bandersnatch Jubjub Callay slumgullion snicker-snack brobdingnagian Jabberwock
+tree Poglorian Binkleborf Wockbristle Zizzotether dinglewock Flumgurgle Glimperwick RazzleDazzle8
+gyre tortlewhack whispyfangle Crumplehorn Higgledy7 Piggledy3 flibberwocky Zamborot Flizzleflink
+gimble Shakespearean Macbeth Othello Hamlet soliloquy iambic pentameter Benvolio Capulet Montague
+Puck Malvolio Beatrice Prospero Iago Falstaff Rosencrantz Guildenstern Cordelia Polonius
+Titania Oberon Tybalt Caliban Mercutio Portia Brabantio 4Lear Desdemona Lysander
+YossarianScar Jujimufu9 Gorgulon Oozyboozle Razzmatazz8 BlinkenWoggle Flibbertigibbet Quixotic2
+Galumphing Widdershins Pecksniffian Bandicoot11 Flapdoodle Fandango Whippersnapper Grandiloquent
+Lollygag Persnickety Gibberish Codswallop Rigmarole Nincompoop Flummox Snollygoster Poppycock
+Kerfuffle Balderdash Gobbledygook Fiddle-faddle Antidisestablishmentarianism
+Supercalifragilisticexpialidocious Rambunctious9 Lickety-split Hullabaloo Skullduggery Ballyhoo
+Flabbergasted Discombobulate Pernicious Bumfuzzle Bamboozle Pandemonium Tomfoolery Hobbledehoy7
+Claptrap Cockamamie Hocus-pocus8 Higgledy-piggledy Dodecahedron Nonsensical Contraption Quizzical
+Snuffleupagus Ostentatious Serendipity Ephemeral Melancholy Sonorous Plethora Brouhaha Absquatulate
+Gobbledygook3 Lilliputian Chortle Euphonious Mellifluous Obfuscate Perspicacious Prevaricate
+Sesquipedalian Tintinnabulation Quibble9 Umbrageous Quotidian Flapdoodle5 NoodleDoodle
+Zigzagumptious Throttlebottom WuzzleWump Canoodle Hodgepodge Blatherskite7 Hornswoggle
+BibbidiBobbidiBoo Prestidigitation Confabulate Abscond8 Lickspittle Ragamuffin Taradiddle
+Widdershins4 Boondoggle Snuffleupagus9 Gallivant Folderol Malarkey Skedaddle Hobgoblin
+BlubberCrumble ZibberZap Snickerdoodle Mooncalf LicketySplit8 Whatchamacallit Thingamajig
+Thingamabob GibbleGabble FuddleDuddle LoopyLoo Splendiferous Bumbershoot Catawampus Flibbertigibbet5
+Gobbledygook7 Whippersnapper9 Ragamuffin8 Splendiferous
+ætheling witan ealdorman leofwyrd swain bēorhall beorn mēarh scōp cyning hēahgerefa
+sceadugenga wilweorc hildoræswa þegn ælfscyne wyrmslaga wælwulf fyrd hrēowmōd dēor
+ealdorleornung scyldwiga þēodcwealm hāligbōc gūþweard wealdend gāstcynn wīfmann
+wīsestōw þrēatung rīcere scealc eorþwerod bealucræft cynerīce sceorp ættwer
+gāsthof ealdrīce wæpnedmann wæterfōr landgemære gafolgelda wīcstede mægenþrymm
+æscwiga læcedōm wīdferhþ eorlgestrēon brimrād wæterstede hūslēoþ searocraeft
+þegnunga wælscenc þrīstguma fyrdrinc wundorcræft cræftleornung eorþbūend
+sǣlācend þunorrad wætergifu wæterscipe wæterþenung eorþtilþ eorþgebyrde
+eorþhæbbend eorþgræf eorþbærn eorþhūs eorþscearu eorþsweg eorþtæfl eorþweorc
+eorþweall eorþwaru eorþwela eorþwīs eorþworn eorþyþ eorþweg eorþwīse eorþwyrhta
+eorþwīn eorþsceaða eorþsweart eorþscræf eorþscrūd eorþswyft eorþscīr eorþscūa
+eorþsēoc eorþsele eorþhūsl eorþsted eorþswyn eorþsittend eorþsniþ eorþscearp
+eorþscyld eorþsceaft eorþstapol eorþstede eorþsmitta eorþscēawere
+velociraptorious chimeraesque bellerophontic serendipitastic transmogrification ultracrepidarian
+prestidigitationary supraluminescence hemidemisemiquaver unquestionability intercontinentalism
+antediluvianistic disproportionately absquatulationism automagicalization
+floccinaucinihilipilification quintessentiality incomprehensibility juxtapositionally
+perpendicularitude transubstantiation synchronicityverse astronomicalunit thermodynamicness
+electromagnetismal procrastinatorily disenfranchisement neutrinooscillation hyperventilatingly
+pneumonoultramicroscopicsilicovolcanoconiosis supercalifragilisticexpialidocious thaumaturgeonomics
+idiosyncratically unencumberedness phantasmagoricity extraterrestrialism philanthropistastic
+xenotransplantation incontrovertibility spontaneityvolution teleportationally labyrinthinean
+megalomaniaction cryptozoologician ineffablemystique multiplicativity sisypheanquandary
+overenthusiastically irrefutablenotion exceptionalitysphere
+blibby ploof twindle zibbet jinty wiblo glimsy snaft trindle quopp vistly chark plizet snibber frint
+trazzle buvvy skipple flizz dworp grindle yipple zarfle clippet swazz mibber brackle tindle grozz
+vindle plazz freggle twazz snuzzle gwippet whindle juzzle krazz yazzle flippet skindle zapple prazz
+buzzle chazz gripple snozzle trizz wazzle blikket zib glup snof yipr tazz vlim frub dwex klop
+aa ab ad ae ag ah ai al am an as at aw ax ay ba be bi bo by de do ed ef eh el em en er es et ex fa
+fe go ha he hi hm ho id if in is it jo ka ki la li lo ma me mi mm mo mu my na ne no nu od oe of oh
+oi om on op or os ow ox oy pa pe pi qi re sh si so ta ti to uh um un up us ut we wo xi xu ya ye yo
+za zo
+hĕlłø cąfѐ ŝmîłe þřęê ċỏẽxist ǩāŕáōķê ŧrävèl кυгiοsity ŭпịςørn мëĺōđỳ ğħōšţ ŵăνę ẓẽṕhýr ғụzzlę
+пåŕŧy åƒƒêct ԁяêåм љúвïĺëë ѓåḿъḽë ţęmƿęşţ říše čajovna želva štěstí ýpsilon ďábel ňadraží ťava
+h3ll0 w0rld c0d1ng 3x3mpl3 pr0gr4mm1ng d3v3l0p3r 5cr4bbl3 3l3ph4nt 4pp 5y5t3m 1nput 0utput 3rr0r
+5t4ck0v3rfl0w 5tr1ng 5l1c3 5h4k35p34r3 5t4nd4rd 3ncrypt10n 5h3ll 5cr1pt 5t4ck 5qu4r3 r3ct4ngl3
+tr14ngl3 c1rc13 5ph3r3 5qu4r3r00t 3xpr35510n 5t4t15t1c5 5t4t3m3nt 5ynt4x 5ugg35t10n 5y5t3m4t1c
+5h0rtcut 5h4d0w 5h4r3d
+1 2 3 4 5 6 7 8 9 0
+a b c d e f g h i j k l m n o p q r s t u v w x y z
+A B C D E F G H I J K L M N O P Q R S T U V W X Y Z`

--- a/pkg/server/http/client_close_test.go
+++ b/pkg/server/http/client_close_test.go
@@ -32,7 +32,7 @@ func TestHttpClientClose(t *testing.T) {
 	mrn.AddBitswapPeers(1)
 	require.NoError(t, mrn.MN.LinkAll())
 
-	srcData := unixfs.GenerateFile(t, &mrn.Remotes[0].LinkSystem, rndReader, 20<<20)
+	srcData := unixfs.GenerateFile(t, mrn.Remotes[0].LinkSystem, rndReader, 20<<20)
 
 	// Setup a new lassie
 	req := require.New(t)


### PR DESCRIPTION
I'm just going to park this here as one of my fun side-quests that's not complete. It comes from wanting to make more portable fixtures for unixfs selector variations and being able to define a set of blocks and a query into those blocks based on path. The core change here is just using a fixed corpus of random words to generate directory and file names.

But interestingly, it makes it _much_ more prone to encounter errors that I have seen when I was developing the unixfs fixturing stuff originally, but somehow managed to stamp out and haven't shown back up as flaky tests. I had suspicions at the time that there was something funky going on inside the traversal, or go-unixfsnode, or somewhere else, but managed to make it go away by massaging sizes and depths I think.

But now it's back, it's really easy to get mismatches between what we want and what we get by using this and re-running the tests. I haven't spent enough time to discern a strong pattern either - directory depth, segment names, special characters. It appears to happen on particularly deep file comparisons, but I've also seen it on shorter depth ones.

The biggest change introduced here is in the range of characters - previously it would use base64 encoding to squash random bytes into ascii characters for paths, now we have more weird unicode characters so I'm suspecting something relating to that. All error cases include at least one unicode character represented in at least 2 bytes. So that's my current hunch, I bet there's two different sorts being invoked here that's messing us up (e.g. go-codec-dagpb sorting Links one way, and go-unixfsnode sorting names another and our selectors getting jumbled in between perhaps?).