### PR TITLE
include a root in car responses

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -242,7 +242,7 @@ func defaultFetchRun(
 		carWriter = storage.NewDeferredCarWriterForPath(rootCid, outfile)
 	}
 
-	tempStore := storage.NewDeferredStorageCar(tempDir)
+	tempStore := storage.NewDeferredStorageCar(tempDir, rootCid)
 	carStore := storage.NewCachingTempStore(carWriter.BlockWriteOpener(), tempStore)
 	defer carStore.Close()
 

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -120,7 +120,7 @@ func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.Response
 		// the response writer. Once closed, no other content should be written.
 		bytesWritten := make(chan struct{}, 1)
 
-		tempStore := storage.NewDeferredStorageCar(cfg.TempDir)
+		tempStore := storage.NewDeferredStorageCar(cfg.TempDir, rootCid)
 		var carWriter storage.DeferredWriter
 		if includeDupes {
 			carWriter = storage.NewDuplicateAdderCarForStream(req.Context(), rootCid, path.String(), dagScope, tempStore, res)

--- a/pkg/storage/cachingtempstore_test.go
+++ b/pkg/storage/cachingtempstore_test.go
@@ -49,7 +49,7 @@ func TestDeferredCarWriterWritesCARv1(t *testing.T) {
 
 			var buf bytes.Buffer
 			cw := NewDeferredCarWriterForStream(testCid1, &buf)
-			ss := NewCachingTempStore(cw.BlockWriteOpener(), NewDeferredStorageCar(""))
+			ss := NewCachingTempStore(cw.BlockWriteOpener(), NewDeferredStorageCar("", testCid1))
 			t.Cleanup(func() { ss.Close() })
 
 			if tt.readBeforeWrite {

--- a/pkg/storage/deferredstoragecar.go
+++ b/pkg/storage/deferredstoragecar.go
@@ -21,6 +21,7 @@ var _ ReadableWritableStorage = (*DeferredStorageCar)(nil)
 // in the case of an error).
 type DeferredStorageCar struct {
 	tempDir string
+	root    cid.Cid
 
 	lk     sync.Mutex
 	closed bool
@@ -29,9 +30,10 @@ type DeferredStorageCar struct {
 }
 
 // NewDeferredStorageCar creates a new DeferredStorageCar.
-func NewDeferredStorageCar(tempDir string) *DeferredStorageCar {
+func NewDeferredStorageCar(tempDir string, root cid.Cid) *DeferredStorageCar {
 	return &DeferredStorageCar{
 		tempDir: tempDir,
+		root:    root,
 	}
 }
 
@@ -136,7 +138,7 @@ func (dcs *DeferredStorageCar) readWrite() (ReadableWritableStorage, error) {
 		if dcs.f, err = os.CreateTemp(dcs.tempDir, "lassie_carstorage"); err != nil {
 			return nil, err
 		}
-		rw, err := carstorage.NewReadableWritable(dcs.f, []cid.Cid{}, carv2.WriteAsCarV1(true))
+		rw, err := carstorage.NewReadableWritable(dcs.f, []cid.Cid{dcs.root}, carv2.WriteAsCarV1(true))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/duplicateaddercar_test.go
+++ b/pkg/storage/duplicateaddercar_test.go
@@ -32,7 +32,7 @@ func TestDuplicateAdderCar(t *testing.T) {
 	unixfsFileWithDupsBlocks := testutil.ToBlocks(t, lsys, unixfsFileWithDups.Root, selectorparse.CommonSelector_ExploreAllRecursively)
 	buf := new(bytes.Buffer)
 
-	store := storage.NewDeferredStorageCar("")
+	store := storage.NewDeferredStorageCar("", unixfsFileWithDups.Root)
 	ctx := context.Background()
 	carWriter := storage.NewDuplicateAdderCarForStream(ctx, unixfsFileWithDups.Root, "", types.DagScopeAll, store, buf)
 	cachingTempStore := storage.NewCachingTempStore(carWriter.BlockWriteOpener(), store)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -40,9 +40,9 @@ func TestTempCarStorage(t *testing.T) {
 						return nil
 					}, nil
 				}
-				cw = NewCachingTempStore(bwo, NewDeferredStorageCar(tempDir))
+				cw = NewCachingTempStore(bwo, NewDeferredStorageCar(tempDir, testCid1))
 			} else {
-				cw = NewDeferredStorageCar(tempDir)
+				cw = NewDeferredStorageCar(tempDir, testCid1)
 			}
 
 			ents, err := os.ReadDir(tempDir)
@@ -154,7 +154,7 @@ func TestPreloadStore(t *testing.T) {
 			return nil
 		}, nil
 	}
-	mainStore := NewCachingTempStore(bwo, NewDeferredStorageCar(t.TempDir()))
+	mainStore := NewCachingTempStore(bwo, NewDeferredStorageCar(t.TempDir(), td[0].cid))
 	t.Cleanup(func() {
 		require.NoError(t, mainStore.Close())
 	})


### PR DESCRIPTION
fix #354

This is a somewhat naive fix, but i don't think it's totally unreasonable.

If you ask for `/ipfs/<cid>/path/to/file`
the root of the car you get back will, with this change, be `<cid>`.

I think the complexity that led to the current structure was a desire to have the root cid be `file`, but for validation and since the response car has blocks that are parents of `file`, it doesn't seem "incorrect" to say that the `root` of the structure in the car is `<cid>`.

ref: https://github.com/ipfs/specs/pull/402#discussion_r1220044618