### PR TITLE
Add HTTP integegration tests

### DIFF
--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -101,6 +101,13 @@ func TestHttpFetch(t *testing.T) {
 			},
 		},
 		{
+			name:        "http large directory",
+			httpRemotes: 1,
+			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
+				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, &remotes[0].LinkSystem, rndReader, 16<<20, false)}
+			},
+		},
+		{
 			name:             "graphsync large sharded directory",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
@@ -112,6 +119,13 @@ func TestHttpFetch(t *testing.T) {
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, true)}
+			},
+		},
+		{
+			name:        "http large sharded directory",
+			httpRemotes: 1,
+			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
+				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, &remotes[0].LinkSystem, rndReader, 16<<20, true)}
 			},
 		},
 		{

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -56,6 +56,7 @@ func TestHttpFetch(t *testing.T) {
 		name             string
 		graphsyncRemotes int
 		bitswapRemotes   int
+		httpRemotes      int
 		disableGraphsync bool
 		expectFail       bool
 		modifyHttpConfig func(httpserver.HttpServerConfig) httpserver.HttpServerConfig
@@ -76,6 +77,13 @@ func TestHttpFetch(t *testing.T) {
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)}
+			},
+		},
+		{
+			name:        "http large sharded file",
+			httpRemotes: 1,
+			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
+				return []unixfs.DirEntry{unixfs.GenerateFile(t, &remotes[0].LinkSystem, rndReader, 4<<20)}
 			},
 		},
 		{
@@ -636,6 +644,8 @@ func TestHttpFetch(t *testing.T) {
 				finishedChans = append(finishedChans, mocknet.SetupRetrieval(t, r))
 			}
 			mrn.AddBitswapPeers(testCase.bitswapRemotes)
+			mrn.AddHttpPeers(testCase.httpRemotes)
+
 			require.NoError(t, mrn.MN.LinkAll())
 
 			carFiles := debugRemotes(t, ctx, testCase.name, mrn.Remotes)

--- a/pkg/internal/itest/mocknet/mocknet.go
+++ b/pkg/internal/itest/mocknet/mocknet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	lpmock "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,26 +63,19 @@ func NewMockRetrievalNet(ctx context.Context, t *testing.T) *MockRetrievalNet {
 }
 
 func (mrn *MockRetrievalNet) AddBitswapPeers(n int) {
-	peers := mrn.testPeerGenerator.BitswapPeers(n)
-	for i := 0; i < n; i++ {
-		mrn.Remotes = append(mrn.Remotes, peers[i])
-		mrn.RemoteEvents = append(mrn.RemoteEvents, make([]datatransfer.Event, 0)) // not used for bitswap
-		mrn.FinishedChan = append(mrn.FinishedChan, make(chan struct{}, 1))        // not used for bitswap
-	}
+	mrn.addPeers(mrn.testPeerGenerator.BitswapPeers(n))
 }
 
 func (mrn *MockRetrievalNet) AddGraphsyncPeers(n int) {
-	peers := mrn.testPeerGenerator.GraphsyncPeers(n)
-	for i := 0; i < n; i++ {
-		mrn.Remotes = append(mrn.Remotes, peers[i])
-		mrn.RemoteEvents = append(mrn.RemoteEvents, make([]datatransfer.Event, 0))
-		mrn.FinishedChan = append(mrn.FinishedChan, make(chan struct{}, 1))
-	}
+	mrn.addPeers(mrn.testPeerGenerator.GraphsyncPeers(n))
 }
 
 func (mrn *MockRetrievalNet) AddHttpPeers(n int) {
-	peers := mrn.testPeerGenerator.HttpPeers(n)
-	for i := 0; i < n; i++ {
+	mrn.addPeers(mrn.testPeerGenerator.HttpPeers(n))
+}
+
+func (mrn *MockRetrievalNet) addPeers(peers []testpeer.TestPeer) {
+	for i := 0; i < len(peers); i++ {
 		mrn.Remotes = append(mrn.Remotes, peers[i])
 		mrn.RemoteEvents = append(mrn.RemoteEvents, make([]datatransfer.Event, 0))
 		mrn.FinishedChan = append(mrn.FinishedChan, make(chan struct{}, 1))
@@ -139,7 +133,9 @@ func (mrn *MockRetrievalNet) TearDown() error {
 			if h.BitswapNetwork != nil {
 				h.BitswapNetwork.Stop()
 			}
-			// TODO: teardown http server
+			if h.HttpServer != nil {
+				h.HttpServer.Close()
+			}
 		}(h)
 	}
 	wg.Wait()
@@ -155,12 +151,13 @@ func (mcf *mockCandidateFinder) FindCandidates(ctx context.Context, cid cid.Cid)
 	for _, h := range mcf.mrn.Remotes {
 		if _, has := h.Cids[cid]; has {
 			var md metadata.Metadata
-			if h.Bitswap {
+			switch h.Protocol {
+			case multicodec.TransportBitswap:
 				md = metadata.Default.New(metadata.Bitswap{})
-			} else if h.Http {
-				md = metadata.Default.New(&metadata.IpfsGatewayHttp{})
-			} else if h.Graphsync {
+			case multicodec.TransportGraphsyncFilecoinv1:
 				md = metadata.Default.New(&metadata.GraphsyncFilecoinV1{PieceCID: cid})
+			case multicodec.TransportIpfsGatewayHttp:
+				md = metadata.Default.New(&metadata.IpfsGatewayHttp{})
 			}
 			candidates = append(candidates, types.RetrievalCandidate{MinerPeer: *h.AddrInfo(), RootCid: cid, Metadata: md})
 		}

--- a/pkg/internal/itest/testpeer/peerhttpserver.go
+++ b/pkg/internal/itest/testpeer/peerhttpserver.go
@@ -1,0 +1,67 @@
+package testpeer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	servertiming "github.com/mitchellh/go-server-timing"
+)
+
+type TestPeerHttpServer struct {
+	cancel   context.CancelFunc
+	ctx      context.Context
+	listener net.Listener
+	server   *http.Server
+	Mux      *http.ServeMux
+}
+
+// NewTestPeerHttpServer creates a new HttpServer
+func NewTestPeerHttpServer(ctx context.Context, host string, port string) (*TestPeerHttpServer, error) {
+	addr := fmt.Sprintf("%s:%s", host, port)
+	listener, err := net.Listen("tcp", addr) // assigns a port if port is 0
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	// create server
+	mux := http.NewServeMux()
+	handler := servertiming.Middleware(mux, nil)
+	server := &http.Server{
+		Addr:        addr,
+		BaseContext: func(listener net.Listener) context.Context { return ctx },
+		Handler:     handler,
+	}
+
+	httpServer := &TestPeerHttpServer{
+		cancel:   cancel,
+		ctx:      ctx,
+		listener: listener,
+		server:   server,
+		Mux:      mux,
+	}
+
+	return httpServer, nil
+}
+
+// Start starts the http server, returning an error if the server failed to start
+func (s *TestPeerHttpServer) Start() error {
+	logger.Infow("starting test peer http server", "listen_addr", s.listener.Addr())
+	err := s.server.Serve(s.listener)
+	if err != http.ErrServerClosed {
+		logger.Errorw("failed to start test peer http server", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+// Close shutsdown the server and cancels the server context
+func (s *TestPeerHttpServer) Close() error {
+	logger.Info("closing test peer http server")
+	s.cancel()
+	return s.server.Shutdown(context.Background())
+}


### PR DESCRIPTION
Adds HTTP integration tests that test that Lassie can fetch a valid car over the HTTP protocol. Remote HTTP peers are generated with an http multiaddress and run an HTTP server on that address for serving valid cars.

### Notable Changes
- `itest/testpeer/generator.go` can now generate HTTP peers with an HTTP server that returns valid cars
- `itest/testpeer/mocknet.go` has been updated to add HTTP peers
- Added `itest/testpeer/peerhttpserver.go` to create separate http server instances for each peer, as well as manage start and teardown appropriately.