### PR TITLE
chore: turn off debug in main itest

### DIFF
--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -44,7 +44,7 @@ import (
 // DEBUG_DATA, when true, will write source and received data to CARs
 // for inspection if tests fail; otherwise they are cleaned up as tests
 // proceed.
-const DEBUG_DATA = true
+const DEBUG_DATA = false
 
 func TestHttpFetch(t *testing.T) {
 	entityQuery := func(q url.Values, _ []testpeer.TestPeer) {


### PR DESCRIPTION
I meant to push this turned off when I originally added it but obviously went back and did more tinkering with it on and never turned it back off again. It's noisy, slows down the tests, and only useful if you're debugging DAGs.