### PR TITLE
Remove simultaneous retrieval limits for HTTP

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -90,7 +90,7 @@ func (session *Session) isAcceptableCandidate(storageProviderId peer.ID) bool {
 }
 
 func (session *Session) isAcceptableCandidateForProtocol(storageProviderId peer.ID, protocol multicodec.Code) bool {
-	if protocol == multicodec.TransportBitswap {
+	if protocol == multicodec.TransportBitswap || protocol == multicodec.TransportIpfsGatewayHttp {
 		return true
 	}
 


### PR DESCRIPTION
# Goals

We're currently filtering out a ton of requests to .storage because of the simultaneous provider limit which is set to 1 in Saturn. I'm not sure this is the right long term solution -- perhaps we should explore incorporating concurrency into weighting, combined with a higher absolute limit. But it's a quick way to get the requests flowing until we decide the ideal approach.