### PR TITLE
Allow overridden fixed peers per request

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -73,7 +73,7 @@ var fetchCmd = &cli.Command{
 			Name:        "providers",
 			Aliases:     []string{"provider"},
 			DefaultText: "Providers will be discovered automatically",
-			Usage:       "Provider addresses including its peer ID, seperated by a comma. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+			Usage:       "Addresses of providers, including peer IDs, to use instead of automatic discovery, seperated by a comma. All protocols will be attempted when connecting to these providers. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 			Action: func(cctx *cli.Context, v string) error {
 				var err error
 				fetchProviderAddrInfos, err = types.ParseProviderStrings(v)

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -75,15 +75,9 @@ var fetchCmd = &cli.Command{
 			DefaultText: "Providers will be discovered automatically",
 			Usage:       "Provider addresses including its peer ID, seperated by a comma. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 			Action: func(cctx *cli.Context, v string) error {
-				vs := strings.Split(v, ",")
-				for _, v := range vs {
-					fetchProviderAddrInfo, err := peer.AddrInfoFromString(v)
-					if err != nil {
-						return err
-					}
-					fetchProviderAddrInfos = append(fetchProviderAddrInfos, *fetchProviderAddrInfo)
-				}
-				return nil
+				var err error
+				fetchProviderAddrInfos, err = types.ParseProviderStrings(v)
+				return err
 			},
 		},
 		FlagEventRecorderAuth,

--- a/pkg/retriever/assignablecandidatefinder.go
+++ b/pkg/retriever/assignablecandidatefinder.go
@@ -10,6 +10,9 @@ import (
 	"github.com/filecoin-project/lassie/pkg/events"
 	"github.com/filecoin-project/lassie/pkg/internal/candidatebuffer"
 	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipni/go-libipni/metadata"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 type FilterIndexerCandidate func(types.RetrievalCandidate) (bool, types.RetrievalCandidate)
@@ -62,6 +65,9 @@ func (acf AssignableCandidateFinder) FindCandidates(ctx context.Context, request
 	}, acf.clock)
 
 	err := candidateBuffer.BufferStream(ctx, func(ctx context.Context, onNextCandidate candidatebuffer.OnNextCandidate) error {
+		if len(request.FixedPeers) > 0 {
+			return sendFixedPeers(request.Cid, request.FixedPeers, onNextCandidate)
+		}
 		return acf.candidateFinder.FindCandidatesAsync(ctx, request.Cid, onNextCandidate)
 	}, BufferWindow)
 
@@ -73,6 +79,18 @@ func (acf AssignableCandidateFinder) FindCandidates(ctx context.Context, request
 	if totalCandidates.Load() == 0 {
 		eventsCallback(events.Failed(acf.clock.Now(), request.RetrievalID, phaseStarted, types.IndexerPhase, types.RetrievalCandidate{RootCid: request.Cid}, ErrNoCandidates.Error()))
 		return ErrNoCandidates
+	}
+	return nil
+}
+
+func sendFixedPeers(requestCid cid.Cid, fixedPeers []peer.AddrInfo, onNextCandidate candidatebuffer.OnNextCandidate) error {
+	md := metadata.Default.New(&metadata.GraphsyncFilecoinV1{}, &metadata.Bitswap{})
+	for _, fixedPeer := range fixedPeers {
+		onNextCandidate(types.RetrievalCandidate{
+			MinerPeer: fixedPeer,
+			RootCid:   requestCid,
+			Metadata:  md,
+		})
 	}
 	return nil
 }

--- a/pkg/retriever/assignablecandidatefinder_test.go
+++ b/pkg/retriever/assignablecandidatefinder_test.go
@@ -26,6 +26,7 @@ func TestAssignableCandidateFinder(t *testing.T) {
 		candidateResults   map[cid.Cid][]string
 		candidateError     error
 		filteredPeers      []string
+		fixedPeers         map[cid.Cid][]string
 		expectedEvents     map[cid.Cid][]types.EventCode
 		expectedCandidates map[cid.Cid][]string
 		expectedErrors     map[cid.Cid]error
@@ -108,6 +109,25 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
 			},
 		},
+		{
+			name: "fixed peers",
+			candidateResults: map[cid.Cid][]string{
+				cid1: {"fiz", "bang", "booz"},
+				cid2: {"apples", "oranges", "cheese"},
+			},
+			expectedCandidates: map[cid.Cid][]string{
+				cid1: {"double", "trouble"},
+				cid2: {"super", "duper"},
+			},
+			fixedPeers: map[cid.Cid][]string{
+				cid1: {"double", "trouble"},
+				cid2: {"super", "duper"},
+			},
+			expectedEvents: map[cid.Cid][]types.EventCode{
+				cid1: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -122,6 +142,17 @@ func TestAssignableCandidateFinder(t *testing.T) {
 					candidateResults = append(candidateResults, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID(stringResult)}})
 				}
 				allCandidateResults[c] = candidateResults
+			}
+			if testCase.fixedPeers == nil {
+				testCase.fixedPeers = make(map[cid.Cid][]string)
+			}
+			allFixedPeers := make(map[cid.Cid][]peer.AddrInfo, len(testCase.fixedPeers))
+			for c, stringResults := range testCase.fixedPeers {
+				fixedPeers := make([]peer.AddrInfo, 0, len(stringResults))
+				for _, stringResult := range stringResults {
+					fixedPeers = append(fixedPeers, peer.AddrInfo{ID: peer.ID(stringResult)})
+				}
+				allFixedPeers[c] = fixedPeers
 			}
 			candidateFinder := testutil.NewMockCandidateFinder(testCase.candidateError, allCandidateResults)
 			isAcceptableStorageProvider := func(candidate types.RetrievalCandidate) (bool, types.RetrievalCandidate) {
@@ -152,10 +183,12 @@ func TestAssignableCandidateFinder(t *testing.T) {
 			candidateCollector := func(incoming []types.RetrievalCandidate) {
 				candidates = append(candidates, incoming...)
 			}
+
 			err = retrievalCandidateFinder.FindCandidates(ctx, types.RetrievalRequest{
 				RetrievalID: rid1,
 				Cid:         cid1,
 				LinkSystem:  cidlink.DefaultLinkSystem(),
+				FixedPeers:  allFixedPeers[cid1],
 			}, retrievalCollector, candidateCollector)
 			if err != nil {
 				receivedErrors[cid1] = err
@@ -169,6 +202,7 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				RetrievalID: rid2,
 				Cid:         cid2,
 				LinkSystem:  cidlink.DefaultLinkSystem(),
+				FixedPeers:  allFixedPeers[cid2],
 			}, retrievalCollector, candidateCollector)
 			if err != nil {
 				receivedErrors[cid2] = err

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -13,6 +13,7 @@ import (
 	ipldstorage "github.com/ipld/go-ipld-prime/storage"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multicodec"
 )
 
@@ -54,6 +55,7 @@ type RetrievalRequest struct {
 	Protocols         []multicodec.Code
 	PreloadLinkSystem ipld.LinkSystem
 	MaxBlocks         uint64
+	FixedPeers        []peer.AddrInfo
 }
 
 // NewRequestForPath creates a new RetrievalRequest from the provided parameters
@@ -144,4 +146,18 @@ func ParseProtocolsString(v string) ([]multicodec.Code, error) {
 		protocols = append(protocols, protocol)
 	}
 	return protocols, nil
+}
+
+func ParseProviderStrings(v string) ([]peer.AddrInfo, error) {
+	vs := strings.Split(v, ",")
+	providerAddrInfos := make([]peer.AddrInfo, 0, len(vs))
+
+	for _, v := range vs {
+		providerAddrInfo, err := peer.AddrInfoFromString(v)
+		if err != nil {
+			return nil, err
+		}
+		providerAddrInfos = append(providerAddrInfos, *providerAddrInfo)
+	}
+	return providerAddrInfos, nil
 }


### PR DESCRIPTION
# Goals

Adds a providers parameter to set fixed providers on a per request basis. Oft requested feature.