### PR TITLE
Comment on spec related validation and pull out constants

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	MimeTypeCar        = "application/vnd.ipld.var" // The only accepted MIME type
+	MimeTypeCar        = "application/vnd.ipld.car" // The only accepted MIME type
 	MimeTypeCarVersion = "1"                        // We only accept version 1 of the MIME type
 	FormatParameterCar = "car"                      // The only valid format parameter value
 	FilenameExtCar     = ".car"                     // The only valid filename extension


### PR DESCRIPTION
This pulls out up all of the constants that are used in multiple places or controls behavior that is spec related. Also adds comments about spec decisions around supporting different parameters and header values.