### PR TITLE
gate assignment into a map

### DIFF
--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -188,16 +188,20 @@ func (a *aggregateEventRecorder) ingestEvents() {
 				spid := events.Identifier(ret)
 				retrievalTtfb := ret.Time().Sub(tempData.startTime).String()
 				spTtfb := ret.Duration().String()
-				tempData.retrievalAttempts[spid].TimeToFirstByte = spTtfb
-				if tempData.ttfb == "" {
-					tempData.firstByteTime = ret.Time()
-					tempData.ttfb = retrievalTtfb
+				if _, ok := tempData.retrievalAttempts[spid]; ok {
+					tempData.retrievalAttempts[spid].TimeToFirstByte = spTtfb
+					if tempData.ttfb == "" {
+						tempData.firstByteTime = ret.Time()
+						tempData.ttfb = retrievalTtfb
+					}
 				}
 
 			case events.FailedRetrievalEvent:
 				// Add an error message to the retrieval attempt
 				spid := events.Identifier(ret)
-				tempData.retrievalAttempts[spid].Error = ret.ErrorMessage()
+				if _, ok := tempData.retrievalAttempts[spid]; ok {
+					tempData.retrievalAttempts[spid].Error = ret.ErrorMessage()
+				}
 
 			case events.SucceededEvent:
 				tempData.success = true


### PR DESCRIPTION
rel: https://github.com/filecoin-project/lassie/issues/358

There's a "real" fix of figuring out why we can fail a specific retrieval attempt before emitting the `StartedRetrievalEvent` for that same event.

That said, this will be safer in terms of panics