### PR TITLE
fix(cli): move log level logic to flag action

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -84,7 +84,6 @@ var daemonFlags = []cli.Flag{
 var daemonCmd = &cli.Command{
 	Name:   "daemon",
 	Usage:  "Starts a lassie daemon, accepting http requests",
-	Before: before,
 	After:  after,
 	Flags:  daemonFlags,
 	Action: daemonAction,

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -64,7 +64,6 @@ var fetchFlags = []cli.Flag{
 var fetchCmd = &cli.Command{
 	Name:   "fetch",
 	Usage:  "Fetches content from the IPFS and Filecoin network",
-	Before: before,
 	After:  after,
 	Action: fetchAction,
 	Flags:  fetchFlags,

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -63,33 +63,6 @@ func main() {
 	}
 }
 
-func before(cctx *cli.Context) error {
-	// Determine logging level
-	subsystems := []string{
-		"lassie",
-		"lassie/httpserver",
-		"indexerlookup",
-		"lassie/bitswap",
-	}
-
-	level := "WARN"
-	if IsVerbose {
-		level = "INFO"
-	}
-	if IsVeryVerbose {
-		level = "DEBUG"
-	}
-
-	// don't over-ride logging if set in the environment.
-	if os.Getenv("GOLOG_LOG_LEVEL") == "" {
-		for _, name := range subsystems {
-			_ = log.SetLogLevel(name, level)
-		}
-	}
-
-	return nil
-}
-
 func after(cctx *cli.Context) error {
 	ResetGlobalFlags()
 	return nil

--- a/cmd/lassie/version.go
+++ b/cmd/lassie/version.go
@@ -9,11 +9,11 @@ import (
 
 var versionCmd = &cli.Command{
 	Name:      "version",
-	Before:    before,
 	Usage:     "Prints the version and exits",
 	UsageText: "lassie version",
 	Flags: []cli.Flag{
 		FlagVerbose,
+		FlagVeryVerbose,
 	},
 	Action: versionCommand,
 }


### PR DESCRIPTION
The verbose flags were both on the main lassie command and the subcommands, but after some investigation were found to only be affecting all of the listed logging subsystems when used on the subcommand. When the log levels were set as an action on the flag instead of relying on a global var to be set during a before hook, all the subsystems were affected as expected. Additionally, the list of logging subsystems that responded to the verbose flags was not updated during an update that normalized the naming convention of all the loggers.

Closes #327.