### PR TITLE
fix: add back pprof endpoints

### DIFF
--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/filecoin-project/lassie/pkg/lassie"
 	"github.com/ipfs/go-log/v2"
@@ -67,6 +68,13 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, cfg HttpServerCon
 
 	// Routes
 	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, cfg))
+
+	// Handle pprof endpoints
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	return httpServer, nil
 }


### PR DESCRIPTION
Looks like the pprof endpoints were accidentally removed in PR #286 while removing the metrics server and prometheus exporter. This commit adds them back to the HttpServer. Closes #297.