### PR TITLE
feat: add -providers flag to the daemon command

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lassie/pkg/lassie"
+	"github.com/filecoin-project/lassie/pkg/net/host"
+	"github.com/filecoin-project/lassie/pkg/retriever"
 	httpserver "github.com/filecoin-project/lassie/pkg/server/http"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
@@ -80,6 +82,7 @@ var daemonFlags = []cli.Flag{
 	FlagVerbose,
 	FlagVeryVerbose,
 	FlagProtocols,
+	FlagAllowProviders,
 	FlagExcludeProviders,
 	FlagTempDir,
 	FlagBitswapConcurrency,
@@ -127,6 +130,14 @@ func daemonCommand(cctx *cli.Context) error {
 	}
 	if len(protocols) > 0 {
 		lassieOpts = append(lassieOpts, lassie.WithProtocols(protocols))
+	}
+	if len(fetchProviderAddrInfos) > 0 {
+		host, err := host.InitHost(ctx, []libp2p.Option{})
+		if err != nil {
+			return err
+		}
+		finderOpt := lassie.WithFinder(retriever.NewDirectCandidateFinder(host, fetchProviderAddrInfos))
+		lassieOpts = append(lassieOpts, finderOpt)
 	}
 	if len(providerBlockList) > 0 {
 		lassieOpts = append(lassieOpts, lassie.WithProviderBlockList(providerBlockList))

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -19,11 +19,8 @@ import (
 	"github.com/ipfs/go-cid"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/urfave/cli/v2"
 )
-
-var fetchProviderAddrInfos []peer.AddrInfo
 
 var fetchCmd = &cli.Command{
 	Name:   "fetch",
@@ -72,22 +69,6 @@ var fetchCmd = &cli.Command{
 			},
 		},
 		&cli.StringFlag{
-			Name:        "providers",
-			Aliases:     []string{"provider"},
-			DefaultText: "Providers will be discovered automatically",
-			Usage:       "Addresses of providers, including peer IDs, to use instead of automatic discovery, seperated by a comma. All protocols will be attempted when connecting to these providers. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
-			Action: func(cctx *cli.Context, v string) error {
-				// Do nothing if given an empty string
-				if v == "" {
-					return nil
-				}
-
-				var err error
-				fetchProviderAddrInfos, err = types.ParseProviderStrings(v)
-				return err
-			},
-		},
-		&cli.StringFlag{
 			Name:        "ipni-endpoint",
 			Aliases:     []string{"ipni"},
 			DefaultText: "Defaults to https://cid.contact",
@@ -99,6 +80,7 @@ var fetchCmd = &cli.Command{
 		FlagVerbose,
 		FlagVeryVerbose,
 		FlagProtocols,
+		FlagAllowProviders,
 		FlagExcludeProviders,
 		FlagTempDir,
 		FlagBitswapConcurrency,

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -89,6 +89,25 @@ var FlagExcludeProviders = &cli.StringFlag{
 	},
 }
 
+var fetchProviderAddrInfos []peer.AddrInfo
+
+var FlagAllowProviders = &cli.StringFlag{
+	Name:        "providers",
+	Aliases:     []string{"provider"},
+	DefaultText: "Providers will be discovered automatically",
+	Usage:       "Addresses of providers, including peer IDs, to use instead of automatic discovery, seperated by a comma. All protocols will be attempted when connecting to these providers. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+	Action: func(cctx *cli.Context, v string) error {
+		// Do nothing if given an empty string
+		if v == "" {
+			return nil
+		}
+
+		var err error
+		fetchProviderAddrInfos, err = types.ParseProviderStrings(v)
+		return err
+	},
+}
+
 var protocols []multicodec.Code
 var FlagProtocols = &cli.StringFlag{
 	Name:        "protocols",

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -96,6 +96,7 @@ var FlagAllowProviders = &cli.StringFlag{
 	Aliases:     []string{"provider"},
 	DefaultText: "Providers will be discovered automatically",
 	Usage:       "Addresses of providers, including peer IDs, to use instead of automatic discovery, seperated by a comma. All protocols will be attempted when connecting to these providers. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+	EnvVars:     []string{"LASSIE_ALLOW_PROVIDERS"},
 	Action: func(cctx *cli.Context, v string) error {
 		// Do nothing if given an empty string
 		if v == "" {


### PR DESCRIPTION
useful for when you can't configure providers in the request url

example: `lassie daemon -provider=/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWEgStu69HeP9nTgFzjegYk2wqxiSJggK6isW3hCuvyxGz`