### PR TITLE
fix(httpretriever): add client headers

### DIFF
--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -27,6 +27,8 @@ var (
 
 const HttpDefaultInitialWait time.Duration = 0
 
+const DefaultUserAgent = "lassie"
+
 var _ TransportProtocol = &ProtocolHttp{}
 
 type ProtocolHttp struct {
@@ -180,6 +182,8 @@ func makeRequest(ctx context.Context, request types.RetrievalRequest, candidate 
 		return nil, fmt.Errorf("%w for peer %s: %v", ErrBadPathForRequest, candidate.MinerPeer.ID, err)
 	}
 	req.Header.Add("Accept", request.Scope.AcceptHeader())
+	req.Header.Add("User-Agent", DefaultUserAgent)
+	req.Header.Add("X-Request-Id", request.RetrievalID.String())
 
 	return req, nil
 }


### PR DESCRIPTION
From this comment by @willscott: https://github.com/filecoin-project/lassie/pull/193#discussion_r1187500928

We use `"lassie"` as our default when talking to the indexer so it seems reasonable. We could add a version too?