### PR TITLE
Update car-scope to dag-scope

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -55,17 +55,17 @@ var fetchCmd = &cli.Command{
 			Usage:   "print progress output",
 		},
 		&cli.StringFlag{
-			Name:        "car-scope",
-			Usage:       "describes the fetch behavior at the end of the traversal path. Valid values include [all, file, block].",
+			Name:        "dag-scope",
+			Usage:       "describes the fetch behavior at the end of the traversal path. Valid values include [all, entity, block].",
 			DefaultText: "defaults to all, the entire DAG at the end of the path will be fetched",
 			Value:       "all",
 			Action: func(cctx *cli.Context, v string) error {
 				switch v {
-				case string(types.CarScopeAll):
-				case string(types.CarScopeFile):
-				case string(types.CarScopeBlock):
+				case string(types.DagScopeAll):
+				case string(types.DagScopeEntity):
+				case string(types.DagScopeBlock):
 				default:
-					return fmt.Errorf("invalid car-scope parameter, must be of value [all, file, block]")
+					return fmt.Errorf("invalid dag-scope parameter, must be of value [all, entity, block]")
 				}
 
 				return nil
@@ -117,7 +117,7 @@ func Fetch(cctx *cli.Context) error {
 	progress := cctx.Bool("progress")
 	providerTimeout := cctx.Duration("provider-timeout")
 	globalTimeout := cctx.Duration("global-timeout")
-	carScope := cctx.String("car-scope")
+	dagScope := cctx.String("dag-scope")
 	tempDir := cctx.String("tempdir")
 	bitswapConcurrency := cctx.Int("bitswap-concurrency")
 	eventRecorderURL := cctx.String("event-recorder-url")
@@ -230,7 +230,7 @@ func Fetch(cctx *cli.Context) error {
 		}
 	}, false)
 
-	request, err := types.NewRequestForPath(carStore, rootCid, path, types.CarScope(carScope))
+	request, err := types.NewRequestForPath(carStore, rootCid, path, types.DagScope(dagScope))
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/itest/direct_fetch_test.go
+++ b/pkg/internal/itest/direct_fetch_test.go
@@ -116,7 +116,7 @@ func TestDirectFetch(t *testing.T) {
 			}()
 			outCar, err := storage.NewReadableWritable(outFile, []cid.Cid{srcData1.Root}, carv2.WriteAsCarV1(true))
 			req.NoError(err)
-			request, err := types.NewRequestForPath(outCar, srcData1.Root, "", types.CarScopeAll)
+			request, err := types.NewRequestForPath(outCar, srcData1.Root, "", types.DagScopeAll)
 			req.NoError(err)
 			_, err = lassie.Fetch(ctx, request, func(types.RetrievalEvent) {})
 			req.NoError(err)

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -43,11 +43,11 @@ import (
 const DEBUG_DATA = true
 
 func TestHttpFetch(t *testing.T) {
-	fileQuery := func(q url.Values, _ []testpeer.TestPeer) {
-		q.Set("car-scope", "file")
+	entityQuery := func(q url.Values, _ []testpeer.TestPeer) {
+		q.Set("dag-scope", "entity")
 	}
 	blockQuery := func(q url.Values, _ []testpeer.TestPeer) {
-		q.Set("car-scope", "block")
+		q.Set("dag-scope", "block")
 	}
 
 	type queryModifier func(url.Values, []testpeer.TestPeer)
@@ -191,32 +191,32 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			// car-scope file fetch should get the same DAG as full for a plain file
-			name:             "graphsync large sharded file, car-scope file",
+			// dag-scope entity fetch should get the same DAG as full for a plain file
+			name:             "graphsync large sharded file, dag-scope entity",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)}
 			},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 		},
 		{
-			// car-scope file fetch should get the same DAG as full for a plain file
-			name:           "bitswap large sharded file, car-scope file",
+			// dag-scope entity fetch should get the same DAG as full for a plain file
+			name:           "bitswap large sharded file, dag-scope entity",
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)}
 			},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 		},
 		{
-			name:             "graphsync nested large sharded file, with path, car-scope file",
+			name:             "graphsync nested large sharded file, with path, dag-scope entity",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem
 				return []unixfs.DirEntry{unixfs.WrapContent(t, rndReader, lsys, unixfs.GenerateFile(t, lsys, rndReader, 4<<20))}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -229,14 +229,14 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:           "bitswap nested large sharded file, with path, car-scope file",
+			name:           "bitswap nested large sharded file, with path, dag-scope entity",
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem
 				return []unixfs.DirEntry{unixfs.WrapContent(t, rndReader, lsys, unixfs.GenerateFile(t, lsys, rndReader, 4<<20))}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -249,38 +249,38 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:             "graphsync large directory, car-scope file",
+			name:             "graphsync large directory, dag-scope entity",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, false)}
 			},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				// expect a CAR of one block, to represent the root directory we asked for
 				validateCarBody(t, body, srcData.Root, []cid.Cid{srcData.Root}, true)
 			}},
 		},
 		{
-			name:           "bitswap large directory, car-scope file",
+			name:           "bitswap large directory, dag-scope entity",
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, false)}
 			},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				// expect a CAR of one block, to represent the root directory we asked for
 				validateCarBody(t, body, srcData.Root, []cid.Cid{srcData.Root}, true)
 			}},
 		},
 		{
-			name:             "graphsync nested large directory, with path, car-scope file",
+			name:             "graphsync nested large directory, with path, dag-scope entity",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem
 				return []unixfs.DirEntry{unixfs.WrapContent(t, rndReader, lsys, unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, false))}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -293,14 +293,14 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:           "bitswap nested large directory, with path, car-scope file",
+			name:           "bitswap nested large directory, with path, dag-scope entity",
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem
 				return []unixfs.DirEntry{unixfs.WrapContent(t, rndReader, lsys, unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, false))}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -328,7 +328,7 @@ func TestHttpFetch(t *testing.T) {
 				},
 					srcData.Children[1].Children[1].Children[1].SelfCids..., // unixfs.WrapPath (full dir)
 				)
-				// validate we got the car-scope file form
+				// validate we got the dag-scope entity form
 				validateCarBody(t, body, srcData.Root, wantCids, false)
 				// validate that we got the full depth form under the path
 				gotDir := unixfs.CarToDirEntry(t, bytes.NewReader(body), srcData.Children[1].Children[1].Children[1].Root, true)
@@ -352,7 +352,7 @@ func TestHttpFetch(t *testing.T) {
 				},
 					srcData.Children[1].Children[1].Children[1].SelfCids..., // unixfs.WrapPath (full dir)
 				)
-				// validate we got the car-scope file form
+				// validate we got the dag-scope entity form
 				validateCarBody(t, body, srcData.Root, wantCids, false)
 				// validate that we got the full depth form under the path
 				gotDir := unixfs.CarToDirEntry(t, bytes.NewReader(body), srcData.Children[1].Children[1].Children[1].Root, true)
@@ -361,12 +361,12 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:             "graphsync nested large sharded directory, car-scope file",
+			name:             "graphsync nested large sharded directory, dag-scope entity",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, true)}
 			},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				// sharded directory contains multiple blocks, so we expect a CAR with
 				// exactly those blocks
@@ -374,12 +374,12 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:           "bitswap nested large sharded directory, car-scope file",
+			name:           "bitswap nested large sharded directory, dag-scope entity",
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, true)}
 			},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				// sharded directory contains multiple blocks, so we expect a CAR with
 				// exactly those blocks
@@ -387,14 +387,14 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:             "graphsync nested large sharded directory, with path, car-scope file",
+			name:             "graphsync nested large sharded directory, with path, dag-scope entity",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem
 				return []unixfs.DirEntry{unixfs.WrapContent(t, rndReader, lsys, unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, true))}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -407,14 +407,14 @@ func TestHttpFetch(t *testing.T) {
 			}},
 		},
 		{
-			name:           "bitswap nested large sharded directory, with path, car-scope file",
+			name:           "bitswap nested large sharded directory, with path, dag-scope entity",
 			bitswapRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem
 				return []unixfs.DirEntry{unixfs.WrapContent(t, rndReader, lsys, unixfs.GenerateDirectory(t, remotes[0].LinkSystem, rndReader, 16<<20, true))}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -442,7 +442,7 @@ func TestHttpFetch(t *testing.T) {
 				},
 					srcData.Children[1].Children[1].Children[1].SelfCids..., // unixfs.WrapPath (full dir)
 				)
-				// validate we got the car-scope file form
+				// validate we got the dag-scope entity form
 				validateCarBody(t, body, srcData.Root, wantCids, false)
 				// validate that we got the full depth form under the path
 				gotDir := unixfs.CarToDirEntry(t, bytes.NewReader(body), srcData.Children[1].Children[1].Children[1].Root, true)
@@ -466,7 +466,7 @@ func TestHttpFetch(t *testing.T) {
 				},
 					srcData.Children[1].Children[1].Children[1].SelfCids..., // unixfs.WrapPath (full dir)
 				)
-				// validate we got the car-scope file form
+				// validate we got the dag-scope entity form
 				validateCarBody(t, body, srcData.Root, wantCids, false)
 				// validate that we got the full depth form under the path
 				gotDir := unixfs.CarToDirEntry(t, bytes.NewReader(body), srcData.Children[1].Children[1].Children[1].Root, true)
@@ -479,7 +479,7 @@ func TestHttpFetch(t *testing.T) {
 			// then we also make sure the root is in all of them, so the CandidateFinder will return them
 			// all. The retriever should then form a swarm of 4 peers and fetch the content from across
 			// the set.
-			name:           "bitswap, nested large sharded directory, spread across multiple peers, with path, car-scope file",
+			name:           "bitswap, nested large sharded directory, spread across multiple peers, with path, dag-scope entity",
 			bitswapRemotes: 4,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				// rotating linksystem - each block will be written to a different remote
@@ -513,7 +513,7 @@ func TestHttpFetch(t *testing.T) {
 				return []unixfs.DirEntry{data}
 			},
 			paths:         []string{unixfs.WrapPath},
-			modifyQueries: []queryModifier{fileQuery},
+			modifyQueries: []queryModifier{entityQuery},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				wantCids := append([]cid.Cid{
 					srcData.Root,                         // "/""
@@ -569,8 +569,8 @@ func TestHttpFetch(t *testing.T) {
 			},
 		},
 		{
-			// car-scope block fetch should only get the the root node for a plain file
-			name:             "graphsync large sharded file, car-scope block",
+			// dag-scope block fetch should only get the the root node for a plain file
+			name:             "graphsync large sharded file, dag-scope block",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)}
@@ -586,7 +586,7 @@ func TestHttpFetch(t *testing.T) {
 			},
 		},
 		{
-			name:             "graphsync nested large sharded file, with path, car-scope block",
+			name:             "graphsync nested large sharded file, with path, dag-scope block",
 			graphsyncRemotes: 1,
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				lsys := remotes[0].LinkSystem

--- a/pkg/internal/itest/testpeer/generator.go
+++ b/pkg/internal/itest/testpeer/generator.go
@@ -355,31 +355,31 @@ func MockIpfsHandler(ctx context.Context, lsys linking.LinkSystem) func(http.Res
 			unixfsPath = "/" + strings.Join(urlPath[2:], "/")
 		}
 
-		// We're always providing the car-scope parameter, so add a failure case if we stop
+		// We're always providing the dag-scope parameter, so add a failure case if we stop
 		// providing it in the future
-		if !req.URL.Query().Has("car-scope") {
-			http.Error(res, "Missing car-scope parameter", http.StatusBadRequest)
+		if !req.URL.Query().Has("dag-scope") {
+			http.Error(res, "Missing dag-scope parameter", http.StatusBadRequest)
 			return
 		}
 
 		// Parse car scope and use it to get selector
-		var carScope types.CarScope
-		switch req.URL.Query().Get("car-scope") {
+		var dagScope types.DagScope
+		switch req.URL.Query().Get("dag-scope") {
 		case "all":
-			carScope = types.CarScopeAll
-		case "file":
-			carScope = types.CarScopeFile
+			dagScope = types.DagScopeAll
+		case "entity":
+			dagScope = types.DagScopeEntity
 		case "block":
-			carScope = types.CarScopeBlock
+			dagScope = types.DagScopeBlock
 		default:
-			http.Error(res, fmt.Sprintf("Invalid car-scope parameter: %s", req.URL.Query().Get("car-scope")), http.StatusBadRequest)
+			http.Error(res, fmt.Sprintf("Invalid dag-scope parameter: %s", req.URL.Query().Get("dag-scope")), http.StatusBadRequest)
 			return
 		}
 
-		selNode := unixfsnode.UnixFSPathSelectorBuilder(unixfsPath, carScope.TerminalSelectorSpec(), false)
+		selNode := unixfsnode.UnixFSPathSelectorBuilder(unixfsPath, dagScope.TerminalSelectorSpec(), false)
 		sel, err := selector.CompileSelector(selNode)
 		if err != nil {
-			http.Error(res, fmt.Sprintf("Failed to compile selector from car-scope: %v", err), http.StatusInternalServerError)
+			http.Error(res, fmt.Sprintf("Failed to compile selector from dag-scope: %v", err), http.StatusInternalServerError)
 			return
 		}
 

--- a/pkg/retriever/httpretriever_test.go
+++ b/pkg/retriever/httpretriever_test.go
@@ -61,7 +61,7 @@ func TestHTTPRetriever(t *testing.T) {
 		name           string
 		requests       map[cid.Cid]types.RetrievalID
 		requestPath    map[cid.Cid]string
-		requestScope   map[cid.Cid]types.CarScope
+		requestScope   map[cid.Cid]types.DagScope
 		remotes        map[cid.Cid][]testutil.MockRoundTripRemote
 		expectedStats  map[cid.Cid]*types.RetrievalStats
 		expectedErrors map[cid.Cid]struct{}

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -51,7 +51,7 @@ type RetrievalRequest struct {
 	LinkSystem        ipld.LinkSystem
 	Selector          ipld.Node
 	Path              string
-	Scope             CarScope
+	Scope             DagScope
 	Protocols         []multicodec.Code
 	PreloadLinkSystem ipld.LinkSystem
 	MaxBlocks         uint64
@@ -65,7 +65,7 @@ type RetrievalRequest struct {
 // and writing and it is explicitly set to be trusted (i.e. it will not
 // check CIDs match bytes). If the storage is not truested,
 // request.LinkSystem.TrustedStore should be set to false after this call.
-func NewRequestForPath(store ipldstorage.WritableStorage, cid cid.Cid, path string, carScope CarScope) (RetrievalRequest, error) {
+func NewRequestForPath(store ipldstorage.WritableStorage, cid cid.Cid, path string, dagScope DagScope) (RetrievalRequest, error) {
 	retrievalId, err := NewRetrievalID()
 	if err != nil {
 		return RetrievalRequest{}, err
@@ -83,7 +83,7 @@ func NewRequestForPath(store ipldstorage.WritableStorage, cid cid.Cid, path stri
 		RetrievalID: retrievalId,
 		Cid:         cid,
 		Path:        path,
-		Scope:       carScope,
+		Scope:       dagScope,
 		LinkSystem:  linkSystem,
 	}, nil
 }
@@ -108,9 +108,14 @@ func (r RetrievalRequest) GetUrlPath() (string, error) {
 	}
 	scope := r.Scope
 	if r.Scope == "" {
-		scope = CarScopeAll
+		scope = DagScopeAll
 	}
-	return fmt.Sprintf("%s?car-scope=%s", r.Path, scope), nil
+	// TODO: remove once relevant endpoints support dag-scope
+	legacyScope := string(scope)
+	if legacyScope == string(DagScopeEntity) {
+		legacyScope = "file"
+	}
+	return fmt.Sprintf("%s?dag-scope=%s&car-scope=%s", r.Path, scope, legacyScope), nil
 }
 
 // GetSupportedProtocols will safely return the supported protocols for a specific request.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -287,31 +287,31 @@ func RetrievalIDFromContext(ctx context.Context) (RetrievalID, error) {
 	return id, nil
 }
 
-type CarScope string
+type DagScope string
 
-const CarScopeAll CarScope = "all"
-const CarScopeFile CarScope = "file"
-const CarScopeBlock CarScope = "block"
+const DagScopeAll DagScope = "all"
+const DagScopeEntity DagScope = "entity"
+const DagScopeBlock DagScope = "block"
 
 var matcherSelector = builder.NewSelectorSpecBuilder(basicnode.Prototype.Any).Matcher()
 
-func (cs CarScope) TerminalSelectorSpec() builder.SelectorSpec {
-	switch cs {
-	case CarScopeAll:
+func (ds DagScope) TerminalSelectorSpec() builder.SelectorSpec {
+	switch ds {
+	case DagScopeAll:
 		return unixfsnode.ExploreAllRecursivelySelector
-	case CarScopeFile:
+	case DagScopeEntity:
 		return unixfsnode.MatchUnixFSPreloadSelector // file
-	case CarScopeBlock:
+	case DagScopeBlock:
 		return matcherSelector
-	case CarScope(""):
-		return unixfsnode.ExploreAllRecursivelySelector // default to explore-all for zero-value CarScope
+	case DagScope(""):
+		return unixfsnode.ExploreAllRecursivelySelector // default to explore-all for zero-value DagScope
 	}
-	panic(fmt.Sprintf("unknown CarScope: [%s]", string(cs)))
+	panic(fmt.Sprintf("unknown DagScope: [%s]", string(ds)))
 }
 
-func (cs CarScope) AcceptHeader() string {
-	switch cs {
-	case CarScopeBlock:
+func (ds DagScope) AcceptHeader() string {
+	switch ds {
+	case DagScopeBlock:
 		return "application/vnd.ipld.block"
 	default:
 		return "application/vnd.ipld.car"


### PR DESCRIPTION
# Goals

fix #238 - update to latest IPIP-402 renames, namely car-scope becomes dag-scope.

# Implementation

- rename carScope to dagScope throughout code base
- on incoming request handler, support both params being passed for now
- when making outgoing http requests, send both params for now (Web3.storage is not up to date)