### PR TITLE
Fixes for Boost compatibility

### DIFF
--- a/pkg/retriever/directcandidatefinder.go
+++ b/pkg/retriever/directcandidatefinder.go
@@ -177,6 +177,12 @@ func (d *DirectCandidateFinder) retrievalCandidatesFromTransportsProtocol(ctx co
 					return
 				}
 			}
+		case "http":
+			for _, addr := range addrs {
+				if err := cs.sendCandidate(addr, &metadata.IpfsGatewayHttp{}); err != nil {
+					return
+				}
+			}
 		default:
 		}
 	}

--- a/pkg/verifiedcar/verifiedcar.go
+++ b/pkg/verifiedcar/verifiedcar.go
@@ -42,6 +42,7 @@ type Config struct {
 	Root               cid.Cid        // The single root we expect to appear in the CAR and that we use to run our traversal against
 	AllowCARv2         bool           // If true, allow CARv2 files to be received, otherwise strictly only allow CARv1
 	Selector           datamodel.Node // The selector to execute, starting at the provided Root, to verify the contents of the CAR
+	CheckRootsMismatch bool           // Check if roots match expected behavior
 	ExpectDuplicatesIn bool           // Handles whether the incoming stream has duplicates
 	WriteDuplicatesOut bool           // Handles whether duplicates should be written a second time as blocks
 	MaxBlocks          uint64         // set a budget for the traversal
@@ -78,7 +79,7 @@ func (cfg Config) VerifyCar(ctx context.Context, rdr io.Reader, lsys linking.Lin
 		return 0, 0, ErrBadVersion
 	}
 
-	if len(cbr.Roots) != 1 || cbr.Roots[0] != cfg.Root {
+	if cfg.CheckRootsMismatch && (len(cbr.Roots) != 1 || cbr.Roots[0] != cfg.Root) {
 		return 0, 0, ErrBadRoots
 	}
 	return cfg.VerifyBlockStream(ctx, cbr, lsys)

--- a/pkg/verifiedcar/verifiedcar_test.go
+++ b/pkg/verifiedcar/verifiedcar_test.go
@@ -156,6 +156,16 @@ func TestVerifiedCar(t *testing.T) {
 			roots:  []cid.Cid{root1, root1},
 			err:    "root CID mismatch",
 			cfg: verifiedcar.Config{
+				Root:               root1,
+				Selector:           allSelector,
+				CheckRootsMismatch: true,
+			},
+		},
+		{
+			name:   "carv1 with multiple roots errors, no root cid mismatch",
+			blocks: consumedBlocks(allBlocks),
+			roots:  []cid.Cid{root1, root1},
+			cfg: verifiedcar.Config{
 				Root:     root1,
 				Selector: allSelector,
 			},
@@ -166,8 +176,9 @@ func TestVerifiedCar(t *testing.T) {
 			roots:  []cid.Cid{tbc1.AllBlocks()[1].Cid()},
 			err:    "root CID mismatch",
 			cfg: verifiedcar.Config{
-				Root:     root1,
-				Selector: allSelector,
+				Root:               root1,
+				Selector:           allSelector,
+				CheckRootsMismatch: true,
 			},
 		},
 		{


### PR DESCRIPTION
# Goals

Found 2 issues testing with booster-http:
1. we don't capture the http protocol when using the DirectCandidateFinder
2. we're currently incompatible with IPIP-402 for roots (see larger discussion)

# Implementation

- Add HTTP to decode of responses on libp2p/transports protocol
- Make roots checking optional for now