### PR TITLE
fix(server-timings): lock header while inspecting/modifying Extra

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -241,6 +241,7 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 				return
 			}
 
+			header.Lock()
 			if header.Metrics != nil {
 				for _, m := range header.Metrics {
 					if m.Name == string(re.Phase()) {
@@ -248,10 +249,12 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 							m.Extra = map[string]string{}
 						}
 						m.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(re.PhaseStartTime()))
+						header.Unlock()
 						return
 					}
 				}
 			}
+			header.Unlock()
 
 			metric := header.NewMetric(string(re.Phase()))
 			metric.Duration = re.Time().Sub(re.PhaseStartTime())


### PR DESCRIPTION
Reported from Saturn:

```
fatal error: concurrent map writes

goroutine 8048914 [running]:
github.com/filecoin-project/lassie/pkg/server/http.ipfsHandler.func1.3({0x1831098, 0xc0268c0cf0})
        /github/workspace/pkg/server/http/ipfs.go:250 +0x346
github.com/filecoin-project/lassie/pkg/retriever.makeOnRetrievalEvent.func1({0x1831098?, 0xc0268c0cf0?})
        /github/workspace/pkg/retriever/retriever.go:226 +0x3ba
github.com/filecoin-project/lassie/pkg/retriever.collectResults({0x18252b0, 0xc001ee9600}, 0xc01c73f4c0, 0xc01b61dc20)
        /github/workspace/pkg/retriever/graphsyncretriever.go:242 +0x1bf
github.com/filecoin-project/lassie/pkg/retriever.(*graphsyncRetrieval).RetrieveFromAsyncCandidates(0xc0147c0500, 0xc01b61dec0)
        /github/workspace/pkg/retriever/graphsyncretriever.go:215 +0x458
github.com/filecoin-project/lassie/pkg/types.AsyncRetrievalTask.Run(...)
        /github/workspace/pkg/types/types.go:131
github.com/filecoin-project/lassie/pkg/retriever/coordinators.Race.func1.1.1()
        /github/workspace/pkg/retriever/coordinators/race.go:23 +0x90
created by github.com/filecoin-project/lassie/pkg/retriever/coordinators.Race.func1.1
        /github/workspace/pkg/retriever/coordinators/race.go:21 +0x105
```

`Header` has a lock: https://pkg.go.dev/github.com/mitchellh/go-server-timing@v1.0.1#Header and it's used for the `header.NewMetric` call just below this section, so this is a double-lock unfortunately.

Longer-term solution might be to go back to the state we had originally where this callback is only called on the goroutine of the caller, so there's no concurrent executions at all. I think we changed that when we added bitswap retriever and added the complexity of scheduling and racing.