### PR TITLE
Rename "root" to "block"

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -54,16 +54,16 @@ var fetchCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:        "car-scope",
-			Usage:       "describes the fetch behavior at the end of the traversal path. Valid values include [all, file, root].",
+			Usage:       "describes the fetch behavior at the end of the traversal path. Valid values include [all, file, block].",
 			DefaultText: "defaults to all, the entire DAG at the end of the path will be fetched",
 			Value:       "all",
 			Action: func(cctx *cli.Context, v string) error {
 				switch v {
 				case string(types.CarScopeAll):
 				case string(types.CarScopeFile):
-				case string(types.CarScopeRoot):
+				case string(types.CarScopeBlock):
 				default:
-					return fmt.Errorf("invalid car-scope parameter, must be of value [all, file, root]")
+					return fmt.Errorf("invalid car-scope parameter, must be of value [all, file, block]")
 				}
 
 				return nil

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -34,8 +34,8 @@ func TestHttpFetch(t *testing.T) {
 	fileQuery := func(q url.Values) {
 		q.Set("car-scope", "file")
 	}
-	rootQuery := func(q url.Values) {
-		q.Set("car-scope", "root")
+	blockQuery := func(q url.Values) {
+		q.Set("car-scope", "block")
 	}
 
 	type queryModifier func(url.Values)
@@ -535,13 +535,13 @@ func TestHttpFetch(t *testing.T) {
 			},
 		},
 		{
-			// car-scope root fetch should only get the the root node for a plain file
-			name:             "graphsync large sharded file, car-scope root",
+			// car-scope block fetch should only get the the root node for a plain file
+			name:             "graphsync large sharded file, car-scope block",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateFile(t, &remotes[0].LinkSystem, rndReader, 4<<20)}
 			},
-			modifyQueries: []queryModifier{rootQuery},
+			modifyQueries: []queryModifier{blockQuery},
 			validateBodies: []bodyValidator{
 				func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 					wantCids := []cid.Cid{
@@ -552,14 +552,14 @@ func TestHttpFetch(t *testing.T) {
 			},
 		},
 		{
-			name:             "graphsync nested large sharded file, with path, car-scope root",
+			name:             "graphsync nested large sharded file, with path, car-scope block",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := &remotes[0].LinkSystem
 				return []unixfs.DirEntry{wrapUnixfsContent(t, rndReader, lsys, unixfs.GenerateFile(t, lsys, rndReader, 4<<20))}
 			},
 			paths:         []string{"/want2/want1/want0"},
-			modifyQueries: []queryModifier{rootQuery},
+			modifyQueries: []queryModifier{blockQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := []cid.Cid{
 					srcData.Root,                                     // "/""

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -128,8 +128,8 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 			case "all":
 			case "file":
 				carScope = types.CarScopeFile
-			case "root":
-				carScope = types.CarScopeRoot
+			case "block":
+				carScope = types.CarScopeBlock
 			default:
 				logger.logStatus(http.StatusBadRequest, "Invalid car-scope parameter")
 				res.WriteHeader(http.StatusBadRequest)

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -75,7 +75,7 @@ func NewRequestForPath(store ipldstorage.WritableStorage, cid cid.Cid, path stri
 	case CarScopeAll:
 	case CarScopeFile:
 		targetSelector = unixfsnode.MatchUnixFSPreloadSelector // file
-	case CarScopeRoot:
+	case CarScopeBlock:
 		ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
 		targetSelector = ssb.Matcher() // root
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -266,4 +266,4 @@ type CarScope string
 
 const CarScopeAll CarScope = "all"
 const CarScopeFile CarScope = "file"
-const CarScopeRoot CarScope = "root"
+const CarScopeBlock CarScope = "block"


### PR DESCRIPTION
# Goals

Looks like we got the new parameter naming a bit off, it changed, now we have the final version.