### PR TITLE
Ignore empty string env vars when we parse CLI flags

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -75,6 +75,11 @@ var fetchCmd = &cli.Command{
 			DefaultText: "Providers will be discovered automatically",
 			Usage:       "Addresses of providers, including peer IDs, to use instead of automatic discovery, seperated by a comma. All protocols will be attempted when connecting to these providers. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 			Action: func(cctx *cli.Context, v string) error {
+				// Do nothing if given an empty string
+				if v == "" {
+					return nil
+				}
+
 				var err error
 				fetchProviderAddrInfos, err = types.ParseProviderStrings(v)
 				return err

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -97,6 +97,11 @@ var FlagExcludeProviders = &cli.StringFlag{
 	Usage:       "Provider peer IDs, seperated by a comma. Example: 12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 	EnvVars:     []string{"LASSIE_EXCLUDE_PROVIDERS"},
 	Action: func(cctx *cli.Context, v string) error {
+		// Do nothing if given an empty string
+		if v == "" {
+			return nil
+		}
+
 		providerBlockList = make(map[peer.ID]bool)
 		vs := strings.Split(v, ",")
 		for _, v := range vs {
@@ -117,6 +122,11 @@ var FlagProtocols = &cli.StringFlag{
 	Usage:       "List of retrieval protocols to use, seperated by a comma",
 	EnvVars:     []string{"LASSIE_SUPPORTED_PROTOCOLS"},
 	Action: func(cctx *cli.Context, v string) error {
+		// Do nothing if given an empty string
+		if v == "" {
+			return nil
+		}
+
 		var err error
 		protocols, err = types.ParseProtocolsString(v)
 		return err


### PR DESCRIPTION
Ignores CLI flags that require parsing the flag value when the value of the flag is an empty string. This prevents environment variables that default to empty strings in build systems from erroring out when the empty string value is parsed as though it was a user provided value, as mentioned in #191.

Closes #191