### PR TITLE
Use unique http client for indexer

### DIFF
--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -55,7 +55,7 @@ func NewLassie(ctx context.Context, opts ...LassieOption) (*Lassie, error) {
 func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error) {
 	if cfg.Finder == nil {
 		var err error
-		cfg.Finder, err = indexerlookup.NewCandidateFinder()
+		cfg.Finder, err = indexerlookup.NewCandidateFinder(indexerlookup.WithHttpClient(&http.Client{}))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Goals

We have an inadvertent HTTP timeout for fetches from HTTP providers. It's because we share the HTTP default client with the indexer fetcher, and that sets a 1 minute timeout.

# Implementation

- Use a unique client with the indexer
