### PR TITLE
fix(http): address client cancellation panic

### DIFF
--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -714,7 +714,7 @@ func TestHttpFetch(t *testing.T) {
 					req.Equal(http.StatusOK, resp.StatusCode)
 					body, err := io.ReadAll(resp.Body)
 					req.NoError(err)
-					resp.Body.Close()
+					err = resp.Body.Close()
 					req.NoError(err)
 
 					if testCase.validateBodies != nil && testCase.validateBodies[i] != nil {

--- a/pkg/server/http/client_close_test.go
+++ b/pkg/server/http/client_close_test.go
@@ -1,0 +1,92 @@
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/internal/itest/mocknet"
+	"github.com/filecoin-project/lassie/pkg/internal/itest/unixfs"
+	"github.com/filecoin-project/lassie/pkg/lassie"
+	"github.com/multiformats/go-multicodec"
+	"github.com/stretchr/testify/require"
+)
+
+// This test won't reliably fail but will be flaky if the handler performs any
+// writes after the request context has been cancelled.
+// > while (go test -run TestHttpClientClose -count 50) do :; done
+
+func TestHttpClientClose(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rndSeed := time.Now().UTC().UnixNano()
+	t.Logf("random seed: %d", rndSeed)
+	var rndReader io.Reader = rand.New(rand.NewSource(rndSeed))
+
+	mrn := mocknet.NewMockRetrievalNet(ctx, t)
+	mrn.AddBitswapPeers(1)
+	require.NoError(t, mrn.MN.LinkAll())
+
+	srcData := unixfs.GenerateFile(t, &mrn.Remotes[0].LinkSystem, rndReader, 20<<20)
+
+	// Setup a new lassie
+	req := require.New(t)
+	lassie, err := lassie.NewLassie(
+		ctx,
+		lassie.WithProviderTimeout(20*time.Second),
+		lassie.WithHost(mrn.Self),
+		lassie.WithFinder(mrn.Finder),
+		lassie.WithProtocols([]multicodec.Code{multicodec.TransportBitswap}),
+	)
+	req.NoError(err)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	handler := ipfsHandler(lassie, HttpServerConfig{TempDir: t.TempDir()})
+	response := &responseWriter{t: t, header: http.Header{}, ctx: reqCtx, cancelFn: reqCancel, fatalCh: make(chan struct{})}
+	addr := fmt.Sprintf("http://%s/ipfs/%s%s", "127.0.0.1", srcData.Root.String(), "")
+	request, err := http.NewRequestWithContext(reqCtx, "GET", addr, nil)
+	req.NoError(err)
+	request.Header.Add("Accept", "application/vnd.ipld.car")
+	handler(response, request)
+	close(response.fatalCh)
+}
+
+var _ http.ResponseWriter = (*responseWriter)(nil)
+
+type responseWriter struct {
+	t          *testing.T
+	wroteCount int
+	header     http.Header
+	ctx        context.Context
+	cancelFn   context.CancelFunc
+	fatalCh    chan struct{}
+}
+
+func (rw *responseWriter) Header() http.Header {
+	return rw.header
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	// check if rw.endedCh is closed and t.Fatal if it is
+	select {
+	case <-rw.fatalCh:
+		rw.t.Fatal("unexpected Write() call")
+		return 0, io.ErrClosedPipe
+	default:
+	}
+
+	rw.wroteCount += len(b)
+	if rw.wroteCount > 1<<20 {
+		rw.cancelFn()
+	}
+	return len(b), nil
+}
+
+func (rw *responseWriter) WriteHeader(statusCode int) {
+	rw.t.Fatal("unexpected WriteHeader() call")
+}


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/lassie/issues/211

I believe the issue in #211 is that client cancellation leaves open a brief window between request context cancel propagation through the retrieval system and the response cleanup by the http server, leading to a Write to a buffer that no longer exists.

I've added a test that simulates this and although it doesn't hit it perfectly each time it'll be quite flaky (50/50) when the problem persists. I started this test off as an itest, going through the whole http server setup and requesting with a client, and even though I could cause the exact panic, it was too unreliable for a test, so I've moved it closer and simulated the problem in the way I believe it's occurring.

The solution is to just stop the Write()s to the response as soon as the handler function exists—that's the point where we're not allowed to write anymore because it gets cleaned up. We already have a `defer` in there to `Close()` the temporary CAR store which is our primary write interface used by the retrievers, so we just swap out the block writer at that point with one that reports an error back up the stack and doesn't allow any more data through.