### PR TITLE
Check for nil in aggregate events recorder

### DIFF
--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -188,7 +188,11 @@ func (a *aggregateEventRecorder) ingestEvents() {
 				spid := events.Identifier(ret)
 				retrievalTtfb := ret.Time().Sub(tempData.startTime).String()
 				spTtfb := ret.Duration().String()
-				tempData.retrievalAttempts[spid].TimeToFirstByte = spTtfb
+				attempt, ok := tempData.retrievalAttempts[spid]
+				if !ok {
+					logger.Warnw("first byte event without started retrieval event", "spid", spid)
+				}
+				attempt.TimeToFirstByte = spTtfb
 				if tempData.ttfb == "" {
 					tempData.firstByteTime = ret.Time()
 					tempData.ttfb = retrievalTtfb
@@ -197,7 +201,11 @@ func (a *aggregateEventRecorder) ingestEvents() {
 			case events.FailedRetrievalEvent:
 				// Add an error message to the retrieval attempt
 				spid := events.Identifier(ret)
-				tempData.retrievalAttempts[spid].Error = ret.ErrorMessage()
+				attempt, ok := tempData.retrievalAttempts[spid]
+				if !ok {
+					logger.Warnw("error event without started retrieval event", "spid", spid)
+				}
+				attempt.Error = ret.ErrorMessage()
 
 			case events.SucceededEvent:
 				tempData.success = true


### PR DESCRIPTION
# Goals

don't attempt to set values when retrieval attempt does not exist

# Implementation

Gate and log errors

Possible dup of #359