### PR TITLE
Fix http path retrievals

### DIFF
--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -164,7 +164,7 @@ func makeRequest(ctx context.Context, request types.RetrievalRequest, candidate 
 		return nil, fmt.Errorf("%w: %v", ErrBadPathForRequest, err)
 	}
 
-	reqURL := fmt.Sprintf("%s/ipfs/%s%s", candidateURL, request.Cid, path)
+	reqURL := fmt.Sprintf("%s/ipfs/%s/%s", candidateURL, request.Cid, path)
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
 		logger.Warnf("Couldn't construct a http request %s: %v", candidate.MinerPeer.ID, err)


### PR DESCRIPTION
# Goals

Well folks, I guess this is why we integration test. Looks like we had a very missing trailing slash in the HTTP retrievals which will cause everything except for root cid retrievals to fail.

# Implementation

- Fix it
- Add integrations tests we never quite got to that sadly, probably would have caught this one
