### PR TITLE
Standardize logger vars and names

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -161,7 +161,7 @@ func daemonCommand(cctx *cli.Context) error {
 	})
 
 	if err != nil {
-		log.Errorw("failed to create http server", "err", err)
+		logger.Errorw("failed to create http server", "err", err)
 		return err
 	}
 
@@ -178,7 +178,7 @@ func daemonCommand(cctx *cli.Context) error {
 		metricsServer, err = metrics.NewHttpServer(ctx, metricsAddress, metricsPort)
 
 		if err != nil {
-			log.Errorw("failed to create metrics server", "err", err)
+			logger.Errorw("failed to create metrics server", "err", err)
 			return err
 		}
 
@@ -192,20 +192,20 @@ func daemonCommand(cctx *cli.Context) error {
 	select {
 	case <-cctx.Done(): // command was cancelled
 	case err = <-serverErrChan: // error from server
-		log.Errorw("failed to start http server", "err", err)
+		logger.Errorw("failed to start http server", "err", err)
 	case err = <-metricsServerErrChan: // error from server
-		log.Errorw("failed to start metrics server", "err", err)
+		logger.Errorw("failed to start metrics server", "err", err)
 	}
 
 	fmt.Println("Shutting down Lassie daemon")
 	if err = httpServer.Close(); err != nil {
-		log.Errorw("failed to close http server", "err", err)
+		logger.Errorw("failed to close http server", "err", err)
 	}
 
 	if exposeMetrics {
 		fmt.Println("Shutting down Lassie metrics server")
 		if err = metricsServer.Close(); err != nil {
-			log.Errorw("failed to close metrics server", "err", err)
+			logger.Errorw("failed to close metrics server", "err", err)
 		}
 	}
 

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -141,23 +141,23 @@ func Fetch(cctx *cli.Context) error {
 	if len(fetchProviderAddrInfos) > 0 {
 		finderOpt := lassie.WithFinder(retriever.NewDirectCandidateFinder(host, fetchProviderAddrInfos))
 		if cctx.IsSet("ipni-endpoint") {
-			log.Warn("Ignoring ipni-endpoint flag since direct provider is specified")
+			logger.Warn("Ignoring ipni-endpoint flag since direct provider is specified")
 		}
 		lassieOpts = append(lassieOpts, finderOpt)
 	} else if cctx.IsSet("ipni-endpoint") {
 		endpoint := cctx.String("ipni-endpoint")
 		endpointUrl, err := url.Parse(endpoint)
 		if err != nil {
-			log.Errorw("Failed to parse IPNI endpoint as URL", "err", err)
+			logger.Errorw("Failed to parse IPNI endpoint as URL", "err", err)
 			return fmt.Errorf("cannot parse given IPNI endpoint %s as valid URL: %w", endpoint, err)
 		}
 		finder, err := indexerlookup.NewCandidateFinder(indexerlookup.WithHttpEndpoint(endpointUrl))
 		if err != nil {
-			log.Errorw("Failed to instantiate IPNI candidate finder", "err", err)
+			logger.Errorw("Failed to instantiate IPNI candidate finder", "err", err)
 			return err
 		}
 		lassieOpts = append(lassieOpts, lassie.WithFinder(finder))
-		log.Debug("Using explicit IPNI endpoint to find candidates", "endpoint", endpoint)
+		logger.Debug("Using explicit IPNI endpoint to find candidates", "endpoint", endpoint)
 	}
 
 	if len(providerBlockList) > 0 {

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -10,11 +10,11 @@ import (
 	"github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
 	"github.com/filecoin-project/lassie/pkg/lassie"
 	"github.com/google/uuid"
-	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
 )
 
-var log = logging.Logger("lassie")
+var logger = log.Logger("lassie/main")
 
 func main() {
 	// set up a context that is canceled when a command is interrupted
@@ -29,7 +29,7 @@ func main() {
 		select {
 		case <-interrupt:
 			fmt.Println()
-			log.Info("received interrupt signal")
+			logger.Info("received interrupt signal")
 			cancel()
 		case <-ctx.Done():
 		}
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	if err := app.RunContext(ctx, os.Args); err != nil {
-		log.Fatal(err)
+		logger.Fatal(err)
 	}
 }
 
@@ -78,7 +78,7 @@ func before(cctx *cli.Context) error {
 	// don't over-ride logging if set in the environment.
 	if os.Getenv("GOLOG_LOG_LEVEL") == "" {
 		for _, name := range subsystems {
-			_ = logging.SetLogLevel(name, level)
+			_ = log.SetLogLevel(name, level)
 		}
 	}
 
@@ -97,7 +97,7 @@ func setupLassieEventRecorder(
 		if instanceID == "" {
 			uuid, err := uuid.NewRandom()
 			if err != nil {
-				log.Warnw("failed to generate default event recorder instance ID UUID, no instance ID will be provided", "err", err)
+				logger.Warnw("failed to generate default event recorder instance ID UUID, no instance ID will be provided", "err", err)
 			}
 			instanceID = uuid.String() // returns "" if uuid is invalid
 		}
@@ -108,6 +108,6 @@ func setupLassieEventRecorder(
 			EndpointAuthorization: authToken,
 		})
 		lassie.RegisterSubscriber(eventRecorder.RetrievalEventSubscriber())
-		log.Infow("Reporting retrieval events to event recorder API", "url", eventRecorderURL, "instance_id", instanceID)
+		logger.Infow("Reporting retrieval events to event recorder API", "url", eventRecorderURL, "instance_id", instanceID)
 	}
 }

--- a/cmd/lassie/version.go
+++ b/cmd/lassie/version.go
@@ -25,8 +25,8 @@ var versionCmd = &cli.Command{
 
 func versionCommand(cctx *cli.Context) error {
 	if version == "" {
-		log.Warn("executable built without a version")
-		log.Warn("set version with `go build -ldflags=\"-X main.version=v0.0.0\"")
+		logger.Warn("executable built without a version")
+		logger.Warn("set version with `go build -ldflags=\"-X main.version=v0.0.0\"")
 		version = "[not set]"
 	}
 

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ipfs/go-log/v2"
 )
 
-var logging = log.Logger("aggregateeventrecorder")
+var logger = log.Logger("lassie/aggregateeventrecorder")
 
 const httpTimeout = 5 * time.Second
 const parallelPosters = 5
@@ -146,7 +146,7 @@ func (a *aggregateEventRecorder) ingestEvents() {
 			tempData, ok := eventTempMap[id]
 			if !ok {
 				if event.Code() == types.FinishedCode {
-					logging.Errorf("Received Finished event but can't find aggregate data. Skipping creation of aggregate event.")
+					logger.Errorf("Received Finished event but can't find aggregate data. Skipping creation of aggregate event.")
 				}
 				continue
 			}
@@ -270,13 +270,13 @@ func (a *aggregateEventRecorder) postEvents() {
 		case batchedData := <-a.postChan:
 			byts, err := json.Marshal(batchedEvents{batchedData})
 			if err != nil {
-				logging.Errorf("Failed to JSONify and encode event: %w", err.Error())
+				logger.Errorf("Failed to JSONify and encode event: %w", err.Error())
 				continue
 			}
 
 			req, err := http.NewRequest("POST", a.endpointURL, bytes.NewBufferString(string(byts)))
 			if err != nil {
-				logging.Errorf("Failed to create POST request for [%s]: %w", a.endpointURL, err.Error())
+				logger.Errorf("Failed to create POST request for [%s]: %w", a.endpointURL, err.Error())
 				continue
 			}
 
@@ -289,13 +289,13 @@ func (a *aggregateEventRecorder) postEvents() {
 
 			resp, err := client.Do(req)
 			if err != nil {
-				logging.Errorf("Failed to POST event to [%s]: %w", a.endpointURL, err.Error())
+				logger.Errorf("Failed to POST event to [%s]: %w", a.endpointURL, err.Error())
 				continue
 			}
 
 			defer resp.Body.Close() // error not so important at this point
 			if resp.StatusCode < 200 || resp.StatusCode > 299 {
-				logging.Errorf("Expected success response code from server, got: %s", http.StatusText(resp.StatusCode))
+				logger.Errorf("Expected success response code from server, got: %s", http.StatusText(resp.StatusCode))
 			}
 		}
 	}

--- a/pkg/eventrecorder/eventrecorder.go
+++ b/pkg/eventrecorder/eventrecorder.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/filecoin-project/lassie/pkg/events"
 	"github.com/filecoin-project/lassie/pkg/types"
-	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-log/v2"
 	"github.com/multiformats/go-multicodec"
 )
 
 var HttpTimeout = 5 * time.Second
 var ParallelPosters = 5
 
-var log = logging.Logger("eventrecorder")
+var logger = log.Logger("lassie/eventrecorder")
 
 type EventRecorderConfig struct {
 	DisableIndexerEvents  bool
@@ -209,13 +209,13 @@ func (er *EventRecorder) handleReports(client http.Client, reports []report) {
 
 	byts, err := json.Marshal(MultiEventReport{eventReports})
 	if err != nil {
-		log.Errorf("Failed to JSONify and encode event [%s]: %w", sources, err.Error())
+		logger.Errorf("Failed to JSONify and encode event [%s]: %w", sources, err.Error())
 		return
 	}
 
 	req, err := http.NewRequest("POST", er.cfg.EndpointURL, bytes.NewBufferString(string(byts)))
 	if err != nil {
-		log.Errorf("Failed to create POST request [%s] for recorder [%s]: %w", sources, er.cfg.EndpointURL, err.Error())
+		logger.Errorf("Failed to create POST request [%s] for recorder [%s]: %w", sources, er.cfg.EndpointURL, err.Error())
 		return
 	}
 
@@ -228,12 +228,12 @@ func (er *EventRecorder) handleReports(client http.Client, reports []report) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("Failed to POST event [%s] to recorder [%s]: %w", sources, er.cfg.EndpointURL, err.Error())
+		logger.Errorf("Failed to POST event [%s] to recorder [%s]: %w", sources, er.cfg.EndpointURL, err.Error())
 		return
 	}
 
 	defer resp.Body.Close() // error not so important at this point
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		log.Errorf("Expected success response code from event recorder server, got: %s", http.StatusText(resp.StatusCode))
+		logger.Errorf("Expected success response code from event recorder server, got: %s", http.StatusText(resp.StatusCode))
 	}
 }

--- a/pkg/eventrecorder/filelogserver/filelogserver.go
+++ b/pkg/eventrecorder/filelogserver/filelogserver.go
@@ -17,10 +17,10 @@ import (
 	"net/http"
 	"os"
 
-	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-log/v2"
 )
 
-var log = logging.Logger("filelogserver")
+var logger = log.Logger("lassie/filelogserver")
 
 func main() {
 	port := flag.Int("port", 8080, "set port to listen to")
@@ -31,7 +31,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	log.Infof("Writing to file %s", *output)
+	logger.Infof("Writing to file %s", *output)
 
 	http.HandleFunc("/retrieval-events", func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {
@@ -41,27 +41,27 @@ func main() {
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			log.Errorf("Could not decode body: %s", err.Error())
+			logger.Errorf("Could not decode body: %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		m := make(map[string]interface{})
 		err = json.Unmarshal(body, &m)
 		if err != nil {
-			log.Errorf("Could not decode body: %s", err.Error())
+			logger.Errorf("Could not decode body: %s", err.Error())
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		reencode, err := json.Marshal(m)
 		if err != nil {
-			log.Errorf("Error building log entry: %s", err.Error())
+			logger.Errorf("Error building log entry: %s", err.Error())
 			return
 		}
-		log.Debugf("Got: %s", string(reencode))
+		logger.Debugf("Got: %s", string(reencode))
 		outfile.WriteString(string(reencode))
 		outfile.Write([]byte{'\n'})
 	})
 
-	log.Infof("Listening on port %d", *port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+	logger.Infof("Listening on port %d", *port)
+	logger.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -24,7 +24,7 @@ import (
 var (
 	_ retriever.CandidateFinder = (*IndexerCandidateFinder)(nil)
 
-	logger = log.Logger("indexerlookup")
+	logger = log.Logger("lassie/indexerlookup")
 )
 
 type IndexerCandidateFinder struct {

--- a/pkg/internal/lp2ptransports/lp2ptransports.go
+++ b/pkg/internal/lp2ptransports/lp2ptransports.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 )
 
-var clog = logging.Logger("lassie:lp2p:tspt:client")
+var logger = log.Logger("lassie/lp2p/tspt/client")
 
 // TransportsProtocolID is the protocol for querying which retrieval transports
 // the Storage Provider supports (http, libp2p, etc)
@@ -35,7 +35,7 @@ func NewTransportsClient(h host.Host) *TransportsClient {
 
 // SendQuery sends a retrieval query over a libp2p stream to the peer
 func (c *TransportsClient) SendQuery(ctx context.Context, id peer.ID) (*QueryResponse, error) {
-	clog.Debugw("query", "peer", id)
+	logger.Debugw("query", "peer", id)
 
 	// Create a libp2p stream to the provider
 	s, err := c.h.NewStream(ctx, id, TransportsProtocolID)
@@ -56,7 +56,7 @@ func (c *TransportsClient) SendQuery(ctx context.Context, id peer.ID) (*QueryRes
 	}
 	queryResponse := queryResponsei.(*QueryResponse)
 
-	clog.Debugw("response", "peer", id)
+	logger.Debugw("response", "peer", id)
 
 	return queryResponse, nil
 }

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -4,13 +4,10 @@ import (
 	"net/http"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
-	logging "github.com/ipfs/go-log/v2"
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opencensus.io/stats/view"
 )
-
-var logger = logging.Logger("metrics")
 
 func NewExporter(views ...*view.View) http.Handler {
 	if err := view.Register(DefaultViews...); err != nil {

--- a/pkg/metrics/log.go
+++ b/pkg/metrics/log.go
@@ -1,0 +1,5 @@
+package metrics
+
+import "github.com/ipfs/go-log/v2"
+
+var logger = log.Logger("lassie/metrics")

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -8,11 +8,7 @@ import (
 
 	// expose default metrics
 	_ "net/http/pprof"
-
-	logging "github.com/ipfs/go-log/v2"
 )
-
-var log = logging.Logger("lassie/metrics")
 
 // MetricsServer simply exposes prometheus and pprof metrics via HTTP
 type MetricsServer struct {
@@ -59,10 +55,10 @@ func (s MetricsServer) Addr() string {
 
 // Start starts the metrics http server, returning an error if the server failed to start
 func (s *MetricsServer) Start() error {
-	log.Infow("starting metrics server", "listen_addr", s.listener.Addr())
+	logger.Infow("starting metrics server", "listen_addr", s.listener.Addr())
 	err := s.server.Serve(s.listener)
 	if err != http.ErrServerClosed {
-		log.Errorw("failed to start metrics server", "err", err)
+		logger.Errorw("failed to start metrics server", "err", err)
 		return err
 	}
 
@@ -71,7 +67,7 @@ func (s *MetricsServer) Start() error {
 
 // Close shutsdown the server and cancels the server context
 func (s *MetricsServer) Close() error {
-	log.Info("closing http server")
+	logger.Info("closing http server")
 	s.cancel()
 	return s.server.Shutdown(context.Background())
 }

--- a/pkg/retriever/bitswaphelpers/indexerrouting.go
+++ b/pkg/retriever/bitswaphelpers/indexerrouting.go
@@ -83,7 +83,7 @@ func (ir *IndexerRouting) FindProvidersAsync(ctx context.Context, c cid.Cid, max
 			}
 		}
 		ir.providerSetsLk.Unlock()
-		log.Debugw("provider records requested from bitswap, sending back indexer results", "providerCount", len(providers))
+		logger.Debugw("provider records requested from bitswap, sending back indexer results", "providerCount", len(providers))
 		for _, p := range providers {
 			select {
 			case <-ctx.Done():

--- a/pkg/retriever/bitswaphelpers/log.go
+++ b/pkg/retriever/bitswaphelpers/log.go
@@ -1,5 +1,5 @@
 package bitswaphelpers
 
-import logging "github.com/ipfs/go-log/v2"
+import "github.com/ipfs/go-log/v2"
 
-var log = logging.Logger("lassie/bitswap")
+var logger = log.Logger("lassie/bitswap")

--- a/pkg/retriever/bitswaphelpers/preloadcachingstorage.go
+++ b/pkg/retriever/bitswaphelpers/preloadcachingstorage.go
@@ -198,14 +198,14 @@ func (cs *PreloadCachingStorage) Preloader(preloadCtx preload.PreloadContext, li
 
 	// check parent
 	if has, err := linkSystemHas(cs.parentLinkSystem, linkCtx, link.Link); err != nil {
-		log.Errorf("parent LinkSystem block existence check failed: %s", err.Error())
+		logger.Errorf("parent LinkSystem block existence check failed: %s", err.Error())
 	} else if has {
 		return
 	}
 
 	// check cache
 	if has, err := linkSystemHas(cs.cacheLinkSystem, linkCtx, link.Link); err != nil {
-		log.Errorf("cache LinkSystem block existence check failed: %s", err.Error())
+		logger.Errorf("cache LinkSystem block existence check failed: %s", err.Error())
 	} else if has {
 		return
 	}

--- a/pkg/retriever/directcandidatefinder.go
+++ b/pkg/retriever/directcandidatefinder.go
@@ -96,11 +96,11 @@ func (d *DirectCandidateFinder) FindCandidatesAsync(ctx context.Context, c cid.C
 			transportsClient := lp2ptransports.NewTransportsClient(d.h)
 			qr, err := transportsClient.SendQuery(ctx, provider.ID)
 			if err == nil {
-				log.Debugw("retrieving metadata from transports protocol", "peer", provider.ID)
+				logger.Debugw("retrieving metadata from transports protocol", "peer", provider.ID)
 				// if present, construct metadata from Boost libp2p transports response
 				d.retrievalCandidatesFromTransportsProtocol(ctx, qr, provider, cs)
 			} else {
-				log.Debugw("retrieving metadata from libp2p protocol list", "peer", provider.ID)
+				logger.Debugw("retrieving metadata from libp2p protocol list", "peer", provider.ID)
 				// if not present, just make guesses based on list of supported libp2p
 				// protocols catalogued via identify protocol
 				d.retrievalCandidatesFromProtocolProbing(ctx, provider, cs)

--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -190,7 +190,7 @@ func (pg *ProtocolGraphsync) retrievalPhase(
 		ss = string(byts)
 	}
 
-	log.Infof(
+	logger.Infof(
 		"Attempting retrieval from SP %s for %s (with selector: [%s])",
 		candidate.MinerPeer.ID,
 		candidate.RootCid,

--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -163,20 +163,20 @@ func (ph *ProtocolHttp) beginRequest(ctx context.Context, request types.Retrieva
 func makeRequest(ctx context.Context, request types.RetrievalRequest, candidate types.RetrievalCandidate) (*http.Request, error) {
 	candidateURL, err := candidate.ToURL()
 	if err != nil {
-		log.Warnf("Couldn't construct a url for miner %s: %v", candidate.MinerPeer.ID, err)
+		logger.Warnf("Couldn't construct a url for miner %s: %v", candidate.MinerPeer.ID, err)
 		return nil, fmt.Errorf("%w: %v", ErrNoHttpForPeer, err)
 	}
 
 	path, err := request.GetUrlPath()
 	if err != nil {
-		log.Warnf("Couldn't construct a url path for request: %v", err)
+		logger.Warnf("Couldn't construct a url path for request: %v", err)
 		return nil, fmt.Errorf("%w: %v", ErrBadPathForRequest, err)
 	}
 
 	reqURL := fmt.Sprintf("%s/ipfs/%s%s", candidateURL, request.Cid, path)
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
-		log.Warnf("Couldn't construct a http request %s: %v", candidate.MinerPeer.ID, err)
+		logger.Warnf("Couldn't construct a http request %s: %v", candidate.MinerPeer.ID, err)
 		return nil, fmt.Errorf("%w for peer %s: %v", ErrBadPathForRequest, candidate.MinerPeer.ID, err)
 	}
 	req.Header.Add("Accept", request.Scope.AcceptHeader())

--- a/pkg/retriever/log.go
+++ b/pkg/retriever/log.go
@@ -1,5 +1,5 @@
 package retriever
 
-import logging "github.com/ipfs/go-log/v2"
+import "github.com/ipfs/go-log/v2"
 
-var log = logging.Logger("retriever")
+var logger = log.Logger("lassie/retriever")

--- a/pkg/retriever/parallelpeerretriever.go
+++ b/pkg/retriever/parallelpeerretriever.go
@@ -164,7 +164,7 @@ func (retrieval *retrieval) RetrieveFromAsyncCandidates(asyncCandidates types.In
 	select {
 	case <-finishAll:
 	case <-time.After(100 * time.Millisecond):
-		log.Warn("Unable to successfully cancel all retrieval attempts withing 100ms")
+		logger.Warn("Unable to successfully cancel all retrieval attempts withing 100ms")
 	}
 	return stats, err
 }
@@ -287,7 +287,7 @@ func (retrieval *retrieval) runRetrievalCandidate(
 	err := retrieval.Protocol.Connect(connectCtx, retrieval, candidate)
 	if err != nil {
 		if ctx.Err() == nil { // not cancelled, maybe timed out though
-			log.Warnf("Failed to connect to SP %s: %v", candidate.MinerPeer.ID, err)
+			logger.Warnf("Failed to connect to SP %s: %v", candidate.MinerPeer.ID, err)
 			retrievalErr = fmt.Errorf("%w: %v", ErrConnectFailed, err)
 			session.sendEvent(events.Failed(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, phaseStartTime, types.RetrievalPhase, candidate, retrievalErr.Error()))
 		}

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -136,7 +136,7 @@ func (retriever *Retriever) Retrieve(
 	}
 	defer func() {
 		if err := retriever.session.EndRetrieval(request.RetrievalID); err != nil {
-			log.Errorf("failed to end retrieval tracking for %s: %s", request.Cid, err.Error())
+			logger.Errorf("failed to end retrieval tracking for %s: %s", request.Cid, err.Error())
 		}
 	}()
 
@@ -172,7 +172,7 @@ func (retriever *Retriever) Retrieve(
 	}
 
 	// success
-	log.Infof(
+	logger.Infof(
 		"Successfully retrieved from miner %s for %s\n"+
 			"\tDuration: %s\n"+
 			"\tBytes Received: %s\n"+
@@ -257,7 +257,7 @@ func handleFailureEvent(
 		}
 	case types.RetrievalPhase:
 		eventStats.failedCount++
-		log.Warnf(
+		logger.Warnf(
 			"Failed to retrieve from miner %s for %s: %s",
 			event.StorageProviderId(),
 			event.PayloadCid(),
@@ -300,7 +300,7 @@ func handleCandidatesFilteredEvent(
 			ids = append(ids, c.MinerPeer.ID)
 		}
 		if err := session.AddToRetrieval(retrievalId, ids); err != nil {
-			log.Errorf("failed to add storage providers to tracked retrieval for %s: %s", retrievalCid, err.Error())
+			logger.Errorf("failed to add storage providers to tracked retrieval for %s: %s", retrievalCid, err.Error())
 		}
 	}
 }
@@ -345,5 +345,5 @@ func logEvent(event types.RetrievalEvent) {
 	case events.RetrievalEventSuccess:
 		logadd("receivedSize", tevent.ReceivedSize())
 	}
-	log.Debugw("retrieval-event", kv...)
+	logger.Debugw("retrieval-event", kv...)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -7,14 +7,14 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipni/go-libipni/metadata"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multicodec"
 )
 
-var log = logging.Logger("lassie/session")
+var logger = log.Logger("lassie/session")
 
 type State interface {
 	RecordFailure(storageProviderId peer.ID, retrievalId types.RetrievalID) error
@@ -139,7 +139,7 @@ func (s *Session) IsAcceptableQueryResponse(peer peer.ID, req types.RetrievalReq
 
 	acceptable := s.config.PaidRetrievals || big.Add(big.Mul(queryResponse.MinPricePerByte, big.NewIntUnsigned(queryResponse.Size)), queryResponse.UnsealPrice).Equals(big.Zero())
 	if !acceptable {
-		log.Debugf("skipping query response from %s for %s: paid retrieval not allowed", peer, req.Cid)
+		logger.Debugf("skipping query response from %s for %s: paid retrieval not allowed", peer, req.Cid)
 		s.State.RemoveStorageProviderFromRetrieval(peer, req.RetrievalID)
 	}
 	return acceptable

--- a/pkg/session/sptracker.go
+++ b/pkg/session/sptracker.go
@@ -211,7 +211,7 @@ func (spt *spTracker) RecordFailure(storageProviderId peer.ID, retrievalId types
 	}
 
 	if status.isSuspended() {
-		log.Warnf(
+		logger.Warnf(
 			"Suspending storage provider for %s after %d failures within %s: %s",
 			status.suspensionDuration,
 			len(status.failures),


### PR DESCRIPTION
Some loggers didn't have the `lassie/` prefix making it difficult to review Saturn logs and determine which logs were lassie related. I opted for the clean import of `github.com/ipfs/go-log/v2` and naming our Loggers `logger`.