### PR TITLE
Revert use of pkg/aggregateeventrecorder to pkg/eventrecorder

### DIFF
--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
+	"github.com/filecoin-project/lassie/pkg/eventrecorder"
 	"github.com/filecoin-project/lassie/pkg/lassie"
 	"github.com/google/uuid"
 	logging "github.com/ipfs/go-log/v2"
@@ -102,12 +102,12 @@ func setupLassieEventRecorder(
 			instanceID = uuid.String() // returns "" if uuid is invalid
 		}
 
-		eventRecorder := aggregateeventrecorder.NewAggregateEventRecorder(ctx, aggregateeventrecorder.EventRecorderConfig{
+		eventRecorder := eventrecorder.NewEventRecorder(ctx, eventrecorder.EventRecorderConfig{
 			InstanceID:            instanceID,
 			EndpointURL:           eventRecorderURL,
 			EndpointAuthorization: authToken,
 		})
-		lassie.RegisterSubscriber(eventRecorder.RetrievalEventSubscriber())
+		lassie.RegisterSubscriber(eventRecorder.RecordEvent)
 		log.Infow("Reporting retrieval events to event recorder API", "url", eventRecorderURL, "instance_id", instanceID)
 	}
 }


### PR DESCRIPTION
This reverts the use of the aggregate event recorder to the event recorder without reverting any of the other commmits between v0.8.2 - v0.9.0. The instance was swapped in PR #218. That PR had no other edits to anything outside of the aggregate event recorder. 