### PR TITLE
fix: add back waitqueue pause for http

### DIFF
--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -22,6 +22,9 @@ import (
 	"go.uber.org/multierr"
 )
 
+// Connect() may be a near-noop for already-connect libp2p connections, so this
+// allows parallel goroutines of already-connected peers to queue and have the
+// scoring logic to select one to start.
 const GraphsyncDefaultInitialWait = 2 * time.Millisecond
 
 type GraphsyncClient interface {

--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -33,7 +33,9 @@ func (e ErrHttpRequestFailure) Error() string {
 	return fmt.Sprintf("HTTP request failed, remote response code: %d", e.Code)
 }
 
-const HttpDefaultInitialWait time.Duration = 0
+// Connect() is currently a noop, so this simply allows parallel goroutines to
+// queue and the scoring logic to select one to start.
+const HttpDefaultInitialWait time.Duration = 2 * time.Millisecond
 
 const DefaultUserAgent = "lassie"
 


### PR DESCRIPTION
Was left at `0`, so first goroutine in gets chosen. Not so important with so few http peers to select from currently but will become more important over time.