### PR TITLE
Move Lassie instantiation to a common function

### DIFF
--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -90,7 +91,6 @@ var FlagMetricsPort = &cli.UintFlag{
 }
 
 var providerBlockList map[peer.ID]bool
-
 var FlagExcludeProviders = &cli.StringFlag{
 	Name:        "exclude-providers",
 	DefaultText: "All providers allowed",
@@ -147,4 +147,20 @@ var FlagBitswapConcurrency = &cli.IntFlag{
 	Usage:   "maximum number of concurrent bitswap requests per retrieval",
 	Value:   6,
 	EnvVars: []string{"LASSIE_BITSWAP_CONCURRENCY"},
+}
+
+var FlagGlobalTimeout = &cli.DurationFlag{
+	Name:    "global-timeout",
+	Aliases: []string{"gt"},
+	Usage:   "consider it an error after not completing a retrieval after this amount of time",
+	Value:   0,
+	EnvVars: []string{"LASSIE_GLOBAL_TIMEOUT"},
+}
+
+var FlagProviderTimeout = &cli.DurationFlag{
+	Name:    "provider-timeout",
+	Aliases: []string{"pt"},
+	Usage:   "consider it an error after not receiving a response from a storage provider after this amount of time",
+	Value:   20 * time.Second,
+	EnvVars: []string{"LASSIE_PROVIDER_TIMEOUT"},
 }

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -85,6 +85,45 @@ func before(cctx *cli.Context) error {
 	return nil
 }
 
+func BuildLassieFromCLIContext(cctx *cli.Context, lassieOpts []lassie.LassieOption) (*lassie.Lassie, error) {
+	ctx := cctx.Context
+
+	tempDir := cctx.String("tempdir")
+	providerTimeout := cctx.Duration("provider-timeout")
+	globalTimeout := cctx.Duration("global-timeout")
+	bitswapConcurrency := cctx.Int("bitswap-concurrency")
+
+	lassieOpts = append(lassieOpts, lassie.WithProviderTimeout(providerTimeout))
+
+	if globalTimeout > 0 {
+		lassieOpts = append(lassieOpts, lassie.WithGlobalTimeout(globalTimeout))
+	}
+
+	if len(protocols) > 0 {
+		lassieOpts = append(lassieOpts, lassie.WithProtocols(protocols))
+	}
+
+	if len(providerBlockList) > 0 {
+		lassieOpts = append(lassieOpts, lassie.WithProviderBlockList(providerBlockList))
+	}
+
+	if tempDir != "" {
+		lassieOpts = append(lassieOpts, lassie.WithTempDir(tempDir))
+	}
+
+	if bitswapConcurrency > 0 {
+		lassieOpts = append(lassieOpts, lassie.WithBitswapConcurrency(bitswapConcurrency))
+	}
+
+	// create a lassie instance
+	lassie, err := lassie.NewLassie(ctx, lassieOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return lassie, nil
+}
+
 // setupLassieEventRecorder creates and subscribes an EventRecorder if an event recorder URL is given
 func setupLassieEventRecorder(
 	ctx context.Context,


### PR DESCRIPTION
Abstracts the common Lassie option parsing and instantiation to a common function to be used by both the `daemon` and `fetch` commands.

There will need to be some conflict resolution between this and PR #286 since the metric flags were removed.

Waiting for #258 before merging because CLI tests would benefit this change.

Closes #257 