### PR TITLE
test: extra debug output for flaky failure case

### DIFF
--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -997,7 +997,11 @@ func TestHttpFetch(t *testing.T) {
 				if testCase.expectFail {
 					req.Equal(http.StatusGatewayTimeout, resp.StatusCode)
 				} else {
-					req.Equal(http.StatusOK, resp.StatusCode)
+					if resp.StatusCode != http.StatusOK {
+						body, err := io.ReadAll(resp.Body)
+						req.NoError(err)
+						req.Failf("200 response code not received", "got code: %d, body: %s", resp.StatusCode, string(body))
+					}
 					req.Equal(fmt.Sprintf(`attachment; filename="%s.car"`, srcData[i].Root.String()), resp.Header.Get("Content-Disposition"))
 					req.Equal("none", resp.Header.Get("Accept-Ranges"))
 					req.Equal("public, max-age=29030400, immutable", resp.Header.Get("Cache-Control"))


### PR DESCRIPTION
The flaky tests in CI are a 504, which should mean it's coming out of here: https://github.com/filecoin-project/lassie/blob/2edae8be9439dcf3395ae54ebcb002a5daa3c97e/pkg/server/http/ipfs.go#L235

The body should contain the error message.