### PR TITLE
fix: don't throw error if temp file does not exist

### DIFF
--- a/pkg/storage/deferredstoragecar.go
+++ b/pkg/storage/deferredstoragecar.go
@@ -45,11 +45,14 @@ func (dcs *DeferredStorageCar) Close() error {
 	}
 	dcs.closed = true
 	if dcs.f != nil {
-		for _, err := range []error{dcs.f.Close(), os.Remove(dcs.f.Name())} {
-			if err != nil {
-				return err
-			}
+		err := dcs.f.Close()
+		if err != nil {
+			return err
 		}
+
+		// If the file exists, delete it. We don't care about the error here
+		// because we're just cleaning up.
+		_ = os.Remove(dcs.f.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
We were getting errors in the fetch tests that looked like the following
```
=== RUN   TestTrustlessUnixfsFetch/sharded_file_in_directory/entity/bitswap
    trustless_fetch_test.go:46: query=/ipfs/bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq/želva.xml?dag-scope=entity, blocks=8
    trustless_fetch_test.go:87: Fetching http://127.0.0.1:45837/ipfs/bafybeifrrglx2issn2had5rtstn3xltla6vxmpjfwfz7o3hapvkynh4zoq/%C5%BEelva.xml?dag-scope=entity
    trustless_fetch_test.go:96: 
        	Error Trace:	/home/runner/work/lassie/lassie/pkg/internal/itest/trustless_fetch_test.go:96
        	Error:      	Did not receive responses
        	Test:       	TestTrustlessUnixfsFetch/sharded_file_in_directory/entity/bitswap
2023-07-12T21:34:27.657Z	ERROR	lassie/httpserver	http/ipfs.go:138	error closing temp store: remove /tmp/TestTrustlessUnixfsFetchsharded_file_in_directoryentitybitswap2694152088/001/lassie_carstorage1003049595: no such file or directory
```

This PR addresses what I'm guessing to be the resulting `closing temp store error`. The source of the panic was handled via #358.