### PR TITLE
refactor: remove export of internal util functions

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -55,13 +55,13 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 			return
 		}
 
-		includeDupes, err := CheckFormat(req)
+		includeDupes, err := checkFormat(req)
 		if err != nil {
 			errorResponse(res, statusLogger, http.StatusBadRequest, err)
 			return
 		}
 
-		fileName, err := ParseFilename(req)
+		fileName, err := parseFilename(req)
 		if err != nil {
 			errorResponse(res, statusLogger, http.StatusBadRequest, err)
 			return
@@ -76,7 +76,7 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 			return
 		}
 
-		dagScope, err := ParseScope(req)
+		dagScope, err := parseScope(req)
 		if err != nil {
 			errorResponse(res, statusLogger, http.StatusBadRequest, err)
 			return

--- a/pkg/server/http/util.go
+++ b/pkg/server/http/util.go
@@ -10,9 +10,9 @@ import (
 	"github.com/filecoin-project/lassie/pkg/types"
 )
 
-// ParseScope returns the dag-scope query parameter or an error if the dag-scope
+// parseScope returns the dag-scope query parameter or an error if the dag-scope
 // parameter is not one of the supported values.
-func ParseScope(req *http.Request) (types.DagScope, error) {
+func parseScope(req *http.Request) (types.DagScope, error) {
 	if req.URL.Query().Has("dag-scope") {
 		switch req.URL.Query().Get("dag-scope") {
 		case "all":
@@ -41,10 +41,10 @@ func ParseScope(req *http.Request) (types.DagScope, error) {
 	return types.DagScopeAll, nil
 }
 
-// ParseFilename returns the filename query parameter or an error if the filename
+// parseFilename returns the filename query parameter or an error if the filename
 // extension is not ".car". Lassie only supports returning CAR data.
 // See https://specs.ipfs.tech/http-gateways/path-gateway/#filename-request-query-parameter
-func ParseFilename(req *http.Request) (string, error) {
+func parseFilename(req *http.Request) (string, error) {
 	// check if provided filename query parameter has .car extension
 	if req.URL.Query().Has("filename") {
 		filename := req.URL.Query().Get("filename")
@@ -60,7 +60,7 @@ func ParseFilename(req *http.Request) (string, error) {
 	return "", nil
 }
 
-// CheckFormat validates that the data being requested is of the type CAR.
+// checkFormat validates that the data being requested is of the type CAR.
 // We do this validation because the http gateway path spec allows for additional
 // response formats that Lassie does not currently support, so we throw an error in
 // the cases where the request is requesting one of Lassie's unsupported response
@@ -74,10 +74,10 @@ func ParseFilename(req *http.Request) (string, error) {
 //
 // Lassie only allows the "car" format query parameter
 // https://specs.ipfs.tech/http-gateways/path-gateway/#format-request-query-parameter
-func CheckFormat(req *http.Request) (bool, error) {
+func checkFormat(req *http.Request) (bool, error) {
 	hasAccept := req.Header.Get("Accept") != ""
 	// check if Accept header includes application/vnd.ipld.car
-	validAccept, includeDupes := ParseAccept(req.Header.Get("Accept"))
+	validAccept, includeDupes := parseAccept(req.Header.Get("Accept"))
 	if hasAccept && !validAccept {
 		return false, fmt.Errorf("no acceptable content type")
 	}
@@ -97,10 +97,10 @@ func CheckFormat(req *http.Request) (bool, error) {
 	return includeDupes, nil
 }
 
-// ParseAccept validates that the request Accept header is of the type CAR and
+// parseAccept validates that the request Accept header is of the type CAR and
 // returns whether or not duplicate blocks are allowed in the response via
 // IPIP-412: https://github.com/ipfs/specs/pull/412.
-func ParseAccept(acceptHeader string) (validAccept bool, includeDupes bool) {
+func parseAccept(acceptHeader string) (validAccept bool, includeDupes bool) {
 	acceptTypes := strings.Split(acceptHeader, ",")
 	validAccept = false
 	includeDupes = DefaultIncludeDupes


### PR DESCRIPTION
Since these functions are only used internally in a non-exported function, we shouldn't expose them to users.