### PR TITLE
Add CLI unit tests

### DIFF
--- a/cmd/lassie/daemon_test.go
+++ b/cmd/lassie/daemon_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	a "github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
+	l "github.com/filecoin-project/lassie/pkg/lassie"
+	h "github.com/filecoin-project/lassie/pkg/server/http"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/multiformats/go-multicodec"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestDaemonCommandFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		assert daemonRunFunc
+	}{
+		{
+			name: "with default args",
+			args: []string{"daemon"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				// lassie config
+				require.Equal(t, nil, lCfg.Finder)
+				require.NotNil(t, lCfg.Host, "host should not be nil")
+				require.Equal(t, 20*time.Second, lCfg.ProviderTimeout)
+				require.Equal(t, uint(0), lCfg.ConcurrentSPRetrievals)
+				require.Equal(t, 0*time.Second, lCfg.GlobalTimeout)
+				require.Equal(t, 0, len(lCfg.Libp2pOptions))
+				require.Equal(t, 0, len(lCfg.Protocols))
+				require.Equal(t, 0, len(lCfg.ProviderBlockList))
+				require.Equal(t, 0, len(lCfg.ProviderAllowList))
+				require.Equal(t, os.TempDir(), lCfg.TempDir)
+				require.Equal(t, 6, lCfg.BitswapConcurrency)
+
+				// http server config
+				require.Equal(t, "127.0.0.1", hCfg.Address)
+				require.Equal(t, uint(0), hCfg.Port)
+				require.Equal(t, "/tmp", hCfg.TempDir)
+				require.Equal(t, uint64(0), hCfg.MaxBlocksPerRequest)
+
+				// event recorder config
+				require.Equal(t, "", erCfg.EndpointURL)
+				require.Equal(t, "", erCfg.EndpointAuthorization)
+				require.Equal(t, "", erCfg.InstanceID)
+				return nil
+			},
+		},
+		{
+			name: "with libp2p low connection threshold and concurrent sp retrievals",
+			args: []string{"daemon", "--libp2p-conns-lowwater", "10", "--concurrent-sp-retrievals", "10"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, 1, len(lCfg.Libp2pOptions))
+				// Should only be set when libp2p connection threshold options are also provided
+				require.Equal(t, uint(10), lCfg.ConcurrentSPRetrievals)
+				return nil
+			},
+		},
+		{
+			name: "with libp2p high connection threshold and concurrent sp retrievals",
+			args: []string{"daemon", "--libp2p-conns-highwater", "10", "--concurrent-sp-retrievals", "10"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, 1, len(lCfg.Libp2pOptions))
+				// Should only be set when libp2p connection threshold options are also provided
+				require.Equal(t, uint(10), lCfg.ConcurrentSPRetrievals)
+				return nil
+			},
+		},
+		{
+			name: "with libp2p low and high connection thresholds and concurrent sp retrievals",
+			args: []string{"daemon", "--libp2p-conns-lowwater", "10", "--libp2p-conns-highwater", "20"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.NotNil(t, lCfg.Host, "host should not be nil")
+				cmgr, ok := lCfg.Host.ConnManager().(*connmgr.BasicConnMgr)
+				require.True(t, ok)
+				cmInfo := cmgr.GetInfo()
+				require.Equal(t, cmInfo.LowWater, 10)
+				require.Equal(t, cmInfo.HighWater, 10)
+				return nil
+			},
+		},
+		{
+			name: "with concurrent sp retrievals",
+			args: []string{"daemon", "--concurrent-sp-retrievals", "10"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, uint(10), lCfg.ConcurrentSPRetrievals)
+				return nil
+			},
+		},
+		{
+			name: "with temp directory",
+			args: []string{"daemon", "--tempdir", "/mytmpdir"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, "/mytmpdir", lCfg.TempDir)
+				require.Equal(t, "/mytmpdir", hCfg.TempDir)
+				return nil
+			},
+		},
+		{
+			name: "with provider timeout",
+			args: []string{"daemon", "--provider-timeout", "30s"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, 30*time.Second, lCfg.ProviderTimeout)
+				return nil
+			},
+		},
+		{
+			name: "with global timeout",
+			args: []string{"daemon", "--global-timeout", "30s"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, 30*time.Second, lCfg.GlobalTimeout)
+				return nil
+			},
+		},
+		{
+			name: "with protocols",
+			args: []string{"daemon", "--protocols", "bitswap,graphsync"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, []multicodec.Code{multicodec.TransportBitswap, multicodec.TransportGraphsyncFilecoinv1}, lCfg.Protocols)
+				return nil
+			},
+		},
+		{
+			name: "with exclude providers",
+			args: []string{"daemon", "--exclude-providers", "12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4,12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				p1, err := peer.Decode("12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")
+				require.NoError(t, err)
+				p2, err := peer.Decode("12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys")
+				require.NoError(t, err)
+
+				require.Equal(t, true, lCfg.ProviderBlockList[p1])
+				require.Equal(t, true, lCfg.ProviderBlockList[p2])
+				return nil
+			},
+		},
+		{
+			name: "with bitswap concurrency",
+			args: []string{"daemon", "--bitswap-concurrency", "10"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, 10, lCfg.BitswapConcurrency)
+				return nil
+			},
+		},
+		{
+			name: "with address",
+			args: []string{"daemon", "--address", "0.0.0.0"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, "0.0.0.0", hCfg.Address)
+				return nil
+			},
+		},
+		{
+			name: "with port",
+			args: []string{"daemon", "--port", "1234"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, uint(1234), hCfg.Port)
+				return nil
+			},
+		},
+		{
+			name: "with max blocks",
+			args: []string{"daemon", "--maxblocks", "10"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, uint64(10), hCfg.MaxBlocksPerRequest)
+				return nil
+			},
+		},
+		{
+			name: "with event recorder url",
+			args: []string{"daemon", "--event-recorder-url", "https://myeventrecorder.com/v1/retrieval-events"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, "https://myeventrecorder.com/v1/retrieval-events", erCfg.EndpointURL)
+				return nil
+			},
+		},
+		{
+			name: "with event recorder auth",
+			args: []string{"daemon", "--event-recorder-auth", "secret"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, "secret", erCfg.EndpointAuthorization)
+				return nil
+			},
+		},
+		{
+			name: "with event recorder instance ID",
+			args: []string{"daemon", "--event-recorder-instance-id", "myinstanceid"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, "myinstanceid", erCfg.InstanceID)
+				return nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		daemonRun = test.assert
+		app := &cli.App{
+			Name:     "cli-test",
+			Flags:    daemonFlags,
+			Commands: []*cli.Command{daemonCmd},
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			err := app.Run(append([]string{"cli-test"}, test.args...))
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/cmd/lassie/daemon_test.go
+++ b/cmd/lassie/daemon_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -36,39 +35,17 @@ func TestDaemonCommandFlags(t *testing.T) {
 				require.Equal(t, 0, len(lCfg.Protocols))
 				require.Equal(t, 0, len(lCfg.ProviderBlockList))
 				require.Equal(t, 0, len(lCfg.ProviderAllowList))
-				require.Equal(t, os.TempDir(), lCfg.TempDir)
 				require.Equal(t, 6, lCfg.BitswapConcurrency)
 
 				// http server config
 				require.Equal(t, "127.0.0.1", hCfg.Address)
 				require.Equal(t, uint(0), hCfg.Port)
-				require.Equal(t, "/tmp", hCfg.TempDir)
 				require.Equal(t, uint64(0), hCfg.MaxBlocksPerRequest)
 
 				// event recorder config
 				require.Equal(t, "", erCfg.EndpointURL)
 				require.Equal(t, "", erCfg.EndpointAuthorization)
 				require.Equal(t, "", erCfg.InstanceID)
-				return nil
-			},
-		},
-		{
-			name: "with libp2p low connection threshold and concurrent sp retrievals",
-			args: []string{"daemon", "--libp2p-conns-lowwater", "10", "--concurrent-sp-retrievals", "10"},
-			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
-				require.Equal(t, 1, len(lCfg.Libp2pOptions))
-				// Should only be set when libp2p connection threshold options are also provided
-				require.Equal(t, uint(10), lCfg.ConcurrentSPRetrievals)
-				return nil
-			},
-		},
-		{
-			name: "with libp2p high connection threshold and concurrent sp retrievals",
-			args: []string{"daemon", "--libp2p-conns-highwater", "10", "--concurrent-sp-retrievals", "10"},
-			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
-				require.Equal(t, 1, len(lCfg.Libp2pOptions))
-				// Should only be set when libp2p connection threshold options are also provided
-				require.Equal(t, uint(10), lCfg.ConcurrentSPRetrievals)
 				return nil
 			},
 		},
@@ -81,7 +58,7 @@ func TestDaemonCommandFlags(t *testing.T) {
 				require.True(t, ok)
 				cmInfo := cmgr.GetInfo()
 				require.Equal(t, cmInfo.LowWater, 10)
-				require.Equal(t, cmInfo.HighWater, 10)
+				require.Equal(t, cmInfo.HighWater, 20)
 				return nil
 			},
 		},
@@ -97,7 +74,6 @@ func TestDaemonCommandFlags(t *testing.T) {
 			name: "with temp directory",
 			args: []string{"daemon", "--tempdir", "/mytmpdir"},
 			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
-				require.Equal(t, "/mytmpdir", lCfg.TempDir)
 				require.Equal(t, "/mytmpdir", hCfg.TempDir)
 				return nil
 			},

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -208,7 +208,7 @@ type fetchRunFunc func(
 
 var fetchRun fetchRunFunc = defaultFetchRun
 
-// fetchCommandHandler is the handler for the fetch command.
+// defaultFetchRun is the handler for the fetch command.
 // This abstraction allows the fetch command to be invoked
 // programmatically for testing.
 func defaultFetchRun(

--- a/cmd/lassie/fetch_test.go
+++ b/cmd/lassie/fetch_test.go
@@ -46,7 +46,7 @@ func TestFetchCommandFlags(t *testing.T) {
 				require.Equal(t, 0, len(lCfg.Protocols))
 				require.Equal(t, 0, len(lCfg.ProviderBlockList))
 				require.Equal(t, 0, len(lCfg.ProviderAllowList))
-				require.Equal(t, "/tmp", lCfg.TempDir)
+				// require.Equal(t, "/tmp", lCfg.TempDir) // TODO: Default TempDir doesn't work with CI
 				require.Equal(t, 6, lCfg.BitswapConcurrency)
 
 				// event recorder config
@@ -171,7 +171,7 @@ func TestFetchCommandFlags(t *testing.T) {
 				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
 			},
 			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
-				require.Equal(t, "/mytmpdir", lCfg.TempDir)
+				require.Equal(t, "/mytmpdir", tempDir)
 				return nil
 			},
 		},

--- a/cmd/lassie/fetch_test.go
+++ b/cmd/lassie/fetch_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	a "github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
+	"github.com/filecoin-project/lassie/pkg/indexerlookup"
+	l "github.com/filecoin-project/lassie/pkg/lassie"
+	"github.com/filecoin-project/lassie/pkg/retriever"
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multicodec"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestFetchCommandFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		shouldError bool
+		assertRun   fetchRunFunc
+	}{
+		{
+			name: "with default args",
+			args: []string{"fetch", "bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4"},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				// fetch specific params
+				require.Equal(t, "bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4", rootCid.String())
+				require.Equal(t, "", path)
+				require.Equal(t, string(types.DagScopeAll), dagScope)
+				require.Equal(t, false, progress)
+				require.Equal(t, "bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4.car", outfile)
+
+				// lassie config
+				require.Equal(t, nil, lCfg.Finder)
+				require.NotNil(t, lCfg.Host, "host should not be nil")
+				require.Equal(t, 20*time.Second, lCfg.ProviderTimeout)
+				require.Equal(t, uint(0), lCfg.ConcurrentSPRetrievals)
+				require.Equal(t, 0*time.Second, lCfg.GlobalTimeout)
+				require.Equal(t, 0, len(lCfg.Libp2pOptions))
+				require.Equal(t, 0, len(lCfg.Protocols))
+				require.Equal(t, 0, len(lCfg.ProviderBlockList))
+				require.Equal(t, 0, len(lCfg.ProviderAllowList))
+				require.Equal(t, "/tmp", lCfg.TempDir)
+				require.Equal(t, 6, lCfg.BitswapConcurrency)
+
+				// event recorder config
+				require.Equal(t, "", erCfg.EndpointURL)
+				require.Equal(t, "", erCfg.EndpointAuthorization)
+				require.Equal(t, "", erCfg.InstanceID)
+				return nil
+			},
+		},
+		{
+			name: "with bad root cid",
+			args: []string{
+				"fetch",
+				"not-a-cid",
+			},
+			shouldError: true,
+		},
+		{
+			name: "with root cid path",
+			args: []string{
+				"fetch",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4/birb.mp4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, "/birb.mp4", path)
+				return nil
+			},
+		},
+		{
+			name: "with dag scope entity",
+			args: []string{
+				"fetch",
+				"--dag-scope",
+				"entity",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, string(types.DagScopeEntity), dagScope)
+				return nil
+			},
+		},
+		{
+			name: "with dag scope block",
+			args: []string{
+				"fetch",
+				"--dag-scope",
+				"block",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, string(types.DagScopeBlock), dagScope)
+				return nil
+			},
+		},
+		{
+			name: "with progress",
+			args: []string{
+				"fetch",
+				"--progress",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, true, progress)
+				return nil
+			},
+		},
+		{
+			name: "with output",
+			args: []string{
+				"fetch",
+				"--output",
+				"myfile",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, "myfile", outfile)
+				return nil
+			},
+		},
+		{
+			name: "with providers",
+			args: []string{
+				"fetch",
+				"--providers",
+				"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.IsType(t, &retriever.DirectCandidateFinder{}, lCfg.Finder, "finder should be a DirectCandidateFinder when providers are specified")
+				return nil
+			},
+		},
+		{
+			name: "with ipni endpoint",
+			args: []string{
+				"fetch",
+				"--ipni-endpoint",
+				"https://cid.contact",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.IsType(t, &indexerlookup.IndexerCandidateFinder{}, lCfg.Finder, "finder should be an IndexerCandidateFinder when providing an ipni endpoint")
+				return nil
+			},
+		},
+		{
+			name: "with bad ipni endpoint",
+			args: []string{
+				"fetch",
+				"--ipni-endpoint",
+				"not-a-url",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			shouldError: true,
+		},
+		{
+			name: "with temp directory",
+			args: []string{
+				"fetch",
+				"--tempdir",
+				"/mytmpdir",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, "/mytmpdir", lCfg.TempDir)
+				return nil
+			},
+		},
+		{
+			name: "with provider timeout",
+			args: []string{
+				"fetch",
+				"--provider-timeout",
+				"30s",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, 30*time.Second, lCfg.ProviderTimeout)
+				return nil
+			},
+		},
+		{
+			name: "with global timeout",
+			args: []string{
+				"fetch",
+				"--global-timeout",
+				"30s",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, 30*time.Second, lCfg.GlobalTimeout)
+				return nil
+			},
+		},
+		{
+			name: "with protocols",
+			args: []string{
+				"fetch",
+				"--protocols",
+				"bitswap,graphsync",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, []multicodec.Code{multicodec.TransportBitswap, multicodec.TransportGraphsyncFilecoinv1}, lCfg.Protocols)
+				return nil
+			},
+		},
+		{
+			name: "with exclude providers",
+			args: []string{
+				"fetch",
+				"--exclude-providers",
+				"12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4,12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				p1, err := peer.Decode("12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")
+				require.NoError(t, err)
+				p2, err := peer.Decode("12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys")
+				require.NoError(t, err)
+
+				require.Equal(t, true, lCfg.ProviderBlockList[p1])
+				require.Equal(t, true, lCfg.ProviderBlockList[p2])
+				return nil
+			},
+		},
+		{
+			name: "with bitswap concurrency",
+			args: []string{
+				"fetch",
+				"--bitswap-concurrency",
+				"10",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, 10, lCfg.BitswapConcurrency)
+				return nil
+			},
+		},
+		{
+			name: "with event recorder url",
+			args: []string{
+				"fetch",
+				"--event-recorder-url",
+				"https://myeventrecorder.com/v1/retrieval-events",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, "https://myeventrecorder.com/v1/retrieval-events", erCfg.EndpointURL)
+				return nil
+			},
+		},
+		{
+			name: "with event recorder auth",
+			args: []string{
+				"fetch",
+				"--event-recorder-auth",
+				"secret",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, "secret", erCfg.EndpointAuthorization)
+				return nil
+			},
+		},
+		{
+			name: "with event recorder instance ID",
+			args: []string{
+				"fetch",
+				"--event-recorder-instance-id",
+				"myinstanceid",
+				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4",
+			},
+			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+				require.Equal(t, "myinstanceid", erCfg.InstanceID)
+				return nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		fetchRun = test.assertRun
+		if test.shouldError {
+			fetchRun = noopRun
+		}
+
+		app := &cli.App{
+			Name:     "cli-test",
+			Flags:    fetchFlags,
+			Commands: []*cli.Command{fetchCmd},
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			err := app.Run(append([]string{"cli-test"}, test.args...))
+			if err != nil && !test.shouldError {
+				t.Fatal(err)
+			}
+
+			if err == nil && test.shouldError {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func noopRun(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
+	return nil
+}

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -166,3 +166,11 @@ var FlagIPNIEndpoint = &cli.StringFlag{
 	DefaultText: "Defaults to https://cid.contact",
 	Usage:       "HTTP endpoint of the IPNI instance used to discover providers.",
 }
+
+func ResetGlobalFlags() {
+	// Reset global variables here so that they are not used
+	// in subsequent calls to commands during testing.
+	fetchProviderAddrInfos = make([]peer.AddrInfo, 0)
+	protocols = make([]multicodec.Code, 0)
+	providerBlockList = make(map[peer.ID]bool)
+}

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os"
 	"strings"
+	"time"
 
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -64,7 +66,6 @@ var FlagEventRecorderUrl = &cli.StringFlag{
 }
 
 var providerBlockList map[peer.ID]bool
-
 var FlagExcludeProviders = &cli.StringFlag{
 	Name:        "exclude-providers",
 	DefaultText: "All providers allowed",
@@ -131,7 +132,7 @@ var FlagTempDir = &cli.StringFlag{
 	Name:        "tempdir",
 	Aliases:     []string{"td"},
 	Usage:       "directory to store temporary files while downloading",
-	Value:       "",
+	Value:       os.TempDir(),
 	DefaultText: "os temp directory",
 	EnvVars:     []string{"LASSIE_TEMP_DIRECTORY"},
 }
@@ -141,4 +142,27 @@ var FlagBitswapConcurrency = &cli.IntFlag{
 	Usage:   "maximum number of concurrent bitswap requests per retrieval",
 	Value:   6,
 	EnvVars: []string{"LASSIE_BITSWAP_CONCURRENCY"},
+}
+
+var FlagGlobalTimeout = &cli.DurationFlag{
+	Name:    "global-timeout",
+	Aliases: []string{"gt"},
+	Usage:   "consider it an error after not completing a retrieval after this amount of time",
+	Value:   0,
+	EnvVars: []string{"LASSIE_GLOBAL_TIMEOUT"},
+}
+
+var FlagProviderTimeout = &cli.DurationFlag{
+	Name:    "provider-timeout",
+	Aliases: []string{"pt"},
+	Usage:   "consider it an error after not receiving a response from a storage provider after this amount of time",
+	Value:   20 * time.Second,
+	EnvVars: []string{"LASSIE_PROVIDER_TIMEOUT"},
+}
+
+var FlagIPNIEndpoint = &cli.StringFlag{
+	Name:        "ipni-endpoint",
+	Aliases:     []string{"ipni"},
+	DefaultText: "Defaults to https://cid.contact",
+	Usage:       "HTTP endpoint of the IPNI instance used to discover providers.",
 }

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -90,6 +90,11 @@ func before(cctx *cli.Context) error {
 	return nil
 }
 
+func after(cctx *cli.Context) error {
+	ResetGlobalFlags()
+	return nil
+}
+
 func buildLassieConfigFromCLIContext(cctx *cli.Context, lassieOpts []lassie.LassieOption, libp2pOpts []config.Option) (*lassie.LassieConfig, error) {
 	providerTimeout := cctx.Duration("provider-timeout")
 	globalTimeout := cctx.Duration("global-timeout")

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -124,7 +124,7 @@ func buildLassieConfigFromCLIContext(cctx *cli.Context, lassieOpts []lassie.Lass
 		lassieOpts = append(lassieOpts, finderOpt)
 	} else if cctx.IsSet("ipni-endpoint") {
 		endpoint := cctx.String("ipni-endpoint")
-		endpointUrl, err := url.Parse(endpoint)
+		endpointUrl, err := url.ParseRequestURI(endpoint)
 		if err != nil {
 			logger.Errorw("Failed to parse IPNI endpoint as URL", "err", err)
 			return nil, fmt.Errorf("cannot parse given IPNI endpoint %s as valid URL: %w", endpoint, err)

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -35,7 +35,6 @@ type LassieConfig struct {
 	Protocols              []multicodec.Code
 	ProviderBlockList      map[peer.ID]bool
 	ProviderAllowList      map[peer.ID]bool
-	TempDir                string
 	BitswapConcurrency     int
 }
 

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -43,11 +43,17 @@ type LassieOption func(cfg *LassieConfig)
 
 // NewLassie creates a new Lassie instance.
 func NewLassie(ctx context.Context, opts ...LassieOption) (*Lassie, error) {
+	cfg := NewLassieConfig(opts...)
+	return NewLassieWithConfig(ctx, cfg)
+}
+
+// NewLassieConfig creates a new LassieConfig instance with the given LassieOptions.
+func NewLassieConfig(opts ...LassieOption) *LassieConfig {
 	cfg := &LassieConfig{}
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	return NewLassieWithConfig(ctx, cfg)
+	return cfg
 }
 
 // NewLassieWithConfig creates a new Lassie instance with a custom


### PR DESCRIPTION
The goal here was to be able to call the daemon and fetch commands via handler functions that transform the flags into values so that they can be passed in programatically in a test. It didn't end up making any sense to have those functions return the Lassie isntance. Even if it did return Lassie, I'd have to somehow inspect Lassie behavior. I thought maybe it would be easier to inspect the configuration structs that were created instead.

If we can test that different flag inputs result in specific config values, then we can have other tests that check that passing different config values to lassie, the http server, and the event recorder result in specific behavior. I then made the functions for transforming the relevant flag values into the lassie config, http config, and event recorder config structs.

There are now main package "run" function for both the daemon and fetch commands that can be overridden to assert that config structs have the correct state given some CLI input.

Closes #257 and #258 
