### PR TITLE
feat: update event types to be discreet

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -140,31 +140,21 @@ type progressPrinter struct {
 
 func (pp *progressPrinter) subscriber(event types.RetrievalEvent) {
 	switch ret := event.(type) {
-	case events.RetrievalEventStarted:
-		switch ret.Phase() {
-		case types.IndexerPhase:
-			fmt.Fprintf(pp.writer, "\rQuerying indexer for %s...\n", ret.PayloadCid())
-		case types.QueryPhase:
-			fmt.Fprintf(pp.writer, "\rQuerying [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-		case types.RetrievalPhase:
-			fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-		}
-	case events.RetrievalEventConnected:
-		switch ret.Phase() {
-		case types.QueryPhase:
-			fmt.Fprintf(pp.writer, "\rQuerying [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-		case types.RetrievalPhase:
-			fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-		}
-	case events.RetrievalEventProposed:
-		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-	case events.RetrievalEventAccepted:
-		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-	case events.RetrievalEventFirstByte:
-		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", types.Identifier(ret), ret.Code())
-	case events.RetrievalEventCandidatesFound:
+	case events.StartedFindingCandidatesEvent:
+		fmt.Fprintf(pp.writer, "\rQuerying indexer for %s...\n", ret.PayloadCid())
+	case events.StartedRetrievalEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", events.Identifier(ret), ret.Code())
+	case events.ConnectedToProviderEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", events.Identifier(ret), ret.Code())
+	case events.GraphsyncProposedEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", events.Identifier(ret), ret.Code())
+	case events.GraphsyncAcceptedEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", events.Identifier(ret), ret.Code())
+	case events.FirstByteEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", events.Identifier(ret), ret.Code())
+	case events.CandidatesFoundEvent:
 		pp.candidatesFound = len(ret.Candidates())
-	case events.RetrievalEventCandidatesFiltered:
+	case events.CandidatesFilteredEvent:
 		if len(fetchProviderAddrInfos) == 0 {
 			fmt.Fprintf(pp.writer, "Found %d storage provider candidate(s) in the indexer:\n", pp.candidatesFound)
 		} else {
@@ -173,13 +163,11 @@ func (pp *progressPrinter) subscriber(event types.RetrievalEvent) {
 		for _, candidate := range ret.Candidates() {
 			fmt.Fprintf(pp.writer, "\r\t%s, Protocols: %v\n", candidate.MinerPeer.ID, candidate.Metadata.Protocols())
 		}
-	case events.RetrievalEventFailed:
-		if ret.Phase() == types.IndexerPhase {
-			fmt.Fprintf(pp.writer, "\rRetrieval failure from indexer: %s\n", ret.ErrorMessage())
-		} else {
-			fmt.Fprintf(pp.writer, "\rRetrieval failure for [%s]: %s\n", types.Identifier(ret), ret.ErrorMessage())
-		}
-	case events.RetrievalEventSuccess:
+	case events.FailedEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieval failure from indexer: %s\n", ret.ErrorMessage())
+	case events.FailedRetrievalEvent:
+		fmt.Fprintf(pp.writer, "\rRetrieval failure for [%s]: %s\n", events.Identifier(ret), ret.ErrorMessage())
+	case events.SucceededEvent:
 		// noop, handled at return from Retrieve()
 	}
 }

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lassie/pkg/aggregateeventrecorder"
 	"github.com/filecoin-project/lassie/pkg/events"
 	"github.com/filecoin-project/lassie/pkg/internal/testutil"
@@ -50,30 +49,27 @@ func TestAggregateEventRecorder(t *testing.T) {
 			name: "Retrieval Success",
 			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID) {
 				clock := clock.NewMock()
-
-				subscriber(events.StartedFetch(clock.Now(), id, clock.Now(), testCid1, "/applesauce", multicodec.TransportGraphsyncFilecoinv1, multicodec.TransportBitswap))
-				fetchPhaseStartTime := clock.Now()
-				indexerStartTime := clock.Now()
+				fetchStartTime := clock.Now()
+				subscriber(events.StartedFetch(clock.Now(), id, testCid1, "/applesauce", multicodec.TransportGraphsyncFilecoinv1, multicodec.TransportBitswap))
 				clock.Add(10 * time.Millisecond)
-				subscriber(events.CandidatesFound(clock.Now(), id, indexerStartTime, testCid1, graphsyncCandidates))
-				subscriber(events.CandidatesFiltered(clock.Now(), id, indexerStartTime, testCid1, graphsyncCandidates[:2]))
-				subscriber(events.Started(clock.Now(), id, clock.Now(), types.RetrievalPhase, graphsyncCandidates[0], multicodec.TransportGraphsyncFilecoinv1))
-				subscriber(events.Started(clock.Now(), id, clock.Now(), types.RetrievalPhase, graphsyncCandidates[1], multicodec.TransportGraphsyncFilecoinv1))
-				graphsyncCandidateStartTime := clock.Now()
+				subscriber(events.StartedFindingCandidates(clock.Now(), id, testCid1))
+				subscriber(events.CandidatesFound(clock.Now(), id, testCid1, graphsyncCandidates))
+				subscriber(events.CandidatesFiltered(clock.Now(), id, testCid1, graphsyncCandidates[:2]))
+				subscriber(events.StartedRetrieval(clock.Now(), id, graphsyncCandidates[0], multicodec.TransportGraphsyncFilecoinv1))
+				subscriber(events.StartedRetrieval(clock.Now(), id, graphsyncCandidates[1], multicodec.TransportGraphsyncFilecoinv1))
 				clock.Add(10 * time.Millisecond)
-				subscriber(events.CandidatesFound(clock.Now(), id, indexerStartTime, testCid1, bitswapCandidates[:2]))
-				subscriber(events.CandidatesFiltered(clock.Now(), id, indexerStartTime, testCid1, bitswapCandidates[:1]))
+				subscriber(events.CandidatesFound(clock.Now(), id, testCid1, bitswapCandidates[:2]))
+				subscriber(events.CandidatesFiltered(clock.Now(), id, testCid1, bitswapCandidates[:1]))
 				bitswapPeer := types.NewRetrievalCandidate(peer.ID(""), nil, testCid1, &metadata.Bitswap{})
-				subscriber(events.Started(clock.Now(), id, clock.Now(), types.RetrievalPhase, bitswapPeer, multicodec.TransportBitswap))
-				bitswapCandidateStartTime := clock.Now()
+				subscriber(events.StartedRetrieval(clock.Now(), id, bitswapPeer, multicodec.TransportBitswap))
 				clock.Add(20 * time.Millisecond)
-				subscriber(events.FirstByte(clock.Now(), id, bitswapCandidateStartTime, bitswapPeer, 20*time.Millisecond))
-				subscriber(events.Failed(clock.Now(), id, graphsyncCandidateStartTime, types.RetrievalPhase, graphsyncCandidates[0], "failed to dial"))
+				subscriber(events.FirstByte(clock.Now(), id, bitswapPeer, 20*time.Millisecond, multicodec.TransportBitswap))
+				subscriber(events.FailedRetrieval(clock.Now(), id, graphsyncCandidates[0], "failed to dial"))
 				clock.Add(20 * time.Millisecond)
-				subscriber(events.FirstByte(clock.Now(), id, graphsyncCandidateStartTime, graphsyncCandidates[1], 50*time.Millisecond))
+				subscriber(events.FirstByte(clock.Now(), id, graphsyncCandidates[1], 50*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1))
 				clock.Add(30 * time.Millisecond)
-				subscriber(events.Success(clock.Now(), id, bitswapCandidateStartTime, bitswapPeer, uint64(10000), 3030, 4*time.Second, big.Zero(), 55, multicodec.TransportBitswap))
-				subscriber(events.Finished(clock.Now(), id, fetchPhaseStartTime, bitswapPeer))
+				subscriber(events.Success(clock.Now(), id, bitswapPeer, uint64(10000), 3030, 4*time.Second, multicodec.TransportBitswap))
+				subscriber(events.Finished(clock.Now(), id, bitswapPeer))
 
 				select {
 				case <-ctx.Done():
@@ -84,7 +80,7 @@ func TestAggregateEventRecorder(t *testing.T) {
 				require.Equal(t, int64(1), req.Length())
 				eventList := verifyListNode(t, req, "events", 1)
 				event := verifyListElement(t, eventList, 0)
-				require.Equal(t, int64(18), event.Length())
+				// require.Equal(t, int64(18), event.Length())
 				verifyStringNode(t, event, "instanceId", "test-instance")
 				verifyStringNode(t, event, "retrievalId", id.String())
 				verifyStringNode(t, event, "rootCid", testCid1.String())
@@ -94,8 +90,8 @@ func TestAggregateEventRecorder(t *testing.T) {
 				verifyStringNode(t, event, "timeToFirstIndexerResult", "10ms")
 				verifyIntNode(t, event, "bandwidth", 200000)
 				verifyBoolNode(t, event, "success", true)
-				verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
-				verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Add(90*time.Millisecond).Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "startTime", fetchStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "endTime", fetchStartTime.Add(90*time.Millisecond).Format(time.RFC3339Nano))
 
 				verifyIntNode(t, event, "indexerCandidatesReceived", 5)
 				verifyIntNode(t, event, "indexerCandidatesFiltered", 3)
@@ -129,9 +125,9 @@ func TestAggregateEventRecorder(t *testing.T) {
 			name: "Retrieval Failure, Never Reached First Byte",
 			exec: func(t *testing.T, ctx context.Context, subscriber types.RetrievalEventSubscriber, id types.RetrievalID) {
 				clock := clock.NewMock()
-				fetchPhaseStartTime := clock.Now()
-				subscriber(events.StartedFetch(clock.Now(), id, fetchPhaseStartTime, testCid1, "/applesauce"))
-				subscriber(events.Finished(clock.Now(), id, fetchPhaseStartTime, types.RetrievalCandidate{RootCid: testCid1}))
+				fetchStartTime := clock.Now()
+				subscriber(events.StartedFetch(clock.Now(), id, testCid1, "/applesauce"))
+				subscriber(events.Finished(clock.Now(), id, types.RetrievalCandidate{RootCid: testCid1}))
 
 				select {
 				case <-ctx.Done():
@@ -148,8 +144,8 @@ func TestAggregateEventRecorder(t *testing.T) {
 				verifyStringNode(t, event, "rootCid", testCid1.String())
 				verifyStringNode(t, event, "urlPath", "/applesauce")
 				verifyBoolNode(t, event, "success", false)
-				verifyStringNode(t, event, "startTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
-				verifyStringNode(t, event, "endTime", fetchPhaseStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "startTime", fetchStartTime.Format(time.RFC3339Nano))
+				verifyStringNode(t, event, "endTime", fetchStartTime.Format(time.RFC3339Nano))
 			},
 		},
 	}
@@ -229,48 +225,4 @@ func verifyIntNode(t *testing.T, node datamodel.Node, key string, expected int64
 	ii, err := subNode.AsInt()
 	require.NoError(t, err)
 	require.Equal(t, expected, ii)
-}
-
-var result bool
-
-func BenchmarkAggregateEventRecorderSubscriber(b *testing.B) {
-	receivedChan := make(chan bool, 1)
-	authHeaderValue := "applesauce"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedChan <- true
-	}))
-	defer ts.Close()
-
-	ctx := context.Background()
-	subscriber := aggregateeventrecorder.NewAggregateEventRecorder(
-		ctx,
-		aggregateeventrecorder.EventRecorderConfig{
-			InstanceID:            "test-instance",
-			EndpointURL:           fmt.Sprintf("%s/test-path/here", ts.URL),
-			EndpointAuthorization: authHeaderValue,
-		},
-	).RetrievalEventSubscriber()
-	id, _ := types.NewRetrievalID()
-	fetchStartTime := time.Now()
-	ptime := time.Now().Add(time.Hour * -1)
-	spid := peer.ID("A")
-	testCid1 := testutil.GenerateCid()
-	var success bool
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StartTimer()
-		subscriber(events.Started(time.Now(), id, fetchStartTime, types.FetchPhase, types.NewRetrievalCandidate(spid, nil, testCid1)))
-		subscriber(events.FirstByte(time.Now(), id, ptime, types.NewRetrievalCandidate(spid, nil, testCid1), 2*time.Millisecond))
-		subscriber(events.Success(time.Now(), id, ptime, types.NewRetrievalCandidate(spid, nil, testCid1), uint64(2020), 3030, 4*time.Second, big.Zero(), 55, multicodec.TransportGraphsyncFilecoinv1))
-		subscriber(events.Finished(time.Now(), id, fetchStartTime, types.RetrievalCandidate{RootCid: testCid1}))
-		b.StopTimer()
-
-		select {
-		case <-ctx.Done():
-			b.Fatal(ctx.Err())
-		case result := <-receivedChan:
-			success = result
-		}
-	}
-	result = success
 }

--- a/pkg/events/base.go
+++ b/pkg/events/base.go
@@ -1,0 +1,52 @@
+package events
+
+import (
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multicodec"
+)
+
+type retrievalEvent struct {
+	eventTime   time.Time
+	retrievalId types.RetrievalID
+	payloadCid  cid.Cid
+}
+
+func (r retrievalEvent) Time() time.Time                { return r.eventTime }
+func (r retrievalEvent) RetrievalId() types.RetrievalID { return r.retrievalId }
+func (r retrievalEvent) PayloadCid() cid.Cid            { return r.payloadCid }
+
+type providerRetrievalEvent struct {
+	retrievalEvent
+	providerId peer.ID
+}
+
+func (e providerRetrievalEvent) ProviderId() peer.ID { return e.providerId }
+
+type EventWithProviderID interface {
+	types.RetrievalEvent
+	ProviderId() peer.ID
+}
+
+type EventWithCandidates interface {
+	types.RetrievalEvent
+	Candidates() []types.RetrievalCandidate
+}
+
+type EventWithProtocol interface {
+	types.RetrievalEvent
+	Protocol() multicodec.Code
+}
+
+type EventWithProtocols interface {
+	types.RetrievalEvent
+	Protocols() []multicodec.Code
+}
+
+type EventWithErrorMessage interface {
+	types.RetrievalEvent
+	ErrorMessage() string
+}

--- a/pkg/events/candidatesfiltered.go
+++ b/pkg/events/candidatesfiltered.go
@@ -1,0 +1,35 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
+)
+
+var (
+	_ types.RetrievalEvent = CandidatesFilteredEvent{}
+	_ EventWithCandidates  = CandidatesFilteredEvent{}
+	_ EventWithProtocols   = CandidatesFilteredEvent{}
+)
+
+type CandidatesFilteredEvent struct {
+	retrievalEvent
+	candidates []types.RetrievalCandidate
+	protocols  []multicodec.Code
+}
+
+func (e CandidatesFilteredEvent) Code() types.EventCode                  { return types.CandidatesFilteredCode }
+func (e CandidatesFilteredEvent) Candidates() []types.RetrievalCandidate { return e.candidates }
+func (e CandidatesFilteredEvent) Protocols() []multicodec.Code           { return e.protocols }
+func (e CandidatesFilteredEvent) String() string {
+	return fmt.Sprintf("CandidatesFilteredEvent<%s, %s, %s, %d>", e.eventTime, e.retrievalId, e.payloadCid, len(e.candidates))
+}
+
+func CandidatesFiltered(at time.Time, retrievalId types.RetrievalID, payloadCid cid.Cid, candidates []types.RetrievalCandidate) CandidatesFilteredEvent {
+	c := make([]types.RetrievalCandidate, len(candidates))
+	copy(c, candidates)
+	return CandidatesFilteredEvent{retrievalEvent{at, retrievalId, payloadCid}, c, collectProtocols(c)}
+}

--- a/pkg/events/candidatesfound.go
+++ b/pkg/events/candidatesfound.go
@@ -1,0 +1,31 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+)
+
+var (
+	_ types.RetrievalEvent = CandidatesFoundEvent{}
+	_ EventWithCandidates  = CandidatesFoundEvent{}
+)
+
+type CandidatesFoundEvent struct {
+	retrievalEvent
+	candidates []types.RetrievalCandidate
+}
+
+func (e CandidatesFoundEvent) Code() types.EventCode                  { return types.CandidatesFoundCode }
+func (e CandidatesFoundEvent) Candidates() []types.RetrievalCandidate { return e.candidates }
+func (e CandidatesFoundEvent) String() string {
+	return fmt.Sprintf("CandidatesFoundEvent<%s, %s, %s, %d>", e.eventTime, e.retrievalId, e.payloadCid, len(e.candidates))
+}
+
+func CandidatesFound(at time.Time, retrievalId types.RetrievalID, payloadCid cid.Cid, candidates []types.RetrievalCandidate) CandidatesFoundEvent {
+	c := make([]types.RetrievalCandidate, len(candidates))
+	copy(c, candidates)
+	return CandidatesFoundEvent{retrievalEvent{at, retrievalId, payloadCid}, c}
+}

--- a/pkg/events/connectedtoprovider.go
+++ b/pkg/events/connectedtoprovider.go
@@ -1,0 +1,26 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+)
+
+var (
+	_ types.RetrievalEvent = ConnectedToProviderEvent{}
+	_ EventWithProviderID  = ConnectedToProviderEvent{}
+)
+
+type ConnectedToProviderEvent struct {
+	providerRetrievalEvent
+}
+
+func (e ConnectedToProviderEvent) Code() types.EventCode { return types.ConnectedToProviderCode }
+func (e ConnectedToProviderEvent) String() string {
+	return fmt.Sprintf("ConnectedToProviderEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+}
+
+func ConnectedToProvider(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) ConnectedToProviderEvent {
+	return ConnectedToProviderEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}}
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,57 +1,25 @@
 package events
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lassie/pkg/types"
-	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multicodec"
 )
 
-var (
-	_ types.RetrievalEvent = RetrievalEventCandidatesFound{}
-	_ types.RetrievalEvent = RetrievalEventCandidatesFiltered{}
-	_ types.RetrievalEvent = RetrievalEventConnected{}
-	_ types.RetrievalEvent = RetrievalEventProposed{}
-	_ types.RetrievalEvent = RetrievalEventAccepted{}
-	_ types.RetrievalEvent = RetrievalEventFirstByte{}
-	_ types.RetrievalEvent = RetrievalEventFailed{}
-	_ types.RetrievalEvent = RetrievalEventSuccess{}
-	_ types.RetrievalEvent = RetrievalEventFinished{}
-)
-
-type EventWithCandidates interface {
-	types.RetrievalEvent
-	Candidates() []types.RetrievalCandidate
-}
-
-type baseEvent struct {
-	eventTime      time.Time
-	retrievalId    types.RetrievalID
-	phaseStartTime time.Time
-	payloadCid     cid.Cid
-	protocols      []multicodec.Code
-}
-
-func (r baseEvent) Time() time.Time                { return r.eventTime }
-func (r baseEvent) RetrievalId() types.RetrievalID { return r.retrievalId }
-func (r baseEvent) PhaseStartTime() time.Time      { return r.phaseStartTime }
-func (r baseEvent) PayloadCid() cid.Cid            { return r.payloadCid }
-func (r baseEvent) Protocols() []multicodec.Code   { return r.protocols }
-
-type indexerEvent struct {
-	baseEvent
-	candidates []types.RetrievalCandidate
-}
-
-func (r indexerEvent) StorageProviderId() peer.ID             { return peer.ID("") }
-func (r indexerEvent) Candidates() []types.RetrievalCandidate { return r.candidates }
-
-type RetrievalEventCandidatesFound struct {
-	indexerEvent
+// Identifier returns the peer ID of the storage provider if this retrieval was
+// requested via peer ID, or the string "Bitswap" if this retrieval was
+// requested via the Bitswap protocol
+func Identifier(evt types.RetrievalEvent) string {
+	spEvent, spOk := evt.(EventWithProviderID)
+	if spOk && spEvent.ProviderId() != peer.ID("") {
+		return spEvent.ProviderId().String()
+	}
+	// we only want to return "Bitswap" if this is an event with a storage provider id using the bitswap protocol
+	protocolEvent, pOk := evt.(EventWithProtocol)
+	if spOk && pOk && protocolEvent.Protocol() == multicodec.TransportBitswap {
+		return types.BitswapIndentifier
+	}
+	return ""
 }
 
 func collectProtocols(candidates []types.RetrievalCandidate) []multicodec.Code {
@@ -66,189 +34,4 @@ func collectProtocols(candidates []types.RetrievalCandidate) []multicodec.Code {
 		allProtocolsArr = append(allProtocolsArr, protocol)
 	}
 	return allProtocolsArr
-}
-
-func CandidatesFound(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, payloadCid cid.Cid, candidates []types.RetrievalCandidate) RetrievalEventCandidatesFound {
-	c := make([]types.RetrievalCandidate, len(candidates))
-	copy(c, candidates)
-	return RetrievalEventCandidatesFound{indexerEvent{baseEvent{at, retrievalId, phaseStartTime, payloadCid, collectProtocols(candidates)}, c}}
-}
-
-type RetrievalEventCandidatesFiltered struct {
-	indexerEvent
-}
-
-func CandidatesFiltered(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, payloadCid cid.Cid, candidates []types.RetrievalCandidate) RetrievalEventCandidatesFiltered {
-	c := make([]types.RetrievalCandidate, len(candidates))
-	copy(c, candidates)
-	return RetrievalEventCandidatesFiltered{indexerEvent{baseEvent{at, retrievalId, phaseStartTime, payloadCid, collectProtocols(candidates)}, c}}
-}
-
-type spBaseEvent struct {
-	baseEvent
-	storageProviderId peer.ID
-}
-
-type RetrievalEventConnected struct {
-	spBaseEvent
-	phase types.Phase
-}
-
-func (r spBaseEvent) StorageProviderId() peer.ID { return r.storageProviderId }
-
-func Connected(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, phase types.Phase, candidate types.RetrievalCandidate) RetrievalEventConnected {
-	return RetrievalEventConnected{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}, phase}
-}
-
-// RetrievalEventProposed describes when the proposal took place during the RetrievalPhase
-type RetrievalEventProposed struct {
-	spBaseEvent
-}
-
-func Proposed(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, candidate types.RetrievalCandidate) RetrievalEventProposed {
-	return RetrievalEventProposed{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}}
-}
-
-// RetrievalEventStarted describes when a phase starts
-type RetrievalEventStarted struct {
-	spBaseEvent
-	phase   types.Phase
-	urlPath string
-}
-
-func StartedFetch(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, rootCid cid.Cid, urlPath string, protocols ...multicodec.Code) RetrievalEventStarted {
-	return RetrievalEventStarted{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, rootCid, protocols}, peer.ID("")}, types.FetchPhase, urlPath}
-}
-
-func Started(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, phase types.Phase, candidate types.RetrievalCandidate, protocols ...multicodec.Code) RetrievalEventStarted {
-	if len(protocols) == 0 {
-		protocols = candidate.Metadata.Protocols()
-	}
-	return RetrievalEventStarted{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, protocols}, candidate.MinerPeer.ID}, phase, ""}
-}
-
-// RetrievalEventFirstByte describes when the first byte of data was received during the RetrievalPhase
-type RetrievalEventAccepted struct {
-	spBaseEvent
-}
-
-func Accepted(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, candidate types.RetrievalCandidate) RetrievalEventAccepted {
-	return RetrievalEventAccepted{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}}
-}
-
-// RetrievalEventFirstByte describes when the first byte of data was received during the RetrievalPhase
-type RetrievalEventFirstByte struct {
-	spBaseEvent
-	duration time.Duration
-}
-
-func FirstByte(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, candidate types.RetrievalCandidate, duration time.Duration) RetrievalEventFirstByte {
-	return RetrievalEventFirstByte{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}, duration}
-}
-
-// RetrievalEventFailed describes a phase agnostic failure
-type RetrievalEventFailed struct {
-	spBaseEvent
-	phase        types.Phase
-	errorMessage string
-}
-
-func Failed(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, phase types.Phase, candidate types.RetrievalCandidate, errorMessage string) RetrievalEventFailed {
-	return RetrievalEventFailed{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}, phase, errorMessage}
-}
-
-// RetrievalEventSuccess describes a successful retrieval of data during the RetrievalPhase
-type RetrievalEventSuccess struct {
-	spBaseEvent
-	receivedSize            uint64
-	receivedCids            uint64
-	duration                time.Duration
-	totalPayment            big.Int
-	bitswapPreloadedPercent uint64
-	protocol                multicodec.Code
-}
-
-func Success(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, candidate types.RetrievalCandidate, receivedSize uint64, receivedCids uint64, duration time.Duration, totalPayment big.Int, bitswapPreloadedPercent uint64, successfulProtocol multicodec.Code) RetrievalEventSuccess {
-	return RetrievalEventSuccess{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}, receivedSize, receivedCids, duration, totalPayment, bitswapPreloadedPercent, successfulProtocol}
-}
-
-// RetrievalEventFinished describes when an entire fetch finishes
-type RetrievalEventFinished struct {
-	spBaseEvent
-}
-
-func Finished(at time.Time, retrievalId types.RetrievalID, phaseStartTime time.Time, candidate types.RetrievalCandidate) RetrievalEventFinished {
-	return RetrievalEventFinished{spBaseEvent{baseEvent{at, retrievalId, phaseStartTime, candidate.RootCid, candidate.Metadata.Protocols()}, candidate.MinerPeer.ID}}
-}
-
-func (r RetrievalEventCandidatesFound) Code() types.EventCode { return types.CandidatesFoundCode }
-func (r RetrievalEventCandidatesFound) Phase() types.Phase    { return types.IndexerPhase }
-func (r RetrievalEventCandidatesFound) String() string {
-	return fmt.Sprintf("CandidatesFoundEvent<%s, %s, %s, %d, %v>", r.eventTime, r.retrievalId, r.payloadCid, len(r.candidates), r.protocols)
-}
-func (r RetrievalEventCandidatesFiltered) Code() types.EventCode { return types.CandidatesFilteredCode }
-func (r RetrievalEventCandidatesFiltered) Phase() types.Phase    { return types.IndexerPhase }
-func (r RetrievalEventCandidatesFiltered) String() string {
-	return fmt.Sprintf("CandidatesFilteredEvent<%s, %s, %s, %d, %v>", r.eventTime, r.retrievalId, r.payloadCid, len(r.candidates), r.Protocols())
-}
-func (r RetrievalEventStarted) Code() types.EventCode { return types.StartedCode }
-func (r RetrievalEventStarted) Phase() types.Phase    { return r.phase }
-func (r RetrievalEventStarted) String() string {
-	return fmt.Sprintf("StartedEvent<%s, %s, %s, %s, %s, %v>", r.phase, r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols)
-}
-func (r RetrievalEventStarted) UrlPath() string {
-	return r.urlPath
-}
-
-func (r RetrievalEventConnected) Code() types.EventCode { return types.ConnectedCode }
-func (r RetrievalEventConnected) Phase() types.Phase    { return r.phase }
-func (r RetrievalEventConnected) String() string {
-	return fmt.Sprintf("ConnectedEvent<%s, %s, %s, %s, %s, %v>", r.phase, r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols)
-}
-func (r RetrievalEventProposed) Code() types.EventCode { return types.ProposedCode }
-func (r RetrievalEventProposed) Phase() types.Phase    { return types.RetrievalPhase }
-func (r RetrievalEventProposed) String() string {
-	return fmt.Sprintf("ProposedEvent<%s, %s, %s, %s, %v>", r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols)
-}
-func (r RetrievalEventAccepted) Code() types.EventCode { return types.AcceptedCode }
-func (r RetrievalEventAccepted) Phase() types.Phase    { return types.RetrievalPhase }
-func (r RetrievalEventAccepted) String() string {
-	return fmt.Sprintf("AcceptedEvent<%s, %s, %s, %s, %v>", r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols)
-}
-func (r RetrievalEventFirstByte) Code() types.EventCode   { return types.FirstByteCode }
-func (r RetrievalEventFirstByte) Phase() types.Phase      { return types.RetrievalPhase }
-func (r RetrievalEventFirstByte) Duration() time.Duration { return r.duration }
-func (r RetrievalEventFirstByte) String() string {
-	return fmt.Sprintf("FirstByteEvent<%s, %s, %s, %s, %v>", r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols)
-}
-func (r RetrievalEventFailed) Code() types.EventCode { return types.FailedCode }
-func (r RetrievalEventFailed) Phase() types.Phase    { return r.phase }
-
-// ErrorMessage returns a string form of the error that caused the retrieval
-// failure
-func (r RetrievalEventFailed) ErrorMessage() string { return r.errorMessage }
-func (r RetrievalEventFailed) String() string {
-	return fmt.Sprintf("FailedEvent<%s, %s, %s, %s, %v, %s>", r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols, r.errorMessage)
-}
-func (r RetrievalEventSuccess) Code() types.EventCode           { return types.SuccessCode }
-func (r RetrievalEventSuccess) Phase() types.Phase              { return types.RetrievalPhase }
-func (r RetrievalEventSuccess) Duration() time.Duration         { return r.duration }
-func (r RetrievalEventSuccess) TotalPayment() big.Int           { return r.totalPayment }
-func (r RetrievalEventSuccess) BitswapPreloadedPercent() uint64 { return r.bitswapPreloadedPercent }
-func (r RetrievalEventSuccess) Protocol() multicodec.Code       { return r.protocol }
-
-// ReceivedSize returns the number of bytes received
-func (r RetrievalEventSuccess) ReceivedSize() uint64 { return r.receivedSize }
-
-// ReceivedCids returns the number of (non-unique) CIDs received so far - note
-// that a block can exist in more than one place in the DAG so this may not
-// equal the total number of blocks transferred
-func (r RetrievalEventSuccess) ReceivedCids() uint64 { return r.receivedCids }
-func (r RetrievalEventSuccess) String() string {
-	return fmt.Sprintf("SuccessEvent<%s, %s, %s, %s, %v, { %s, %s, %d, %d }>", r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols, r.duration, r.totalPayment, r.receivedSize, r.receivedCids)
-}
-func (r RetrievalEventFinished) Code() types.EventCode { return types.FinishedCode }
-func (r RetrievalEventFinished) Phase() types.Phase    { return types.FetchPhase }
-func (r RetrievalEventFinished) String() string {
-	return fmt.Sprintf("FinishedEvent<%s, %s, %s, %s, %v>", r.eventTime, r.retrievalId, r.payloadCid, r.storageProviderId, r.protocols)
 }

--- a/pkg/events/failed.go
+++ b/pkg/events/failed.go
@@ -1,0 +1,28 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+)
+
+var (
+	_ types.RetrievalEvent  = FailedEvent{}
+	_ EventWithErrorMessage = FailedEvent{}
+)
+
+type FailedEvent struct {
+	retrievalEvent
+	errorMessage string
+}
+
+func (e FailedEvent) Code() types.EventCode { return types.FailedCode }
+func (e FailedEvent) ErrorMessage() string  { return e.errorMessage }
+func (e FailedEvent) String() string {
+	return fmt.Sprintf("FailedEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.payloadCid, e.errorMessage)
+}
+
+func Failed(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, errorMessage string) FailedEvent {
+	return FailedEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, errorMessage}
+}

--- a/pkg/events/failedretrieval.go
+++ b/pkg/events/failedretrieval.go
@@ -1,0 +1,29 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+)
+
+var (
+	_ types.RetrievalEvent  = FailedRetrievalEvent{}
+	_ EventWithProviderID   = FailedRetrievalEvent{}
+	_ EventWithErrorMessage = FailedRetrievalEvent{}
+)
+
+type FailedRetrievalEvent struct {
+	providerRetrievalEvent
+	errorMessage string
+}
+
+func (e FailedRetrievalEvent) Code() types.EventCode { return types.FailedRetrievalCode }
+func (e FailedRetrievalEvent) ErrorMessage() string  { return e.errorMessage }
+func (e FailedRetrievalEvent) String() string {
+	return fmt.Sprintf("FailedRetrievalEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.payloadCid, e.errorMessage)
+}
+
+func FailedRetrieval(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, errorMessage string) FailedRetrievalEvent {
+	return FailedRetrievalEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, errorMessage}
+}

--- a/pkg/events/finished.go
+++ b/pkg/events/finished.go
@@ -1,0 +1,26 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+)
+
+var (
+	_ types.RetrievalEvent = FinishedEvent{}
+	_ EventWithProviderID  = FinishedEvent{}
+)
+
+type FinishedEvent struct {
+	providerRetrievalEvent
+}
+
+func (e FinishedEvent) Code() types.EventCode { return types.FinishedCode }
+func (e FinishedEvent) String() string {
+	return fmt.Sprintf("FinishedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+}
+
+func Finished(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) FinishedEvent {
+	return FinishedEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}}
+}

--- a/pkg/events/firstbyte.go
+++ b/pkg/events/firstbyte.go
@@ -1,0 +1,32 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
+)
+
+var (
+	_ types.RetrievalEvent = FirstByteEvent{}
+	_ EventWithProviderID  = FirstByteEvent{}
+	_ EventWithProtocol    = FirstByteEvent{}
+)
+
+type FirstByteEvent struct {
+	providerRetrievalEvent
+	duration time.Duration
+	protocol multicodec.Code // TODO: remove when we can get the storage provider id from bitswap. This is required to determine the SP ID from events.Identifier().
+}
+
+func (e FirstByteEvent) Code() types.EventCode     { return types.FirstByteCode }
+func (e FirstByteEvent) Duration() time.Duration   { return e.duration }
+func (e FirstByteEvent) Protocol() multicodec.Code { return e.protocol }
+func (e FirstByteEvent) String() string {
+	return fmt.Sprintf("FirstByteEvent<%s, %s, %s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.duration.String(), e.protocol.String())
+}
+
+func FirstByte(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, duration time.Duration, protocol multicodec.Code) FirstByteEvent {
+	return FirstByteEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, duration, protocol}
+}

--- a/pkg/events/graphsyncaccepted.go
+++ b/pkg/events/graphsyncaccepted.go
@@ -1,0 +1,26 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+)
+
+var (
+	_ types.RetrievalEvent = GraphsyncAcceptedEvent{}
+	_ EventWithProviderID  = GraphsyncAcceptedEvent{}
+)
+
+type GraphsyncAcceptedEvent struct {
+	providerRetrievalEvent
+}
+
+func (e GraphsyncAcceptedEvent) Code() types.EventCode { return types.AcceptedCode }
+func (e GraphsyncAcceptedEvent) String() string {
+	return fmt.Sprintf("GraphsyncAcceptedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+}
+
+func Accepted(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) GraphsyncAcceptedEvent {
+	return GraphsyncAcceptedEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}}
+}

--- a/pkg/events/graphsyncproposed.go
+++ b/pkg/events/graphsyncproposed.go
@@ -1,0 +1,26 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+)
+
+var (
+	_ types.RetrievalEvent = GraphsyncProposedEvent{}
+	_ EventWithProviderID  = GraphsyncProposedEvent{}
+)
+
+type GraphsyncProposedEvent struct {
+	providerRetrievalEvent
+}
+
+func (e GraphsyncProposedEvent) Code() types.EventCode { return types.ProposedCode }
+func (e GraphsyncProposedEvent) String() string {
+	return fmt.Sprintf("GraphsyncProposedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+}
+
+func Proposed(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) GraphsyncProposedEvent {
+	return GraphsyncProposedEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}}
+}

--- a/pkg/events/startedfetch.go
+++ b/pkg/events/startedfetch.go
@@ -1,0 +1,33 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
+)
+
+var (
+	_ types.RetrievalEvent = StartedFetchEvent{}
+	_ EventWithProtocols   = StartedFetchEvent{}
+)
+
+// StartedFetchEvent signals the start of a Lassie fetch. It is emitted when a fetch is started.
+type StartedFetchEvent struct {
+	retrievalEvent
+	urlPath            string
+	supportedProtocols []multicodec.Code
+}
+
+func (e StartedFetchEvent) Code() types.EventCode        { return types.StartedFetchCode }
+func (e StartedFetchEvent) UrlPath() string              { return e.urlPath }
+func (e StartedFetchEvent) Protocols() []multicodec.Code { return e.supportedProtocols }
+func (e StartedFetchEvent) String() string {
+	return fmt.Sprintf("StartedFetchEvent<%s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid)
+}
+
+func StartedFetch(at time.Time, retrievalId types.RetrievalID, rootCid cid.Cid, urlPath string, supportedProtocols ...multicodec.Code) StartedFetchEvent {
+	return StartedFetchEvent{retrievalEvent{at, retrievalId, rootCid}, urlPath, supportedProtocols}
+}

--- a/pkg/events/startedfindingcandidates.go
+++ b/pkg/events/startedfindingcandidates.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/ipfs/go-cid"
+)
+
+var _ types.RetrievalEvent = StartedFindingCandidatesEvent{}
+
+// StartedFindingCandidatesEvent signals the start of finding candidates for a fetch.
+type StartedFindingCandidatesEvent struct {
+	retrievalEvent
+}
+
+func (e StartedFindingCandidatesEvent) Code() types.EventCode {
+	return types.StartedFindingCandidatesCode
+}
+func (e StartedFindingCandidatesEvent) String() string {
+	return fmt.Sprintf("StartedFindingCandidatesEvent<%s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid)
+}
+
+func StartedFindingCandidates(at time.Time, retrievalId types.RetrievalID, payloadCid cid.Cid) StartedFindingCandidatesEvent {
+	return StartedFindingCandidatesEvent{retrievalEvent{at, retrievalId, payloadCid}}
+}

--- a/pkg/events/startedretrieval.go
+++ b/pkg/events/startedretrieval.go
@@ -1,0 +1,31 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
+)
+
+var (
+	_ types.RetrievalEvent = StartedRetrievalEvent{}
+	_ EventWithProviderID  = StartedRetrievalEvent{}
+	_ EventWithProtocol    = StartedRetrievalEvent{}
+)
+
+// StartedRetrievalEvent signals the start of a retrieval from a storage provider. It is emitted when the retrieval is started.
+type StartedRetrievalEvent struct {
+	providerRetrievalEvent
+	protocol multicodec.Code
+}
+
+func (e StartedRetrievalEvent) Code() types.EventCode     { return types.StartedRetrievalCode }
+func (e StartedRetrievalEvent) Protocol() multicodec.Code { return e.protocol }
+func (e StartedRetrievalEvent) String() string {
+	return fmt.Sprintf("StartedRetrievalEvent<%s, %s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.protocol)
+}
+
+func StartedRetrieval(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code) StartedRetrievalEvent {
+	return StartedRetrievalEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, protocol}
+}

--- a/pkg/events/succeeded.go
+++ b/pkg/events/succeeded.go
@@ -1,0 +1,36 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
+)
+
+var (
+	_ types.RetrievalEvent = SucceededEvent{}
+	_ EventWithProviderID  = SucceededEvent{}
+	_ EventWithProtocol    = SucceededEvent{}
+)
+
+type SucceededEvent struct {
+	providerRetrievalEvent
+	receivedBytesSize uint64
+	receivedCidsCount uint64
+	duration          time.Duration
+	protocol          multicodec.Code
+}
+
+func (e SucceededEvent) Code() types.EventCode     { return types.SuccessCode }
+func (e SucceededEvent) ReceivedBytesSize() uint64 { return e.receivedBytesSize }
+func (e SucceededEvent) ReceivedCidsCount() uint64 { return e.receivedCidsCount }
+func (e SucceededEvent) Duration() time.Duration   { return e.duration }
+func (e SucceededEvent) Protocol() multicodec.Code { return e.protocol }
+func (e SucceededEvent) String() string {
+	return fmt.Sprintf("SucceededEvent<%s, %s, %s, %s, { %d, %d, %s, %s }>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.receivedBytesSize, e.receivedCidsCount, e.protocol, e.duration)
+}
+
+func Success(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, receivedBytesSize uint64, receivedCidsCount uint64, duration time.Duration, protocol multicodec.Code) SucceededEvent {
+	return SucceededEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, receivedBytesSize, receivedCidsCount, duration, protocol}
+}

--- a/pkg/internal/testutil/collectingeventlsubscriber.go
+++ b/pkg/internal/testutil/collectingeventlsubscriber.go
@@ -76,39 +76,21 @@ func (el *CollectingEventsListener) Collect(event types.RetrievalEvent) {
 	el.CollectedEvents = append(el.CollectedEvents, event)
 }
 
-func VerifyCollectedEventTimings(t *testing.T, events []types.RetrievalEvent) {
-	for i, event := range events {
-		if i == 0 {
-			continue
-		}
-		prevEvent := events[i-1]
-		// verify that each event comes after the previous one, but allow some
-		// flexibility for overlapping event types
-		if event.Code() != prevEvent.Code() {
-			require.True(t, event.Time() == prevEvent.Time() || event.Time().After(prevEvent.Time()), "event time order for %s/%s vs %s/%s", prevEvent.Code(), prevEvent.Phase(), event.Code(), event.Phase())
-		}
-		if event.Phase() == prevEvent.Phase() {
-			require.Equal(t, event.PhaseStartTime(), prevEvent.PhaseStartTime(), "same phase start time for %s in %s vs %s", event.Phase(), prevEvent.Code(), event.Code())
-		}
-	}
-}
-
 func VerifyContainsCollectedEvent(t *testing.T, afterStart time.Duration, expectedList []types.RetrievalEvent, actual types.RetrievalEvent) types.EventCode {
 	for _, expected := range expectedList {
-		// this matching might need to evolve to be more sophisticated, particularly SP ID
 		if actual.Code() == expected.Code() &&
-			actual.RetrievalId() == expected.RetrievalId() &&
-			actual.PayloadCid() == expected.PayloadCid() &&
-			actual.Phase() == expected.Phase() &&
-			actual.StorageProviderId() == expected.StorageProviderId() {
-			VerifyCollectedEvent(t, actual, expected)
-			return actual.Code()
-		}
-		/*
-			if actual.Code() == expected.Code() {
-				t.Logf("non-matching event: %s <> %s\n", actual, expected)
+			actual.RetrievalId() == expected.RetrievalId() {
+
+			actualSpEvent, aspOk := actual.(events.EventWithProviderID)
+			expectedSpEvent, espOk := expected.(events.EventWithProviderID)
+			haveMatchingSpIDs := aspOk && espOk && expectedSpEvent.ProviderId() == actualSpEvent.ProviderId()
+			haveNoSpIDs := !aspOk && !espOk
+
+			if haveMatchingSpIDs || haveNoSpIDs {
+				VerifyCollectedEvent(t, actual, expected)
+				return actual.Code()
 			}
-		*/
+		}
 	}
 	require.Failf(t, "unexpected event", "got '%s' @ %s", actual.Code(), afterStart)
 	return ""
@@ -118,10 +100,15 @@ func VerifyCollectedEvent(t *testing.T, actual types.RetrievalEvent, expected ty
 	require.Equal(t, expected.Code(), actual.Code(), "event code")
 	require.Equal(t, expected.RetrievalId(), actual.RetrievalId(), fmt.Sprintf("retrieval id for %s", expected.Code()))
 	require.Equal(t, expected.PayloadCid(), actual.PayloadCid(), fmt.Sprintf("cid for %s", expected.Code()))
-	require.Equal(t, expected.Phase(), actual.Phase(), fmt.Sprintf("phase for %s", expected.Code()))
-	require.Equal(t, expected.PhaseStartTime(), actual.PhaseStartTime(), fmt.Sprintf("phase start time for %s", expected.Code()))
 	require.Equal(t, expected.Time(), actual.Time(), fmt.Sprintf("time for %s", expected.Code()))
-	require.Equal(t, expected.StorageProviderId(), actual.StorageProviderId(), fmt.Sprintf("storage provider id for %s", expected.Code()))
+
+	if asp, ok := actual.(events.EventWithProviderID); ok {
+		esp, ok := expected.(events.EventWithProviderID)
+		if !ok {
+			require.Fail(t, fmt.Sprintf("expected event %s should be EventWithSPID", expected.Code()))
+		}
+		require.Equal(t, esp.ProviderId().String(), asp.ProviderId().String(), fmt.Sprintf("storage provider id for %s", expected.Code()))
+	}
 	if ec, ok := expected.(events.EventWithCandidates); ok {
 		if ac, ok := actual.(events.EventWithCandidates); ok {
 			require.Len(t, ac.Candidates(), len(ec.Candidates()), fmt.Sprintf("candidate length for %s", expected.Code()))
@@ -142,24 +129,24 @@ func VerifyCollectedEvent(t *testing.T, actual types.RetrievalEvent, expected ty
 			require.Fail(t, "wrong event type, no Candidates", expected.Code())
 		}
 	}
-	if efb, ok := expected.(events.RetrievalEventFirstByte); ok {
-		if afb, ok := actual.(events.RetrievalEventFirstByte); ok {
+	if efb, ok := expected.(events.FirstByteEvent); ok {
+		if afb, ok := actual.(events.FirstByteEvent); ok {
 			require.Equal(t, efb.Duration(), afb.Duration(), fmt.Sprintf("duration for %s", expected.Code()))
 		} else {
 			require.Fail(t, "wrong event type", expected.Code())
 		}
 	}
-	if efail, ok := expected.(events.RetrievalEventFailed); ok {
-		if afail, ok := actual.(events.RetrievalEventFailed); ok {
+	if efail, ok := expected.(events.FailedEvent); ok {
+		if afail, ok := actual.(events.FailedEvent); ok {
 			require.Equal(t, efail.ErrorMessage(), afail.ErrorMessage(), fmt.Sprintf("error message for %s", expected.Code()))
 		} else {
 			require.Fail(t, "wrong event type", expected.Code())
 		}
 	}
-	if esuccess, ok := expected.(events.RetrievalEventSuccess); ok {
-		if asuccess, ok := actual.(events.RetrievalEventSuccess); ok {
-			require.Equal(t, esuccess.ReceivedSize(), asuccess.ReceivedSize(), fmt.Sprintf("received size for %s", expected.Code()))
-			require.Equal(t, esuccess.ReceivedCids(), asuccess.ReceivedCids(), fmt.Sprintf("received cids for %s", expected.Code()))
+	if esuccess, ok := expected.(events.SucceededEvent); ok {
+		if asuccess, ok := actual.(events.SucceededEvent); ok {
+			require.Equal(t, esuccess.ReceivedBytesSize(), asuccess.ReceivedBytesSize(), fmt.Sprintf("received size for %s", expected.Code()))
+			require.Equal(t, esuccess.ReceivedCidsCount(), asuccess.ReceivedCidsCount(), fmt.Sprintf("received cids for %s", expected.Code()))
 			require.Equal(t, esuccess.Duration(), asuccess.Duration(), fmt.Sprintf("duration for %s", expected.Code()))
 		} else {
 			require.Fail(t, "wrong event type", expected.Code())

--- a/pkg/retriever/assignablecandidatefinder_test.go
+++ b/pkg/retriever/assignablecandidatefinder_test.go
@@ -42,8 +42,8 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: {"apples", "oranges", "cheese"},
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
-				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid1: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid2: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
 			},
 		},
 		{
@@ -54,8 +54,8 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: fmt.Errorf("could not get retrieval candidates for %s: %w", cid2, errors.New("something went wrong")),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FailedCode},
-				cid2: {types.StartedCode, types.FailedCode},
+				cid1: {types.StartedFindingCandidatesCode, types.FailedCode},
+				cid2: {types.StartedFindingCandidatesCode, types.FailedCode},
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: {"apples", "oranges", "cheese"},
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FailedCode},
-				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid1: {types.StartedFindingCandidatesCode, types.FailedCode},
+				cid2: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
 			},
 		},
 		{
@@ -87,8 +87,8 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: {"oranges", "cheese"},
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
-				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid1: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid2: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
 			},
 		},
 		{
@@ -105,8 +105,8 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: {"apples", "oranges", "cheese"},
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.CandidatesFoundCode, types.FailedCode},
-				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid1: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.FailedCode},
+				cid2: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
 			},
 		},
 		{
@@ -124,8 +124,8 @@ func TestAssignableCandidateFinder(t *testing.T) {
 				cid2: {"super", "duper"},
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
-				cid2: {types.StartedCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid1: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
+				cid2: {types.StartedFindingCandidatesCode, types.CandidatesFoundCode, types.CandidatesFilteredCode},
 			},
 		},
 	}

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -81,8 +81,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
-				cid2: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.SuccessCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.SuccessCode},
 			},
 			expectedCids: allCids,
 			expectedRemoteCids: map[cid.Cid][]cid.Cid{
@@ -127,8 +127,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
-				cid2: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.SuccessCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.SuccessCode},
 			},
 			// only expect to bitswap fetch the blocks we don't have
 			expectedRemoteCids: map[cid.Cid][]cid.Cid{
@@ -171,8 +171,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
-				cid2: {types.StartedCode, types.FirstByteCode, types.SuccessCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.SuccessCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.SuccessCode},
 			},
 			expectedCids: append(append([]cid.Cid{}, tbc1Cids[:5]...), tbc2Cids[:5]...),
 			expectedRemoteCids: map[cid.Cid][]cid.Cid{
@@ -211,8 +211,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FirstByteCode, types.FailedCode},
-				cid2: {types.StartedCode, types.FirstByteCode, types.FailedCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
 			},
 			expectedErrors: map[cid.Cid]struct{}{
 				cid1: {},
@@ -232,8 +232,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FailedCode},
-				cid2: {types.StartedCode, types.FailedCode},
+				cid1: {types.StartedRetrievalCode, types.FailedRetrievalCode},
+				cid2: {types.StartedRetrievalCode, types.FailedRetrievalCode},
 			},
 			expectedErrors: map[cid.Cid]struct{}{
 				cid1: {},
@@ -261,8 +261,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedCode, types.FirstByteCode, types.FailedCode},
-				cid2: {types.StartedCode, types.FirstByteCode, types.FailedCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
 			},
 			expectedErrors: map[cid.Cid]struct{}{
 				cid1: {},

--- a/pkg/retriever/graphsyncretriever_test.go
+++ b/pkg/retriever/graphsyncretriever_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lassie/pkg/events"
 	"github.com/filecoin-project/lassie/pkg/internal/testutil"
 	"github.com/filecoin-project/lassie/pkg/retriever"
@@ -59,15 +58,15 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -80,10 +79,10 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*40 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Accepted(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.FirstByte(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, time.Millisecond*20),
-						events.Success(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, 1, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.Accepted(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.FirstByte(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, time.Millisecond*20, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, 1, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -110,15 +109,15 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -131,8 +130,8 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*50 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Connected(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 50},
@@ -142,10 +141,10 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*520 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Accepted(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.FirstByte(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, time.Millisecond*500),
-						events.Success(startTime.Add(time.Millisecond*520+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, 1, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+						events.Proposed(startTime.Add(time.Millisecond*520+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.Accepted(startTime.Add(time.Millisecond*520+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.FirstByte(startTime.Add(time.Millisecond*520+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, time.Millisecond*500, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(time.Millisecond*520+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, 1, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerFoo, Duration: time.Millisecond * 500},
@@ -172,17 +171,17 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Failed(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "unable to connect to provider: Nope"),
-						events.Failed(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, "unable to connect to provider: Nope"),
-						events.Failed(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, "unable to connect to provider: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "unable to connect to provider: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, "unable to connect to provider: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, "unable to connect to provider: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -210,15 +209,15 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -231,8 +230,8 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*40 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Failed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -242,7 +241,7 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:         time.Millisecond * 60,
 					ReceivedRetrievals: []peer.ID{peerBar},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*60), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*60), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 60},
@@ -251,10 +250,10 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 80,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Accepted(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.FirstByte(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, time.Millisecond*20),
-						events.Success(startTime.Add(time.Millisecond*80), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, 2, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+						events.Proposed(startTime.Add(time.Millisecond*80), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.Accepted(startTime.Add(time.Millisecond*80), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.FirstByte(startTime.Add(time.Millisecond*80), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, time.Millisecond*20, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(time.Millisecond*80), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, 2, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerBar, Duration: time.Millisecond * 20},
@@ -281,15 +280,15 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*20), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -298,7 +297,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 25,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*25), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*25), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 25},
@@ -311,7 +310,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 60,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*60), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*60), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBaz, Duration: time.Millisecond * 60},
@@ -321,8 +320,8 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:         time.Millisecond*120 + initialPause,
 					ReceivedRetrievals: []peer.ID{peerBar},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Failed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -332,8 +331,8 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:         time.Millisecond*220 + initialPause,
 					ReceivedRetrievals: []peer.ID{peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*220+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Failed(startTime.Add(time.Millisecond*220+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*220+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*220+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerBar},
@@ -342,8 +341,8 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*320 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*320+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Failed(startTime.Add(time.Millisecond*320+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*320+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*320+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerBaz},
@@ -378,16 +377,16 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz, peerBang},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 1,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*1), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 1},
@@ -400,9 +399,9 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -414,8 +413,8 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:         time.Millisecond*201 + initialPause,
 					ReceivedRetrievals: []peer.ID{peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*201+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Failed(startTime.Add(time.Millisecond*201+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*201+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*201+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -424,10 +423,10 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*221 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Accepted(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.FirstByte(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, time.Millisecond*20),
-						events.Success(startTime.Add(time.Millisecond*221+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, 2, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+						events.Proposed(startTime.Add(time.Millisecond*221+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.Accepted(startTime.Add(time.Millisecond*221+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.FirstByte(startTime.Add(time.Millisecond*221+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, time.Millisecond*20, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(time.Millisecond*221+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, 2, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerBaz, Duration: time.Millisecond * 20},
@@ -461,17 +460,17 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerBar, peerBaz, peerBang},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -486,10 +485,10 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*120 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Accepted(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.FirstByte(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, time.Millisecond*20),
-						events.Success(startTime.Add(time.Millisecond*120+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, 2, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.Accepted(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.FirstByte(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, time.Millisecond*20, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, 2, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerBaz, Duration: time.Millisecond * 20},
@@ -522,16 +521,16 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:          0,
 					ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz, peerBang},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: time.Millisecond * 1,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*1), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 1},
@@ -544,7 +543,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBang, Duration: time.Millisecond * 100},
@@ -553,7 +552,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 200,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*200), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*200), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBaz, Duration: time.Millisecond * 200},
@@ -562,7 +561,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 220,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(time.Millisecond*220), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*220), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 220},
@@ -572,8 +571,8 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:         time.Millisecond*401 + initialPause,
 					ReceivedRetrievals: []peer.ID{peerBang},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*401+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.Failed(startTime.Add(time.Millisecond*401+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.Proposed(startTime.Add(time.Millisecond*401+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*401+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -582,10 +581,10 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*421 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
-						events.Accepted(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
-						events.FirstByte(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, time.Millisecond*20),
-						events.Success(startTime.Add(time.Millisecond*421+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, 4, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+						events.Proposed(startTime.Add(time.Millisecond*421+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.Accepted(startTime.Add(time.Millisecond*421+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.FirstByte(startTime.Add(time.Millisecond*421+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, time.Millisecond*20, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(time.Millisecond*421+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, 4, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerBang, Duration: time.Millisecond * 20},
@@ -708,19 +707,19 @@ func TestMultipleRetrievals(t *testing.T) {
 			AfterStart:          0,
 			ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz, peerBang, peerBoom, peerBing},
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Started(startTime, retrievalID1, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-				events.Started(startTime, retrievalID1, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-				events.Started(startTime, retrievalID1, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-				events.Started(startTime, retrievalID2, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
-				events.Started(startTime, retrievalID2, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBoom}}),
-				events.Started(startTime, retrievalID2, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
+				events.StartedRetrieval(startTime, retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBoom}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 		},
 		{
 			AfterStart: time.Millisecond * 1,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Failed(startTime.Add(time.Millisecond*1), retrievalID2, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBoom}}, "unable to connect to provider: Nope"),
-				events.Connected(startTime.Add(time.Millisecond*1), retrievalID1, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+				events.FailedRetrieval(startTime.Add(time.Millisecond*1), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBoom}}, "unable to connect to provider: Nope"),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Failure, Provider: peerBoom},
@@ -734,8 +733,8 @@ func TestMultipleRetrievals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond*2 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-				events.Failed(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+				events.Proposed(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+				events.FailedRetrieval(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -744,8 +743,8 @@ func TestMultipleRetrievals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 100,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Connected(startTime.Add(time.Millisecond*100), retrievalID1, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-				events.Connected(startTime.Add(time.Millisecond*100), retrievalID2, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -763,10 +762,10 @@ func TestMultipleRetrievals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 300,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*300), retrievalID1, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-				events.Accepted(startTime.Add(time.Millisecond*300), retrievalID1, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-				events.FirstByte(startTime.Add(time.Millisecond*300), retrievalID1, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, time.Millisecond*200),
-				events.Success(startTime.Add(time.Millisecond*300), retrievalID1, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, 2, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+				events.Proposed(startTime.Add(time.Millisecond*300), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+				events.Accepted(startTime.Add(time.Millisecond*300), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+				events.FirstByte(startTime.Add(time.Millisecond*300), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, time.Millisecond*200, multicodec.TransportGraphsyncFilecoinv1),
+				events.Success(startTime.Add(time.Millisecond*300), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, 2, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_FirstByte, Provider: peerBar, Duration: time.Millisecond * 200},
@@ -776,10 +775,10 @@ func TestMultipleRetrievals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond*301 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
-				events.Accepted(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
-				events.FirstByte(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}, time.Millisecond*201),
-				events.Success(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}, 3, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+				events.Proposed(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
+				events.Accepted(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
+				events.FirstByte(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}, time.Millisecond*201, multicodec.TransportGraphsyncFilecoinv1),
+				events.Success(startTime.Add(time.Millisecond*301+initialPause), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}, 3, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_FirstByte, Provider: peerBing, Duration: time.Millisecond * 201},
@@ -920,15 +919,15 @@ func TestDuplicateRetreivals(t *testing.T) {
 			AfterStart:          0,
 			ReceivedConnections: []peer.ID{peerFoo, peerBar, peerBaz},
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-				events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-				events.Started(startTime, retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+				events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.StartedRetrieval(startTime, retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 		},
 		{
 			AfterStart: time.Millisecond * 50,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Connected(startTime.Add(time.Millisecond*50), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*50), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 50},
@@ -941,7 +940,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 75,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Connected(startTime.Add(time.Millisecond*75), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*75), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerBaz, Duration: time.Millisecond * 75},
@@ -950,7 +949,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 100,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Connected(startTime.Add(time.Millisecond*100), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -960,8 +959,8 @@ func TestDuplicateRetreivals(t *testing.T) {
 			AfterStart:         time.Millisecond*200 + initialPause,
 			ReceivedRetrievals: []peer.ID{peerBar},
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*200+initialPause), retrievalID, startTime, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-				events.Failed(startTime.Add(time.Millisecond*200+initialPause), retrievalID, startTime, types.RetrievalPhase, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+				events.Proposed(startTime.Add(time.Millisecond*200+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+				events.FailedRetrieval(startTime.Add(time.Millisecond*200+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -970,10 +969,10 @@ func TestDuplicateRetreivals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond*400 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.Proposed(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
-				events.Accepted(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
-				events.FirstByte(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), time.Millisecond*200),
-				events.Success(startTime.Add(time.Millisecond*400+initialPause), retrievalID, startTime, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), 2, 0, 0, big.Zero(), 0, multicodec.TransportGraphsyncFilecoinv1),
+				events.Proposed(startTime.Add(time.Millisecond*400+initialPause), retrievalID, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.Accepted(startTime.Add(time.Millisecond*400+initialPause), retrievalID, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false})),
+				events.FirstByte(startTime.Add(time.Millisecond*400+initialPause), retrievalID, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), time.Millisecond*200, multicodec.TransportGraphsyncFilecoinv1),
+				events.Success(startTime.Add(time.Millisecond*400+initialPause), retrievalID, types.NewRetrievalCandidate(peerBar, nil, cid.Undef, &metadata.GraphsyncFilecoinV1{PieceCID: cid.Cid{}, VerifiedDeal: true, FastRetrieval: false}), 2, 0, 0, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_FirstByte, Provider: peerBar, Duration: time.Millisecond * 200},

--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -77,7 +77,7 @@ func (ph ProtocolHttp) GetMergedMetadata(cid cid.Cid, currentMetadata, newMetada
 	return &metadata.IpfsGatewayHttp{}
 }
 
-func (ph *ProtocolHttp) Connect(ctx context.Context, retrieval *retrieval, phaseStartTime time.Time, candidate types.RetrievalCandidate) (time.Duration, error) {
+func (ph *ProtocolHttp) Connect(ctx context.Context, retrieval *retrieval, startTime time.Time, candidate types.RetrievalCandidate) (time.Duration, error) {
 	// We could begin the request here by moving ph.beginRequest() to this function.
 	// That would result in parallel connections to candidates as they are received,
 	// then serial reading of bodies.
@@ -94,7 +94,6 @@ func (ph *ProtocolHttp) Retrieve(
 	ctx context.Context,
 	retrieval *retrieval,
 	shared *retrievalShared,
-	phaseStartTime time.Time,
 	timeout time.Duration,
 	candidate types.RetrievalCandidate,
 ) (*types.RetrievalStats, error) {
@@ -118,7 +117,7 @@ func (ph *ProtocolHttp) Retrieve(
 	var ttfb time.Duration
 	rdr := newTimeToFirstByteReader(resp.Body, func() {
 		ttfb = retrieval.Clock.Since(retrievalStart)
-		shared.sendEvent(events.FirstByte(retrieval.Clock.Now(), retrieval.request.RetrievalID, phaseStartTime, candidate, ttfb))
+		shared.sendEvent(events.FirstByte(retrieval.Clock.Now(), retrieval.request.RetrievalID, candidate, ttfb, multicodec.TransportIpfsGatewayHttp))
 	})
 	cfg := verifiedcar.Config{
 		Root:               retrieval.request.Cid,

--- a/pkg/retriever/httpretriever_test.go
+++ b/pkg/retriever/httpretriever_test.go
@@ -100,8 +100,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -114,7 +114,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*40), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*40),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*40), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*40, multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: cid1Cands[0].MinerPeer.ID, Duration: time.Millisecond * 40},
@@ -123,7 +123,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40 + remoteBlockDuration*100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Success(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*100), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), sizeOf(tbc2.AllBlocks()), 100, 40*time.Millisecond+remoteBlockDuration*100, big.Zero(), 0, multicodec.TransportIpfsGatewayHttp),
+						events.Success(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*100), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), sizeOf(tbc2.AllBlocks()), 100, 40*time.Millisecond+remoteBlockDuration*100, multicodec.TransportIpfsGatewayHttp),
 					},
 					ServedRetrievals: []testutil.RemoteStats{
 						{
@@ -187,10 +187,10 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Started(startTime, rid2, startTime, types.RetrievalPhase, toCandidate(cid2, cid2Cands[0].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Connected(startTime, rid2, startTime, types.RetrievalPhase, toCandidate(cid2, cid2Cands[0].MinerPeer)),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.StartedRetrieval(startTime, rid2, toCandidate(cid2, cid2Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid2, toCandidate(cid2, cid2Cands[0].MinerPeer)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -204,7 +204,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*10,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid2, startTime, toCandidate(cid2, cid2Cands[0].MinerPeer), time.Millisecond*10),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid2, toCandidate(cid2, cid2Cands[0].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: cid2Cands[0].MinerPeer.ID, Duration: time.Millisecond * 10},
@@ -213,7 +213,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*40), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*40),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*40), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*40, multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: cid1Cands[0].MinerPeer.ID, Duration: time.Millisecond * 40},
@@ -222,7 +222,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*10 + remoteBlockDuration*100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Success(startTime.Add(initialPause+time.Millisecond*10+remoteBlockDuration*100), rid2, startTime, toCandidate(cid2, cid2Cands[0].MinerPeer), sizeOf(tbc2.AllBlocks()), 100, 10*time.Millisecond+remoteBlockDuration*100, big.Zero(), 0, multicodec.TransportIpfsGatewayHttp),
+						events.Success(startTime.Add(initialPause+time.Millisecond*10+remoteBlockDuration*100), rid2, toCandidate(cid2, cid2Cands[0].MinerPeer), sizeOf(tbc2.AllBlocks()), 100, 10*time.Millisecond+remoteBlockDuration*100, multicodec.TransportIpfsGatewayHttp),
 					},
 					ServedRetrievals: []testutil.RemoteStats{
 						{
@@ -240,7 +240,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40 + remoteBlockDuration*100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Success(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*100), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), sizeOf(tbc1.AllBlocks()), 100, 40*time.Millisecond+remoteBlockDuration*100, big.Zero(), 0, multicodec.TransportIpfsGatewayHttp),
+						events.Success(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*100), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), sizeOf(tbc1.AllBlocks()), 100, 40*time.Millisecond+remoteBlockDuration*100, multicodec.TransportIpfsGatewayHttp),
 					},
 					ServedRetrievals: []testutil.RemoteStats{
 						{
@@ -292,12 +292,12 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[1].MinerPeer)),
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[2].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[1].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[2].MinerPeer)),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -312,8 +312,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*10,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*10),
-						events.Failed(startTime.Add(initialPause+time.Millisecond*10), rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[0].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[1].MinerPeer.ID},
@@ -333,8 +333,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*20), rid1, startTime, toCandidate(cid1, cid1Cands[1].MinerPeer), time.Millisecond*10),
-						events.Failed(startTime.Add(initialPause+time.Millisecond*20), rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[1].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[1].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[2].MinerPeer.ID},
@@ -354,8 +354,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*30,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*30), rid1, startTime, toCandidate(cid1, cid1Cands[2].MinerPeer), time.Millisecond*10),
-						events.Failed(startTime.Add(initialPause+time.Millisecond*30), rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[2].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*30), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*30), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[2].MinerPeer.ID},
 					ServedRetrievals: []testutil.RemoteStats{
@@ -418,12 +418,12 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[1].MinerPeer)),
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[2].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[1].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[2].MinerPeer)),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -438,8 +438,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*10,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*10),
-						events.Failed(startTime.Add(initialPause+time.Millisecond*10), rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[0].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[1].MinerPeer.ID},
@@ -459,8 +459,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*20), rid1, startTime, toCandidate(cid1, cid1Cands[1].MinerPeer), time.Millisecond*10),
-						events.Failed(startTime.Add(initialPause+time.Millisecond*20), rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[1].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[1].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[2].MinerPeer.ID},
@@ -480,7 +480,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*30,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*30), rid1, startTime, toCandidate(cid1, cid1Cands[2].MinerPeer), time.Millisecond*10),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*30), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: cid1Cands[2].MinerPeer.ID, Duration: time.Millisecond * 10},
@@ -489,7 +489,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*30 + remoteBlockDuration*100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Success(startTime.Add(initialPause+time.Millisecond*30+remoteBlockDuration*100), rid1, startTime, toCandidate(cid1, cid1Cands[2].MinerPeer), sizeOf(tbc2.AllBlocks()), 100, 10*time.Millisecond+remoteBlockDuration*100, big.Zero(), 0, multicodec.TransportIpfsGatewayHttp),
+						events.Success(startTime.Add(initialPause+time.Millisecond*30+remoteBlockDuration*100), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), sizeOf(tbc2.AllBlocks()), 100, 10*time.Millisecond+remoteBlockDuration*100, multicodec.TransportIpfsGatewayHttp),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[2].MinerPeer.ID},
 					ServedRetrievals: []testutil.RemoteStats{
@@ -530,8 +530,8 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Started(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.Connected(startTime, rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID},
@@ -544,7 +544,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FirstByte(startTime.Add(initialPause+time.Millisecond*40), rid1, startTime, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*40),
+						events.FirstByte(startTime.Add(initialPause+time.Millisecond*40), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*40, multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: cid1Cands[0].MinerPeer.ID, Duration: time.Millisecond * 40},
@@ -553,7 +553,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40 + remoteBlockDuration*50,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Failed(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*50), rid1, startTime, types.RetrievalPhase, toCandidate(cid1, cid1Cands[0].MinerPeer), "missing block in CAR; ipld: could not find "+tbc1.AllBlocks()[50].Cid().String()),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*50), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), "missing block in CAR; ipld: could not find "+tbc1.AllBlocks()[50].Cid().String()),
 					},
 					ServedRetrievals: []testutil.RemoteStats{
 						{

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -131,8 +131,6 @@ func (retriever *Retriever) Retrieve(
 	request types.RetrievalRequest,
 	eventsCB func(types.RetrievalEvent),
 ) (*types.RetrievalStats, error) {
-	startTime := retriever.clock.Now()
-
 	ctx = types.RegisterRetrievalIDToContext(ctx, request.RetrievalID)
 	if !retriever.eventManager.IsStarted() {
 		return nil, ErrRetrieverNotStarted
@@ -158,8 +156,9 @@ func (retriever *Retriever) Retrieve(
 	)
 
 	urlPath, _ := request.GetUrlPath()
-	// Emit a Started event denoting that the entire fetch phase has started
-	onRetrievalEvent(events.StartedFetch(retriever.clock.Now(), request.RetrievalID, startTime, request.Cid, urlPath, request.GetSupportedProtocols(retriever.protocols)...))
+
+	// Emit a StartedFetch event signaling that the Lassie fetch has started
+	onRetrievalEvent(events.StartedFetch(retriever.clock.Now(), request.RetrievalID, request.Cid, urlPath, request.GetSupportedProtocols(retriever.protocols)...))
 
 	// retrieve, note that we could get a successful retrieval
 	// (retrievalStats!=nil) _and_ also an error return because there may be
@@ -171,8 +170,8 @@ func (retriever *Retriever) Retrieve(
 		onRetrievalEvent,
 	)
 
-	// Emit a Finished event denoting that the entire fetch phase has finished
-	onRetrievalEvent(events.Finished(retriever.clock.Now(), request.RetrievalID, startTime, types.RetrievalCandidate{RootCid: request.Cid}))
+	// Emit a Finished event denoting that the entire fetch has finished
+	onRetrievalEvent(events.Finished(retriever.clock.Now(), request.RetrievalID, types.RetrievalCandidate{RootCid: request.Cid}))
 
 	if err != nil && retrievalStats == nil {
 		return nil, err
@@ -210,9 +209,9 @@ func makeOnRetrievalEvent(
 		logEvent(event)
 
 		switch ret := event.(type) {
-		case events.RetrievalEventCandidatesFiltered:
+		case events.CandidatesFilteredEvent:
 			handleCandidatesFilteredEvent(retrievalId, session, retrievalCid, ret)
-		case events.RetrievalEventFailed:
+		case events.FailedRetrievalEvent:
 			handleFailureEvent(ctx, session, retrievalId, eventStats, ret)
 		}
 		eventManager.DispatchEvent(event)
@@ -228,25 +227,22 @@ func handleFailureEvent(
 	session Session,
 	retrievalId types.RetrievalID,
 	eventStats *eventStats,
-	event events.RetrievalEventFailed,
+	event events.FailedRetrievalEvent,
 ) {
-	switch event.Phase() {
-	case types.RetrievalPhase:
-		eventStats.failedCount++
-		logger.Warnf(
-			"Failed to retrieve from miner %s for %s: %s",
-			event.StorageProviderId(),
-			event.PayloadCid(),
-			event.ErrorMessage(),
-		)
-	}
+	eventStats.failedCount++
+	logger.Warnf(
+		"Failed to retrieve from miner %s for %s: %s",
+		event.ProviderId(),
+		event.PayloadCid(),
+		event.ErrorMessage(),
+	)
 }
 
 func handleCandidatesFilteredEvent(
 	retrievalId types.RetrievalID,
 	session Session,
 	retrievalCid cid.Cid,
-	event events.RetrievalEventCandidatesFiltered,
+	event events.CandidatesFilteredEvent,
 ) {
 	if len(event.Candidates()) > 0 {
 		ids := make([]peer.ID, 0)
@@ -274,9 +270,8 @@ func logEvent(event types.RetrievalEvent) {
 		}
 	}
 	logadd("code", event.Code(),
-		"phase", event.Phase(),
 		"payloadCid", event.PayloadCid(),
-		"storageProviderId", event.StorageProviderId())
+		"storageProviderId", events.Identifier(event))
 	switch tevent := event.(type) {
 	case events.EventWithCandidates:
 		var cands = strings.Builder{}
@@ -287,10 +282,10 @@ func logEvent(event types.RetrievalEvent) {
 			}
 		}
 		logadd("candidates", cands.String())
-	case events.RetrievalEventFailed:
+	case events.FailedEvent:
 		logadd("errorMessage", tevent.ErrorMessage())
-	case events.RetrievalEventSuccess:
-		logadd("receivedSize", tevent.ReceivedSize())
+	case events.SucceededEvent:
+		logadd("receivedSize", tevent.ReceivedBytesSize())
 	}
 	logger.Debugw("retrieval-event", kv...)
 }

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -94,17 +94,17 @@ func TestRetriever(t *testing.T) {
 					},
 					ReceivedConnections: []peer.ID{peerA},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1)}),
-						events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1)}),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1)}),
+						events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1)}),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: 20 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(20*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(20*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 20 * time.Millisecond},
@@ -117,11 +117,11 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 25*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Accepted(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.FirstByte(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond),
-						events.Success(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, big.Zero(), 55, multicodec.TransportGraphsyncFilecoinv1),
-						events.Finished(startTime.Add(25*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.Proposed(startTime.Add(25*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.Accepted(startTime.Add(25*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.FirstByte(startTime.Add(25*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(25*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+						events.Finished(startTime.Add(25*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerA, Duration: 5 * time.Millisecond},
@@ -166,18 +166,18 @@ func TestRetriever(t *testing.T) {
 					},
 					ReceivedConnections: []peer.ID{peerA, peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -190,11 +190,11 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 10*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.Accepted(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond),
-						events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1), 10, 11, 12*time.Second, big.Zero(), 50, multicodec.TransportGraphsyncFilecoinv1),
-						events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.Accepted(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 10, 11, 12*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+						events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -243,17 +243,17 @@ func TestRetriever(t *testing.T) {
 					},
 					ReceivedConnections: []peer.ID{peerA},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(blacklistedPeer, nil, cid1), types.NewRetrievalCandidate(peerA, nil, cid1)}),
-						events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1)}),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(blacklistedPeer, nil, cid1), types.NewRetrievalCandidate(peerA, nil, cid1)}),
+						events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1)}),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: 50 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(50*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(50*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 50 * time.Millisecond},
@@ -266,11 +266,11 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 55*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Accepted(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.FirstByte(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond),
-						events.Success(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, big.Zero(), 55, multicodec.TransportGraphsyncFilecoinv1),
-						events.Finished(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.Proposed(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.Accepted(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.FirstByte(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+						events.Finished(startTime.Add(55*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerA, Duration: 5 * time.Millisecond},
@@ -316,18 +316,18 @@ func TestRetriever(t *testing.T) {
 					},
 					ReceivedConnections: []peer.ID{peerA, peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Failed(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1), "unable to connect to provider: blip"),
+						events.FailedRetrieval(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), "unable to connect to provider: blip"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerA},
@@ -336,7 +336,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 50 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(50*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(50*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 50 * time.Millisecond},
@@ -349,11 +349,11 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 55*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.Accepted(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.FirstByte(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond),
-						events.Success(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1), 1, 2, 3*time.Second, big.Zero(), 55, multicodec.TransportGraphsyncFilecoinv1),
-						events.Finished(startTime.Add(55*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.Proposed(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.Accepted(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.FirstByte(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(55*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 1, 2, 3*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+						events.Finished(startTime.Add(55*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -400,18 +400,18 @@ func TestRetriever(t *testing.T) {
 					},
 					ReceivedConnections: []peer.ID{peerA, peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -424,8 +424,8 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 10*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.Failed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1), "retrieval failed: bork!"),
+						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.FailedRetrieval(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), "retrieval failed: bork!"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerB},
@@ -435,7 +435,7 @@ func TestRetriever(t *testing.T) {
 					AfterStart:         500 * time.Millisecond,
 					ReceivedRetrievals: []peer.ID{peerA},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(500*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(500*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 500 * time.Millisecond},
@@ -444,11 +444,11 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 505 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(505*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Accepted(startTime.Add(505*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.FirstByte(startTime.Add(505*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond),
-						events.Success(startTime.Add(505*time.Millisecond), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 10, 20, 30*time.Second, big.Zero(), 44, multicodec.TransportGraphsyncFilecoinv1),
-						events.Finished(startTime.Add(505*time.Millisecond), rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.Proposed(startTime.Add(505*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.Accepted(startTime.Add(505*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.FirstByte(startTime.Add(505*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(505*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 10, 20, 30*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+						events.Finished(startTime.Add(505*time.Millisecond), rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerA, Duration: 5 * time.Millisecond},
@@ -505,18 +505,18 @@ func TestRetriever(t *testing.T) {
 					},
 					ReceivedConnections: []peer.ID{peerA, peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
-						events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
+						events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 				},
 				{
 					AfterStart: 1 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(1*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(1*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: time.Millisecond},
@@ -529,7 +529,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 100 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Connected(startTime.Add(100*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(100*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 100 * time.Millisecond},
@@ -539,7 +539,7 @@ func TestRetriever(t *testing.T) {
 					AfterStart:         201*time.Millisecond + initialPause,
 					ReceivedRetrievals: []peer.ID{peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Failed(startTime.Add(201*time.Millisecond+initialPause), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1), "timeout after 200ms"),
+						events.FailedRetrieval(startTime.Add(201*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), "timeout after 200ms"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerA},
@@ -548,11 +548,11 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 202*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.Proposed(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.Accepted(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.FirstByte(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1), 1*time.Millisecond),
-						events.Success(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerB, nil, cid1), 20, 30, 40*time.Second, big.Zero(), 50, multicodec.TransportGraphsyncFilecoinv1),
-						events.Finished(startTime.Add(202*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.Proposed(startTime.Add(202*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.Accepted(startTime.Add(202*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.FirstByte(startTime.Add(202*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 1*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+						events.Success(startTime.Add(202*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 20, 30, 40*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+						events.Finished(startTime.Add(202*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_FirstByte, Provider: peerB, Duration: time.Millisecond},
@@ -577,10 +577,10 @@ func TestRetriever(t *testing.T) {
 					AfterStart:           0,
 					CandidatesDiscovered: []testutil.DiscoveredCandidate{},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.Failed(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}, "no candidates"),
-						events.Finished(startTime, rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.Failed(startTime, rid, types.RetrievalCandidate{RootCid: cid1}, "no candidates"),
+						events.Finished(startTime, rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 				},
 			},
@@ -608,11 +608,11 @@ func TestRetriever(t *testing.T) {
 						},
 					},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.StartedFetch(startTime, rid, startTime, cid1, ""),
-						events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-						events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(blacklistedPeer, nil, cid1)}),
-						events.Failed(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}, "no candidates"),
-						events.Finished(startTime, rid, startTime, types.RetrievalCandidate{RootCid: cid1}),
+						events.StartedFetch(startTime, rid, cid1, ""),
+						events.StartedFindingCandidates(startTime, rid, cid1),
+						events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(blacklistedPeer, nil, cid1)}),
+						events.Failed(startTime, rid, types.RetrievalCandidate{RootCid: cid1}, "no candidates"),
+						events.Finished(startTime, rid, types.RetrievalCandidate{RootCid: cid1}),
 					},
 				},
 			},
@@ -756,18 +756,18 @@ func TestLinkSystemPerRequest(t *testing.T) {
 				},
 				ReceivedConnections: []peer.ID{peerA, peerB},
 				ExpectedEvents: []types.RetrievalEvent{
-					events.StartedFetch(startTime, rid, startTime, cid1, ""),
-					events.Started(startTime, rid, startTime, types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-					events.CandidatesFound(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-					events.CandidatesFiltered(startTime, rid, startTime, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-					events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
-					events.Started(startTime, rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+					events.StartedFetch(startTime, rid, cid1, ""),
+					events.StartedFindingCandidates(startTime, rid, cid1),
+					events.CandidatesFound(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+					events.CandidatesFiltered(startTime, rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+					events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
+					events.StartedRetrieval(startTime, rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 				},
 			},
 			{
 				AfterStart: 5 * time.Millisecond,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Connected(startTime.Add(5*time.Millisecond), rid, startTime, types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
+					events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
 				},
 			},
 			{
@@ -777,11 +777,11 @@ func TestLinkSystemPerRequest(t *testing.T) {
 			{
 				AfterStart: 10*time.Millisecond + initialPause,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-					events.Accepted(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1)),
-					events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond),
-					events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, big.Zero(), 55, multicodec.TransportGraphsyncFilecoinv1),
-					events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, startTime, types.RetrievalCandidate{RootCid: cid1})},
+					events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+					events.Accepted(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+					events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+					events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+					events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1})},
 			},
 		},
 	}.RunWithVerification(ctx, t, clock, client, candidateFinder, nil, []testutil.RunRetrieval{
@@ -822,18 +822,18 @@ func TestLinkSystemPerRequest(t *testing.T) {
 				},
 				ReceivedConnections: []peer.ID{peerA, peerB},
 				ExpectedEvents: []types.RetrievalEvent{
-					events.StartedFetch(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), cid1, ""),
-					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.IndexerPhase, types.RetrievalCandidate{RootCid: cid1}),
-					events.CandidatesFound(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-					events.CandidatesFiltered(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
-					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalPhase, types.NewRetrievalCandidate(peerA, nil, cid1)),
-					events.Started(startTime.Add(10*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+					events.StartedFetch(startTime.Add(10*time.Millisecond+initialPause), rid, cid1, ""),
+					events.StartedFindingCandidates(startTime.Add(10*time.Millisecond+initialPause), rid, cid1),
+					events.CandidatesFound(startTime.Add(10*time.Millisecond+initialPause), rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+					events.CandidatesFiltered(startTime.Add(10*time.Millisecond+initialPause), rid, cid1, []types.RetrievalCandidate{types.NewRetrievalCandidate(peerA, nil, cid1), types.NewRetrievalCandidate(peerB, nil, cid1)}),
+					events.StartedRetrieval(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
+					events.StartedRetrieval(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 				},
 			},
 			{
 				AfterStart: 5 * time.Millisecond,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Connected(startTime.Add(15*time.Millisecond+initialPause), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalPhase, types.NewRetrievalCandidate(peerB, nil, cid1)),
+					events.ConnectedToProvider(startTime.Add(15*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
 				},
 			},
 			{
@@ -843,11 +843,11 @@ func TestLinkSystemPerRequest(t *testing.T) {
 			{
 				AfterStart: 10*time.Millisecond + initialPause,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.Proposed(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, nil, cid1)),
-					events.Accepted(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, nil, cid1)),
-					events.FirstByte(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond),
-					events.Success(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.NewRetrievalCandidate(peerB, nil, cid1), 10, 11, 12*time.Second, big.Zero(), 50, multicodec.TransportGraphsyncFilecoinv1),
-					events.Finished(startTime.Add((10*time.Millisecond+initialPause)*2), rid, startTime.Add(10*time.Millisecond+initialPause), types.RetrievalCandidate{RootCid: cid1})},
+					events.Proposed(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+					events.Accepted(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+					events.FirstByte(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
+					events.Success(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 10, 11, 12*time.Second, multicodec.TransportGraphsyncFilecoinv1),
+					events.Finished(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.RetrievalCandidate{RootCid: cid1})},
 			},
 		},
 	}.RunWithVerification(ctx, t, clock, client, candidateFinder, nil, []testutil.RunRetrieval{

--- a/pkg/server/http/servertimingssubscriber.go
+++ b/pkg/server/http/servertimingssubscriber.go
@@ -1,0 +1,111 @@
+package httpserver
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/events"
+	"github.com/filecoin-project/lassie/pkg/types"
+	servertiming "github.com/mitchellh/go-server-timing"
+)
+
+// servertimingsSubscriber is a retrieval event subscriber that records
+// RetrievalEvents and generates a Server-Timing header on an http request.
+// The "dur" field is the duration since the "started-fetch" event in milliseconds.
+// The extra fields are the other events that took place and their durations in
+// nanoseconds since the "started-fetch" event.
+//
+// We are unable to get the duration of the entire fetch or successful retrievals
+// due to the way in which the headers are written. Since the headers are written
+// before an http `Write` occurs, we can only collect info about the retrievals
+// until a `first-byte-received` event that results in data being written to the client.
+// The http `Write` ends up occurring before the success and finished events are emitted,
+// therefore cutting off the trailing events that occur for any given retrieval.
+// Because of this, the `started-fetch`, `success`, and `finished` events are not processed.
+//
+// Additionally, we use the `dur` field to record the time since the `started-fetch` event
+// instead of the duration of the event itself. We do this to render something in the browser
+// since the "dur" field is the only field rendered.
+func servertimingsSubscriber(req *http.Request) types.RetrievalEventSubscriber {
+	var fetchStartTime time.Time
+
+	var candidateFindingMetric *servertiming.Metric
+	var candidateFindingStartTime time.Time
+
+	mapLock := sync.Mutex{}
+	retrievalMetricMap := make(map[string]*servertiming.Metric)
+	retrievalTimingMap := make(map[string]time.Time)
+
+	return func(re types.RetrievalEvent) {
+		timing := servertiming.FromContext(req.Context())
+		if timing == nil {
+			return
+		}
+
+		switch event := re.(type) {
+		case events.StartedFetchEvent:
+			fetchStartTime = re.Time()
+
+		// Candidate finding cases
+		case events.StartedFindingCandidatesEvent:
+			candidateFindingMetric = timing.NewMetric(string(re.Code()))
+			candidateFindingMetric.Extra = make(map[string]string)
+			candidateFindingMetric.Extra["dur"] = formatDuration(re.Time().Sub(fetchStartTime))
+			candidateFindingStartTime = re.Time()
+		case events.CandidatesFoundEvent:
+			candidateFindingMetric.Duration = re.Time().Sub(candidateFindingStartTime)
+			candidateFindingMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(candidateFindingStartTime))
+		case events.CandidatesFilteredEvent:
+			candidateFindingMetric.Duration = re.Time().Sub(candidateFindingStartTime)
+			candidateFindingMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(candidateFindingStartTime))
+
+		// Retrieval cases
+		case events.StartedRetrievalEvent:
+			name := fmt.Sprintf("retrieval-%s", events.Identifier(re))
+			retrievalMetric := timing.NewMetric(name)
+			retrievalMetric.Extra = make(map[string]string)
+			// We're using "dur" here to render the time since the "started-fetch" in the browser
+			retrievalMetric.Extra["dur"] = formatDuration(re.Time().Sub(fetchStartTime))
+			retrievalMetricMap[name] = retrievalMetric
+			retrievalTimingMap[name] = re.Time()
+		case events.FirstByteEvent:
+			name := fmt.Sprintf("retrieval-%s", events.Identifier(event))
+			mapLock.Lock()
+			if retrievalMetric, ok := retrievalMetricMap[name]; ok {
+				retrievalMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(retrievalTimingMap[name]))
+			}
+			mapLock.Unlock()
+		case events.FailedRetrievalEvent:
+			name := fmt.Sprintf("retrieval-%s", events.Identifier(re))
+			mapLock.Lock()
+			if retrievalMetric, ok := retrievalMetricMap[name]; ok {
+				retrievalMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(retrievalTimingMap[name]))
+				retrievalMetric.Duration = re.Time().Sub(retrievalTimingMap[name])
+			}
+			mapLock.Unlock()
+
+		// Due to the timing in which the Server-Timing header is written,
+		// the success and finished events are never emitted in time to make it into the header.
+		case events.SucceededEvent:
+		case events.FinishedEvent:
+
+		default:
+			if event, ok := re.(events.EventWithProviderID); ok {
+				name := fmt.Sprintf("retrieval-%s", events.Identifier(event))
+				mapLock.Lock()
+				if retrievalMetric, ok := retrievalMetricMap[name]; ok {
+					retrievalMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(retrievalTimingMap[name]))
+				}
+				mapLock.Unlock()
+			}
+		}
+	}
+}
+
+// formatDuration formats a duration in milliseconds in the same way the go-server-timing library does.
+func formatDuration(d time.Duration) string {
+	return strconv.FormatFloat(float64(d)/float64(time.Millisecond), 'f', -1, 64)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ipni/go-libipni/metadata"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/multiformats/go-multicodec"
 )
 
 type RetrievalCandidate struct {
@@ -185,69 +184,41 @@ const (
 	SequentialCoordination = "sequential"
 )
 
-type Phase string
-
-const (
-	// FetchPhase encompasses the entire process from start to end, involves the finished event
-	FetchPhase Phase = "fetch"
-	// IndexerPhase involves a candidates-found|failure
-	IndexerPhase Phase = "indexer"
-	// QueryPhase involves a connect, query-asked|failure
-	QueryPhase Phase = "query"
-	// RetrievalPhase involves the full data retrieval: connect, proposed, accepted, first-byte-received, success|failure
-	RetrievalPhase Phase = "retrieval"
-)
-
 type EventCode string
 
 const (
-	CandidatesFoundCode    EventCode = "candidates-found"
-	CandidatesFilteredCode EventCode = "candidates-filtered"
-	StartedCode            EventCode = "started"
-	ConnectedCode          EventCode = "connected"
-	QueryAskedCode         EventCode = "query-asked"
-	QueryAskedFilteredCode EventCode = "query-asked-filtered"
-	ProposedCode           EventCode = "proposed"
-	AcceptedCode           EventCode = "accepted"
-	FirstByteCode          EventCode = "first-byte-received"
-	FailedCode             EventCode = "failure"
-	SuccessCode            EventCode = "success"
-	FinishedCode           EventCode = "finished"
+	CandidatesFoundCode          EventCode = "candidates-found"
+	CandidatesFilteredCode       EventCode = "candidates-filtered"
+	StartedCode                  EventCode = "started"
+	StartedFetchCode             EventCode = "started-fetch"
+	StartedFindingCandidatesCode EventCode = "started-finding-candidates"
+	StartedRetrievalCode         EventCode = "started-retrieval"
+	ConnectedToProviderCode      EventCode = "connected-to-provider"
+	QueryAskedCode               EventCode = "query-asked"
+	QueryAskedFilteredCode       EventCode = "query-asked-filtered"
+	ProposedCode                 EventCode = "proposed"
+	AcceptedCode                 EventCode = "accepted"
+	FirstByteCode                EventCode = "first-byte-received"
+	FailedCode                   EventCode = "failed"
+	FailedRetrievalCode          EventCode = "failed-retrieval"
+	SuccessCode                  EventCode = "success"
+	FinishedCode                 EventCode = "finished"
 )
 
 type RetrievalEvent interface {
 	fmt.Stringer
+
 	// Time returns the time that the event occurred
 	Time() time.Time
 	// RetrievalId returns the unique ID for this retrieval
 	RetrievalId() RetrievalID
 	// Code returns the type of event this is
 	Code() EventCode
-	// Phase returns what phase of a retrieval this even occurred on
-	Phase() Phase
-	// PhaseStartTime returns the time that the phase started for this storage provider
-	PhaseStartTime() time.Time
 	// PayloadCid returns the CID being requested
 	PayloadCid() cid.Cid
-	// StorageProviderId returns the peer ID of the storage provider if this
-	// retrieval was requested via peer ID
-	StorageProviderId() peer.ID
-	// Protocol
-	Protocols() []multicodec.Code
 }
 
 const BitswapIndentifier = "Bitswap"
-
-func Identifier(event RetrievalEvent) string {
-	if event.StorageProviderId() != peer.ID("") {
-		return event.StorageProviderId().String()
-	}
-	protocols := event.Protocols()
-	if len(protocols) == 1 && protocols[0] == multicodec.TransportBitswap && event.Phase() != IndexerPhase {
-		return BitswapIndentifier
-	}
-	return ""
-}
 
 // RetrievalEventSubscriber is a function that receives a stream of retrieval
 // events from all retrievals that are in progress. Various different types


### PR DESCRIPTION
In an effort to cut down on the unneccessary bloat some of our events started to have, this update removes the idea of event phases in favor of making the events discreet from each other. Events should not depend on each other and should not require data that is not relative to them.

### Notable Changes
- Phase and phase start time have been removed from all events
- The started event has been extracted into three separate events singalling:
  1. the start of the entire fetch
  2. the start of the finding candidates
  3. the start of a retrieval from a specific provider
  **Note**: fetch in this case is the beginning of `Lassie.Fetch()` and retrieval is when we start talking to a specific provider.
- The failed event has been extracted into two separate events:
  1. general fails
  2. failing a retrieval
- A number of interfaces have been made for determining if an event has a given property, the most prominent one being if the event has an SP ID with `EventWithSPID`. Checks have been added in places to ensure the event has a given property before using.
- The events have been extracted into their own files due to the one events file becoming very large and hard to parse

> I wonder whether we even want `RetrievalEvent.PayloadCid()` -- does every event actually have a real payload CID? If not, let's delete it. @hannahhoward 

I attempted to extract payloadCid out of the base event, but got caught on some assignable candidate finder tests that use CID keyed maps to assert that specific candidates were found for a given CID. The entire test set would have needed to be rewritten. I've made those changes to the `feat/remove-cid-from-events` branch if we wanted to move forward with this work. I'm going to leave the payloadCid in the base event for this PR.
