### PR TITLE
Make byte range support tolerant of http backends that don't support range requests

### DIFF
--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -966,7 +966,7 @@ func TestHttpFetch(t *testing.T) {
 				finishedChans = append(finishedChans, mocknet.SetupRetrieval(t, r))
 			}
 			mrn.AddBitswapPeers(testCase.bitswapRemotes)
-			mrn.AddHttpPeers(testCase.httpRemotes)
+			mrn.AddHttpPeers(testCase.httpRemotes, true)
 
 			require.NoError(t, mrn.MN.LinkAll())
 

--- a/pkg/internal/itest/mocknet/mocknet.go
+++ b/pkg/internal/itest/mocknet/mocknet.go
@@ -70,8 +70,8 @@ func (mrn *MockRetrievalNet) AddGraphsyncPeers(n int) {
 	mrn.addPeers(mrn.testPeerGenerator.GraphsyncPeers(n))
 }
 
-func (mrn *MockRetrievalNet) AddHttpPeers(n int) {
-	mrn.addPeers(mrn.testPeerGenerator.HttpPeers(n))
+func (mrn *MockRetrievalNet) AddHttpPeers(n int, supportsRanges bool) {
+	mrn.addPeers(mrn.testPeerGenerator.HttpPeers(n, supportsRanges))
 }
 
 func (mrn *MockRetrievalNet) addPeers(peers []testpeer.TestPeer) {

--- a/pkg/internal/itest/testpeer/peerhttpserver.go
+++ b/pkg/internal/itest/testpeer/peerhttpserver.go
@@ -81,7 +81,7 @@ func (s *TestPeerHttpServer) Close() error {
 	return s.server.Shutdown(context.Background())
 }
 
-func MockIpfsHandler(ctx context.Context, lsys linking.LinkSystem) func(http.ResponseWriter, *http.Request) {
+func MockIpfsHandler(ctx context.Context, lsys linking.LinkSystem, supportsRanges bool) func(http.ResponseWriter, *http.Request) {
 	return func(res http.ResponseWriter, req *http.Request) {
 		urlPath := strings.Split(req.URL.Path, "/")[1:]
 
@@ -138,7 +138,7 @@ func MockIpfsHandler(ctx context.Context, lsys linking.LinkSystem) func(http.Res
 			return
 		}
 		var byteRange *types.ByteRange
-		if req.URL.Query().Get("entity-bytes") != "" {
+		if req.URL.Query().Get("entity-bytes") != "" && supportsRanges {
 			br, err := types.ParseByteRange(req.URL.Query().Get("entity-bytes"))
 			if err != nil {
 				http.Error(res, fmt.Sprintf("Invalid entity-bytes parameter: %s", req.URL.Query().Get("entity-bytes")), http.StatusBadRequest)

--- a/pkg/internal/itest/trustless_fetch_test.go
+++ b/pkg/internal/itest/trustless_fetch_test.go
@@ -37,7 +37,7 @@ func TestTrustlessUnixfsFetch(t *testing.T) {
 	lsys.SetReadStorage(storage)
 
 	for _, tc := range testCases {
-		for _, proto := range []string{"http", "graphsync", "bitswap"} {
+		for _, proto := range []string{"http-ranged", "http-no-range", "graphsync", "bitswap"} {
 			t.Run(tc.Name+"/"+proto, func(t *testing.T) {
 				req := require.New(t)
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -47,8 +47,10 @@ func TestTrustlessUnixfsFetch(t *testing.T) {
 
 				mrn := mocknet.NewMockRetrievalNet(ctx, t)
 				switch proto {
-				case "http":
-					mrn.AddHttpPeers(1)
+				case "http-ranged":
+					mrn.AddHttpPeers(1, true)
+				case "http-no-range":
+					mrn.AddHttpPeers(1, false)
 				case "graphsync":
 					mrn.AddGraphsyncPeers(1)
 				case "bitswap":

--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -120,10 +120,11 @@ func (ph *ProtocolHttp) Retrieve(
 		shared.sendEvent(events.FirstByte(retrieval.Clock.Now(), retrieval.request.RetrievalID, candidate, ttfb, multicodec.TransportIpfsGatewayHttp))
 	})
 	cfg := verifiedcar.Config{
-		Root:               retrieval.request.Cid,
-		Selector:           retrieval.request.GetSelector(),
-		ExpectDuplicatesIn: true,
-		MaxBlocks:          retrieval.request.MaxBlocks,
+		Root:                  retrieval.request.Cid,
+		Selector:              retrieval.request.GetSelector(),
+		AllowExtraneousBlocks: !retrieval.request.Bytes.IsDefault(),
+		ExpectDuplicatesIn:    true,
+		MaxBlocks:             retrieval.request.MaxBlocks,
 	}
 
 	blockCount, byteCount, err := cfg.VerifyCar(ctx, rdr, retrieval.request.LinkSystem)

--- a/pkg/verifiedcar/verifiedcar_test.go
+++ b/pkg/verifiedcar/verifiedcar_test.go
@@ -314,6 +314,16 @@ func TestVerifiedCar(t *testing.T) {
 			},
 		},
 		{
+			name:   "carv1 with extraneous trailing block, allow extraneous blocks on",
+			blocks: append(consumedBlocks(append([]blocks.Block{}, allBlocks...)), expectedBlock{extraneousBlk, true}),
+			roots:  []cid.Cid{root1},
+			cfg: verifiedcar.Config{
+				Root:                  root1,
+				Selector:              allSelector,
+				AllowExtraneousBlocks: true,
+			},
+		},
+		{
 			name:      "carv1 with extraneous leading block errors",
 			blocks:    append(consumedBlocks([]blocks.Block{extraneousBlk}), consumedBlocks(allBlocks)...),
 			roots:     []cid.Cid{root1},
@@ -321,6 +331,17 @@ func TestVerifiedCar(t *testing.T) {
 			cfg: verifiedcar.Config{
 				Root:     root1,
 				Selector: allSelector,
+			},
+		},
+
+		{
+			name:   "carv1 with extraneous leading block, allow extraneous blocks on",
+			blocks: append(skippedBlocks([]blocks.Block{extraneousBlk}), consumedBlocks(allBlocks)...),
+			roots:  []cid.Cid{root1},
+			cfg: verifiedcar.Config{
+				Root:                  root1,
+				Selector:              allSelector,
+				AllowExtraneousBlocks: true,
 			},
 		},
 		{
@@ -331,6 +352,16 @@ func TestVerifiedCar(t *testing.T) {
 			cfg: verifiedcar.Config{
 				Root:     root1,
 				Selector: allSelector,
+			},
+		},
+		{
+			name:   "carv1 with extraneous block in middle, final blocks present, allow extraneous blocks on ",
+			blocks: append(append(consumedBlocks(append([]blocks.Block{}, allBlocks[0:99]...)), skippedBlocks([]blocks.Block{extraneousBlk})...), consumedBlocks([]blocks.Block{allBlocks[99]})...),
+			roots:  []cid.Cid{root1},
+			cfg: verifiedcar.Config{
+				Root:                  root1,
+				Selector:              allSelector,
+				AllowExtraneousBlocks: true,
 			},
 		},
 		{


### PR DESCRIPTION
# Goals

This is one proposed solution to support web3.storage in range requests. Essentially, it allows treating full responses from servers that don't support `entity-bytes` as range requests with some extra blocks in the middle. This would enable us to get byte-ranges out the door while we wait for .storage to support. At the same time, the ultimate performance, especially if Saturn starts sending lots of range requests, could be poor.