### PR TITLE
Add test of fail on missing block

### DIFF
--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -76,6 +76,7 @@ func TestHttpFetch(t *testing.T) {
 		setHeader        headerSetter
 		modifyQueries    []queryModifier
 		validateBodies   []bodyValidator
+		lassieOpts       []lassie.LassieOption
 	}{
 		{
 			name:             "graphsync large sharded file",
@@ -214,6 +215,26 @@ func TestHttpFetch(t *testing.T) {
 			},
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				return []unixfs.DirEntry{unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)}
+			},
+			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
+				// 3 blocks max, start at the root and then two blocks into the sharded data
+				wantCids := []cid.Cid{
+					srcData.Root,
+					srcData.SelfCids[0],
+					srcData.SelfCids[1],
+				}
+				validateCarBody(t, body, srcData.Root, wantCids, true)
+			}},
+		},
+		{
+			name:             "bitswap block timeout from missing block",
+			bitswapRemotes:   1,
+			expectUncleanEnd: true,
+			lassieOpts:       []lassie.LassieOption{lassie.WithProviderTimeout(500 * time.Millisecond)},
+			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
+				file := unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)
+				remotes[0].Blockstore().DeleteBlock(context.Background(), file.SelfCids[2])
+				return []unixfs.DirEntry{file}
 			},
 			validateBodies: []bodyValidator{func(t *testing.T, srcData unixfs.DirEntry, body []byte) {
 				// 3 blocks max, start at the root and then two blocks into the sharded data
@@ -740,10 +761,10 @@ func TestHttpFetch(t *testing.T) {
 
 			// Setup a new lassie
 			req := require.New(t)
-			opts := []lassie.LassieOption{lassie.WithProviderTimeout(20 * time.Second),
+			opts := append([]lassie.LassieOption{lassie.WithProviderTimeout(20 * time.Second),
 				lassie.WithHost(mrn.Self),
 				lassie.WithFinder(mrn.Finder),
-			}
+			}, testCase.lassieOpts...)
 			if testCase.disableGraphsync {
 				opts = append(opts, lassie.WithProtocols([]multicodec.Code{multicodec.TransportBitswap}))
 			}


### PR DESCRIPTION
# Goals

I wanted to verify we get the kind of failure we expect when a block is missing on a bitswap remote.

# Implementation

Add a test that removes a block from the remote and also lowers the timeout, confirm it fails and indicates an non-terminated stream.