### PR TITLE
Add events calllback function parameter to Lassie.Fetch

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -218,7 +218,7 @@ func Fetch(cctx *cli.Context) error {
 	request.PreloadLinkSystem.SetWriteStorage(preloadStore)
 	request.PreloadLinkSystem.TrustedStorage = true
 
-	stats, err := lassie.Fetch(ctx, request)
+	stats, err := lassie.Fetch(ctx, request, func(types.RetrievalEvent) {})
 	if err != nil {
 		fmt.Fprintln(msgWriter)
 		return err

--- a/pkg/internal/itest/direct_fetch_test.go
+++ b/pkg/internal/itest/direct_fetch_test.go
@@ -118,7 +118,7 @@ func TestDirectFetch(t *testing.T) {
 			req.NoError(err)
 			request, err := types.NewRequestForPath(outCar, srcData1.Root, "", types.CarScopeAll)
 			req.NoError(err)
-			_, err = lassie.Fetch(ctx, request)
+			_, err = lassie.Fetch(ctx, request, func(types.RetrievalEvent) {})
 			req.NoError(err)
 			err = outCar.Finalize()
 			req.NoError(err)

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -211,13 +211,13 @@ func WithBitswapConcurrency(concurrency int) LassieOption {
 	}
 }
 
-func (l *Lassie) Fetch(ctx context.Context, request types.RetrievalRequest) (*types.RetrievalStats, error) {
+func (l *Lassie) Fetch(ctx context.Context, request types.RetrievalRequest, eventsCb func(types.RetrievalEvent)) (*types.RetrievalStats, error) {
 	var cancel context.CancelFunc
 	if l.cfg.GlobalTimeout != time.Duration(0) {
 		ctx, cancel = context.WithTimeout(ctx, l.cfg.GlobalTimeout)
 		defer cancel()
 	}
-	return l.retriever.Retrieve(ctx, request, func(types.RetrievalEvent) {})
+	return l.retriever.Retrieve(ctx, request, eventsCb)
 }
 
 // RegisterSubscriber registers a subscriber to receive retrieval events.

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -237,7 +237,7 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 		request.PreloadLinkSystem.TrustedStorage = true
 
 		log.Debugw("fetching CID", "retrievalId", retrievalId, "CID", rootCid.String(), "path", unixfsPath, "carScope", carScope)
-		stats, err := lassie.Fetch(req.Context(), request)
+		stats, err := lassie.Fetch(req.Context(), request, func(types.RetrievalEvent) {})
 		if err != nil {
 			select {
 			case <-bytesWritten:


### PR DESCRIPTION
# Goals

The caller of Lassie fetch should be able to pass a per request callback

# Implementation

- Add as a parameter and pass through
- Add to places Lassie.Fetch is called