### PR TITLE
Removes depth type HTTP parameter

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -110,19 +110,6 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 		}
 
 		carScope := types.CarScopeAll
-		// TODO: Deprecating depthType parameter. Remove when Saturn updates to use car-scope parameter.
-		if req.URL.Query().Has("depthType") {
-			switch req.URL.Query().Get("depthType") {
-			case "full":
-			case "shallow":
-				carScope = types.CarScopeFile
-			default:
-				logger.logStatus(http.StatusBadRequest, "Invalid car-scope parameter")
-				res.WriteHeader(http.StatusBadRequest)
-				return
-			}
-		}
-
 		if req.URL.Query().Has("car-scope") {
 			switch req.URL.Query().Get("car-scope") {
 			case "all":


### PR DESCRIPTION
Removes the depth type HTTP parameter parsing. We can merge this once we know Saturn is sending car-scope instead of depth type.

Closes #187 