### PR TITLE
Update go mac binary name for releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,10 @@ archives:
       format: zip
     - goos: darwin
       format: zip
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}mac_os
+      {{- else }}{{ .Os }}{{ end }}_{{ .Arch }}
 release:
   mode: keep-existing
 changelog:


### PR DESCRIPTION
# Goals

Publish mac binary as "mac_os" rather than "darwin"

# Implementation

- Update go-releaseer.yaml
- Test locally