### PR TITLE
feat: protect HTTP API using access token

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -74,6 +74,11 @@ var daemonFlags = []cli.Flag{
 	FlagBitswapConcurrency,
 	FlagGlobalTimeout,
 	FlagProviderTimeout,
+	&cli.StringFlag{
+		Name:  "access-token",
+		Usage: "require HTTP clients to authorize using Bearer scheme and the configured access token",
+		Value: "",
+	},
 }
 
 var daemonCmd = &cli.Command{
@@ -119,7 +124,8 @@ func daemonAction(cctx *cli.Context) error {
 	port := cctx.Uint("port")
 	tempDir := cctx.String("tempdir")
 	maxBlocks := cctx.Uint64("maxblocks")
-	httpServerCfg := getHttpServerConfigForDaemon(address, port, tempDir, maxBlocks)
+	accessToken := cctx.String("access-token")
+	httpServerCfg := getHttpServerConfigForDaemon(address, port, tempDir, maxBlocks, accessToken)
 
 	// event recorder config
 	eventRecorderURL := cctx.String("event-recorder-url")
@@ -200,11 +206,12 @@ func defaultDaemonRun(
 }
 
 // getHttpServerConfigForDaemon returns a HttpServerConfig for the daemon command.
-func getHttpServerConfigForDaemon(address string, port uint, tempDir string, maxBlocks uint64) httpserver.HttpServerConfig {
+func getHttpServerConfigForDaemon(address string, port uint, tempDir string, maxBlocks uint64, accessToken string) httpserver.HttpServerConfig {
 	return httpserver.HttpServerConfig{
 		Address:             address,
 		Port:                port,
 		TempDir:             tempDir,
 		MaxBlocksPerRequest: maxBlocks,
+		AccessToken:         accessToken,
 	}
 }

--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -76,7 +76,7 @@ var daemonFlags = []cli.Flag{
 	FlagProviderTimeout,
 	&cli.StringFlag{
 		Name:  "access-token",
-		Usage: "require HTTP clients to authorize using Bearer scheme and the configured access token",
+		Usage: "require HTTP clients to authorize using Bearer scheme and given access token",
 		Value: "",
 	},
 }

--- a/cmd/lassie/daemon_test.go
+++ b/cmd/lassie/daemon_test.go
@@ -41,6 +41,7 @@ func TestDaemonCommandFlags(t *testing.T) {
 				require.Equal(t, "127.0.0.1", hCfg.Address)
 				require.Equal(t, uint(0), hCfg.Port)
 				require.Equal(t, uint64(0), hCfg.MaxBlocksPerRequest)
+				require.Equal(t, "", hCfg.AccessToken)
 
 				// event recorder config
 				require.Equal(t, "", erCfg.EndpointURL)
@@ -169,6 +170,14 @@ func TestDaemonCommandFlags(t *testing.T) {
 			args: []string{"daemon", "--event-recorder-instance-id", "myinstanceid"},
 			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
 				require.Equal(t, "myinstanceid", erCfg.InstanceID)
+				return nil
+			},
+		},
+		{
+			name: "with access token",
+			args: []string{"daemon", "--access-token", "super-secret"},
+			assert: func(ctx context.Context, lCfg *l.LassieConfig, hCfg h.HttpServerConfig, erCfg *a.EventRecorderConfig) error {
+				require.Equal(t, "super-secret", hCfg.AccessToken)
 				return nil
 			},
 		},

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -110,7 +110,7 @@ func (s *HttpServer) Close() error {
 }
 
 func authorizationMiddleware(next http.Handler, accessToken string) http.Handler {
-	requiredHeaderValue := "Bearer " + accessToken
+	requiredHeaderValue := fmt.Sprintf("Bearer %s", accessToken)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == requiredHeaderValue {
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
Add a new configuration option to enable access-token-based authorization for all incoming HTTP requests.

Example use:

```
❯ go run ./cmd/lassie -- daemon --access-token supersecret
Lassie daemon listening on address 127.0.0.1:56251
Hit CTRL-C to stop the daemon
```

Unauthorized request:

```
❯ curl -i 'http://127.0.0.1:56251/debug/pprof/cmdline'
HTTP/1.1 401 Unauthorized
Date: Fri, 23 Jun 2023 09:13:57 GMT
Content-Length: 13
Content-Type: text/plain; charset=utf-8

Unauthorized
```

Authorized request:

```
❯ curl -i 'http://127.0.0.1:56251/debug/pprof/cmdline' -H 'Authorization: Bearer supersecret'
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 23 Jun 2023 09:13:30 GMT
Content-Length: 120

Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```
