### PR TITLE
fix: various traversal and verifier fixes

### DIFF
--- a/pkg/internal/testutil/gen.go
+++ b/pkg/internal/testutil/gen.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"strconv"
@@ -10,7 +12,10 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	"github.com/ipfs/go-unixfsnode/data"
 	unixfs "github.com/ipfs/go-unixfsnode/testutil"
+	dagpb "github.com/ipld/go-codec-dagpb"
+	"github.com/ipld/go-ipld-prime/linking"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/go-libipni/metadata"
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -150,9 +155,11 @@ func (ZeroReader) Read(b []byte) (n int, err error) {
 	return len(b), nil
 }
 
-// TODO: this should probably be an option in unixfsnode/testutil, for
-// generators to strictly not return a DAG with duplicates
+// TODO: these should probably be in unixfsnode/testutil, or as options to
+// the respective functions there.
 
+// GenerateNoDupes runs the unixfsnode/testutil generator function repeatedly
+// until it produces a DAG with strictly no duplicate CIDs.
 func GenerateNoDupes(gen func() unixfs.DirEntry) unixfs.DirEntry {
 	var check func(unixfs.DirEntry) bool
 	var seen map[cid.Cid]struct{}
@@ -175,6 +182,40 @@ func GenerateNoDupes(gen func() unixfs.DirEntry) unixfs.DirEntry {
 		gend := gen()
 		if check(gend) {
 			return gend
+		}
+	}
+}
+
+// GenerateStrictlyNestedShardedDir is a wrapper around
+// unixfsnode/testutil.GenerateDirectory that uses dark magic to repeatedly
+// generate a sharded directory until it produces one that is strictly nested.
+// That is, it produces a sharded directory structure with strictly at least one
+// level of sharding with at least two child shards.
+//
+// Since it is possible to produce a sharded directory that is
+// contained in a single block, this function provides a way to generate a
+// sharded directory for cases where we need to test multi-level sharding.
+func GenerateStrictlyNestedShardedDir(t *testing.T, linkSys *linking.LinkSystem, randReader io.Reader, targetSize int) unixfs.DirEntry {
+	for {
+		de := unixfs.GenerateDirectory(t, linkSys, randReader, targetSize, true)
+		nd, err := linkSys.Load(linking.LinkContext{}, cidlink.Link{Cid: de.Root}, dagpb.Type.PBNode)
+		require.NoError(t, err)
+		ufsd, err := data.DecodeUnixFSData(nd.(dagpb.PBNode).Data.Must().Bytes())
+		require.NoError(t, err)
+		pfxLen := len(fmt.Sprintf("%X", ufsd.FieldFanout().Must().Int()-1))
+		iter := nd.(dagpb.PBNode).Links.ListIterator()
+		childShards := 0
+		for !iter.Done() {
+			_, lnk, err := iter.Next()
+			require.NoError(t, err)
+			nameLen := len(lnk.(dagpb.PBLink).Name.Must().String())
+			if nameLen == pfxLen {
+				// name is just a shard prefix, so we have at least one level of nesting
+				childShards++
+			}
+		}
+		if childShards >= 2 {
+			return de
 		}
 	}
 }

--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -198,7 +198,7 @@ func newTimeToFirstByteReader(r io.Reader, cb func()) *timeToFirstByteReader {
 	}
 }
 
-func (t *timeToFirstByteReader) Read(p []byte) (n int, err error) {
+func (t *timeToFirstByteReader) Read(p []byte) (int, error) {
 	if !t.first {
 		t.first = true
 		defer t.cb()

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -188,7 +189,7 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 		stats, err := lassie.Fetch(req.Context(), request, servertimingsSubscriber(req))
 
 		// force all blocks to flush
-		if cerr := carWriter.Close(); cerr != nil {
+		if cerr := carWriter.Close(); cerr != nil && !errors.Is(cerr, context.Canceled) {
 			logger.Infof("error closing car writer: %s", cerr)
 		}
 

--- a/pkg/storage/duplicateaddercar.go
+++ b/pkg/storage/duplicateaddercar.go
@@ -131,6 +131,9 @@ func (bs *blockStream) Close() {
 }
 
 func (bs *blockStream) WriteBlock(blk blocks.Block) error {
+	if bs.ctx.Err() != nil {
+		return bs.ctx.Err()
+	}
 	bs.mu.Lock()
 	defer bs.mu.Unlock()
 	if bs.done {


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/lassie/issues/336

* don't treat context cancellation as an ErrExtraneousBlock in the CAR verifier
* capture and properly handle block load errors that are missed by the go-ipld-prime traverser, ref: https://github.com/ipld/go-ipld-prime/pull/524
* fix flaky case(s) in verifiedcar test suite where multi-level sharded directory is assumed but only a single block dir is produced

The flaky one is really interesting, it became more flaky once we started properly and consistently reporting errors from the traversal, then it would flip between two error types. The fix was to ensure that the fixture data had a particular _shape_ because certain forms produce certain errors. Fun fun.