### PR TITLE
feat: extract server timings and measure individual retrievals

### DIFF
--- a/pkg/retriever/bitswapretriever.go
+++ b/pkg/retriever/bitswapretriever.go
@@ -243,7 +243,7 @@ func (br *bitswapRetrieval) RetrieveFromAsyncCandidates(ayncCandidates types.Inb
 	br.bstore.RemoveLinkSystem(br.request.RetrievalID)
 	if err != nil {
 		// record failure
-		br.events(events.Failed(br.clock.Now(), br.request.RetrievalID, bitswapCandidate, err.Error()))
+		br.events(events.FailedRetrieval(br.clock.Now(), br.request.RetrievalID, bitswapCandidate, err.Error()))
 		return nil, err
 	}
 	duration := br.clock.Since(startTime)

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -211,8 +211,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedCode},
-				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
 			},
 			expectedErrors: map[cid.Cid]struct{}{
 				cid1: {},
@@ -232,8 +232,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedRetrievalCode, types.FailedCode},
-				cid2: {types.StartedRetrievalCode, types.FailedCode},
+				cid1: {types.StartedRetrievalCode, types.FailedRetrievalCode},
+				cid2: {types.StartedRetrievalCode, types.FailedRetrievalCode},
 			},
 			expectedErrors: map[cid.Cid]struct{}{
 				cid1: {},
@@ -261,8 +261,8 @@ func TestBitswapRetriever(t *testing.T) {
 				cid2: testutil.GenerateRetrievalCandidates(t, 7),
 			},
 			expectedEvents: map[cid.Cid][]types.EventCode{
-				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedCode},
-				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedCode},
+				cid1: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
+				cid2: {types.StartedRetrievalCode, types.FirstByteCode, types.FailedRetrievalCode},
 			},
 			expectedErrors: map[cid.Cid]struct{}{
 				cid1: {},

--- a/pkg/server/http/servertimingssubscriber.go
+++ b/pkg/server/http/servertimingssubscriber.go
@@ -1,0 +1,111 @@
+package httpserver
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/events"
+	"github.com/filecoin-project/lassie/pkg/types"
+	servertiming "github.com/mitchellh/go-server-timing"
+)
+
+// servertimingsSubscriber is a retrieval event subscriber that records
+// RetrievalEvents and generates a Server-Timing header on an http request.
+// The "dur" field is the duration since the "started-fetch" event in milliseconds.
+// The extra fields are the other events that took place and their durations in
+// nanoseconds since the "started-fetch" event.
+//
+// We are unable to get the duration of the entire fetch or successful retrievals
+// due to the way in which the headers are written. Since the headers are written
+// before an http `Write` occurs, we can only collect info about the retrievals
+// until a `first-byte-received` event that results in data being written to the client.
+// The http `Write` ends up occurring before the success and finished events are emitted,
+// therefore cutting off the trailing events that occur for any given retrieval.
+// Because of this, the `started-fetch`, `success`, and `finished` events are not processed.
+//
+// Additionally, we use the `dur` field to record the time since the `started-fetch` event
+// instead of the duration of the event itself. We do this to render something in the browser
+// since the "dur" field is the only field rendered.
+func servertimingsSubscriber(req *http.Request) types.RetrievalEventSubscriber {
+	var fetchStartTime time.Time
+
+	var candidateFindingMetric *servertiming.Metric
+	var candidateFindingStartTime time.Time
+
+	mapLock := sync.Mutex{}
+	retrievalMetricMap := make(map[string]*servertiming.Metric)
+	retrievalTimingMap := make(map[string]time.Time)
+
+	return func(re types.RetrievalEvent) {
+		timing := servertiming.FromContext(req.Context())
+		if timing == nil {
+			return
+		}
+
+		switch event := re.(type) {
+		case events.StartedFetchEvent:
+			fetchStartTime = re.Time()
+
+		// Candidate finding cases
+		case events.StartedFindingCandidatesEvent:
+			candidateFindingMetric = timing.NewMetric(string(re.Code()))
+			candidateFindingMetric.Extra = make(map[string]string)
+			candidateFindingMetric.Extra["dur"] = formatDuration(re.Time().Sub(fetchStartTime))
+			candidateFindingStartTime = re.Time()
+		case events.CandidatesFoundEvent:
+			candidateFindingMetric.Duration = re.Time().Sub(candidateFindingStartTime)
+			candidateFindingMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(candidateFindingStartTime))
+		case events.CandidatesFilteredEvent:
+			candidateFindingMetric.Duration = re.Time().Sub(candidateFindingStartTime)
+			candidateFindingMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(candidateFindingStartTime))
+
+		// Retrieval cases
+		case events.StartedRetrievalEvent:
+			name := fmt.Sprintf("retrieval-%s", events.Identifier(re))
+			retrievalMetric := timing.NewMetric(name)
+			retrievalMetric.Extra = make(map[string]string)
+			// We're using "dur" here to render the time since the "started-fetch" in the browser
+			retrievalMetric.Extra["dur"] = formatDuration(re.Time().Sub(fetchStartTime))
+			retrievalMetricMap[name] = retrievalMetric
+			retrievalTimingMap[name] = re.Time()
+		case events.FirstByteEvent:
+			name := fmt.Sprintf("retrieval-%s", events.Identifier(event))
+			mapLock.Lock()
+			if retrievalMetric, ok := retrievalMetricMap[name]; ok {
+				retrievalMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(retrievalTimingMap[name]))
+			}
+			mapLock.Unlock()
+		case events.FailedRetrievalEvent:
+			name := fmt.Sprintf("retrieval-%s", events.Identifier(re))
+			mapLock.Lock()
+			if retrievalMetric, ok := retrievalMetricMap[name]; ok {
+				retrievalMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(retrievalTimingMap[name]))
+				retrievalMetric.Duration = re.Time().Sub(retrievalTimingMap[name])
+			}
+			mapLock.Unlock()
+
+		// Due to the timing in which the Server-Timing header is written,
+		// the success and finished events are never emitted in time to make it into the header.
+		case events.SucceededEvent:
+		case events.FinishedEvent:
+
+		default:
+			if event, ok := re.(events.EventWithProviderID); ok {
+				name := fmt.Sprintf("retrieval-%s", events.Identifier(event))
+				mapLock.Lock()
+				if retrievalMetric, ok := retrievalMetricMap[name]; ok {
+					retrievalMetric.Extra[string(re.Code())] = fmt.Sprintf("%d", re.Time().Sub(retrievalTimingMap[name]))
+				}
+				mapLock.Unlock()
+			}
+		}
+	}
+}
+
+// formatDuration formats a duration in milliseconds in the same way the go-server-timing library does.
+func formatDuration(d time.Duration) string {
+	return strconv.FormatFloat(float64(d)/float64(time.Millisecond), 'f', -1, 64)
+}


### PR DESCRIPTION
Pulls the `Server-Timing` response header logic into it's own file and updates the retrieval event parsing to get timing on individual retrieval attempts. This tracks the individual events that occur on a per retrieval basis, whereas before we were treating "retrieval" as a phase and tracking all events under that phase. This was problematic since the second event of any type, for example during a second concurrent retrieval, would overwrite any previous event and it's timings.

The following is an example of the `Server-Timing` response header when fetching `bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4/birb.mp4` via the daemon. I've added newlines for each comma delimited item.

```
Server-Timing: 
started-finding-candidates;dur=0.1301;candidates-found=179140830;candidates-filtered=179186930,
retrieval-Bitswap;dur=179.38963,
retrieval-12D3KooWKGCcFVSAUXxe7YP62wiwsBvpCmMomnNauJCA67XbmHYj;dur=179.36533,
retrieval-12D3KooWPgBdZSbmKbD7ZQGjU7gZCcCKGvWSnBf1q4xAbpDdtJaJ;dur=179.44633;connected-to-sp=5900;first-byte-received=404370468;failed-retrieval=404419368,
retrieval-12D3KooWJ8YAF6DiRxrzcxoeUVjSANYxyxU55ruFgNvQB4EHibpG;dur=179.43173,
retrieval-QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp;dur=179.48633;connected-to-sp=151700;first-byte-received=498249083,
retrieval-12D3KooWDCXxiSsLi1NT9tsiyimwV6YstQkrjTjD2hAkz2KRVAGG;dur=179.49513;connected-to-sp=181700
```

![image](https://github.com/filecoin-project/lassie/assets/3432646/005b005e-6ee7-43fc-9559-c712cba252f0)

### Explaination

Due to the caveat explained below, all the "dur" fields are actually the time since the `started-fetch` event, while the individual metric extras are the duration since the beginning of that metric in nanoseconds. 

### Caveats

We are unable to get the duration of the entire fetch/successful retrievals due to the way in which the headers are written. Since the headers are written before an http `Write` occurs, we can only collect info about the retrievals until a `first-byte-received` event that results in data being written to the client. The http `Write` ends up occurring before the success and finished events are emitted, therefore cutting off the trailing events that occur for any given retrieval. Because of this, the `started-fetch`, `success`, and `finished` events are not processed.

