### PR TITLE
fix: http headers getting sent too late

### DIFF
--- a/pkg/storage/deferredcarwriter.go
+++ b/pkg/storage/deferredcarwriter.go
@@ -87,11 +87,6 @@ func (dcw *DeferredCarWriter) Put(ctx context.Context, key string, content []byt
 	dcw.lk.Lock()
 	defer dcw.lk.Unlock()
 
-	writer, err := dcw.writer()
-	if err != nil {
-		return err
-	}
-
 	if dcw.putCb != nil {
 		// call all callbacks, remove those that were only needed once
 		for i := 0; i < len(dcw.putCb); i++ {
@@ -102,6 +97,12 @@ func (dcw *DeferredCarWriter) Put(ctx context.Context, key string, content []byt
 				i--
 			}
 		}
+	}
+
+	// first Put() call, initialise writer, which will write a CARv1 header
+	writer, err := dcw.writer()
+	if err != nil {
+		return err
 	}
 
 	return writer.Put(ctx, key, content)

--- a/pkg/storage/deferredcarwriter_test.go
+++ b/pkg/storage/deferredcarwriter_test.go
@@ -163,6 +163,7 @@ func TestDeferredCarWriterPutCb(t *testing.T) {
 	cw.OnPut(func(ii int) {
 		switch pc1 {
 		case 0:
+			require.Equal(t, buf.Len(), 0) // called before first write
 			require.Equal(t, len(testData1), ii)
 		case 1:
 			require.Equal(t, len(testData2), ii)
@@ -175,6 +176,7 @@ func TestDeferredCarWriterPutCb(t *testing.T) {
 	cw.OnPut(func(ii int) {
 		switch pc2 {
 		case 0:
+			require.Equal(t, buf.Len(), 0) // called before first write
 			require.Equal(t, len(testData1), ii)
 		case 1:
 			require.Equal(t, len(testData2), ii)
@@ -187,6 +189,7 @@ func TestDeferredCarWriterPutCb(t *testing.T) {
 	cw.OnPut(func(ii int) {
 		switch pc3 {
 		case 0:
+			require.Equal(t, buf.Len(), 0) // called before first write
 			require.Equal(t, len(testData1), ii)
 		default:
 			require.Fail(t, "unexpected put callback")


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/lassie/issues/243

While in here I found some problems with our existing headers that I've ironed out. One of the results was I replaced the incoming request path with go-ipld-prime's `datamodel.Path` implementation. The main change is it becomes more lenient, but also more consistent: https://github.com/ipld/go-ipld-prime/blob/b625f253fa5048f09c40a5240580849822cf601c/datamodel/path.go#L86-L120

so `/ipfs/bafyfoo/bar/////baz` works now and before, but before this change the `////` makes it through to some places we care about, like these headers. With this change it all gets made consistent, the user can still request a dodgy path and we'll handle it gracefully.