### PR TITLE
ref: extract magic numbers and strings into constants

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -17,6 +17,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const stdoutFileString string = "-" // a string representing stdout
+
 var fetchFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:      "output",
@@ -233,7 +235,7 @@ func defaultFetchRun(
 	}
 
 	var carWriter *storage.DeferredCarWriter
-	if outfile == "-" { // stdout
+	if outfile == stdoutFileString {
 		// we need the onlyWriter because stdout is presented as an os.File, and
 		// therefore pretend to support seeks, so feature-checking in go-car
 		// will make bad assumptions about capabilities unless we hide it

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -12,13 +12,21 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var verboseLoggingSubsystems = []string{
-	"lassie",
-	"lassie/retriever",
-	"lassie/httpserver",
-	"lassie/indexerlookup",
-	"lassie/bitswap",
-}
+var (
+	defaultTempDirectory     string   = os.TempDir() // use the system default temp dir
+	verboseLoggingSubsystems []string = []string{    // verbose logging is enabled for these subsystems when using the verbose or very-verbose flags
+		"lassie",
+		"lassie/retriever",
+		"lassie/httpserver",
+		"lassie/indexerlookup",
+		"lassie/bitswap",
+	}
+)
+
+const (
+	defaultBitswapConcurrency int           = 6                // 6 concurrent requests
+	defaultProviderTimeout    time.Duration = 20 * time.Second // 20 seconds
+)
 
 // FlagVerbose enables verbose mode, which shows info information about
 // operations invoked in the CLI.
@@ -59,9 +67,10 @@ func setLogLevel(level string) func(*cli.Context, bool) error {
 // sending metrics to an event recorder API via a Basic auth Authorization
 // HTTP header. Value will formatted as "Basic <value>" if provided.
 var FlagEventRecorderAuth = &cli.StringFlag{
-	Name:    "event-recorder-auth",
-	Usage:   "the authorization token for an event recorder API",
-	EnvVars: []string{"LASSIE_EVENT_RECORDER_AUTH"},
+	Name:        "event-recorder-auth",
+	Usage:       "the authorization token for an event recorder API",
+	DefaultText: "no authorization token will be used",
+	EnvVars:     []string{"LASSIE_EVENT_RECORDER_AUTH"},
 }
 
 // FlagEventRecorderUrl asks for and provides the URL for an event recorder API
@@ -76,9 +85,10 @@ var FlagEventRecorderInstanceId = &cli.StringFlag{
 // FlagEventRecorderUrl asks for and provides the URL for an event recorder API
 // to send metrics to.
 var FlagEventRecorderUrl = &cli.StringFlag{
-	Name:    "event-recorder-url",
-	Usage:   "the url of an event recorder API",
-	EnvVars: []string{"LASSIE_EVENT_RECORDER_URL"},
+	Name:        "event-recorder-url",
+	Usage:       "the url of an event recorder API",
+	DefaultText: "no event recorder API will be used",
+	EnvVars:     []string{"LASSIE_EVENT_RECORDER_URL"},
 }
 
 var providerBlockList map[peer.ID]bool
@@ -148,7 +158,7 @@ var FlagTempDir = &cli.StringFlag{
 	Name:        "tempdir",
 	Aliases:     []string{"td"},
 	Usage:       "directory to store temporary files while downloading",
-	Value:       os.TempDir(),
+	Value:       defaultTempDirectory,
 	DefaultText: "os temp directory",
 	EnvVars:     []string{"LASSIE_TEMP_DIRECTORY"},
 }
@@ -156,7 +166,7 @@ var FlagTempDir = &cli.StringFlag{
 var FlagBitswapConcurrency = &cli.IntFlag{
 	Name:    "bitswap-concurrency",
 	Usage:   "maximum number of concurrent bitswap requests per retrieval",
-	Value:   6,
+	Value:   defaultBitswapConcurrency,
 	EnvVars: []string{"LASSIE_BITSWAP_CONCURRENCY"},
 }
 
@@ -164,7 +174,6 @@ var FlagGlobalTimeout = &cli.DurationFlag{
 	Name:    "global-timeout",
 	Aliases: []string{"gt"},
 	Usage:   "consider it an error after not completing a retrieval after this amount of time",
-	Value:   0,
 	EnvVars: []string{"LASSIE_GLOBAL_TIMEOUT"},
 }
 
@@ -172,7 +181,7 @@ var FlagProviderTimeout = &cli.DurationFlag{
 	Name:    "provider-timeout",
 	Aliases: []string{"pt"},
 	Usage:   "consider it an error after not receiving a response from a storage provider after this amount of time",
-	Value:   20 * time.Second,
+	Value:   defaultProviderTimeout,
 	EnvVars: []string{"LASSIE_PROVIDER_TIMEOUT"},
 }
 

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -15,8 +15,10 @@ import (
 
 var logger = log.Logger("lassie/aggregateeventrecorder")
 
-const httpTimeout = 5 * time.Second
-const parallelPosters = 5
+const (
+	httpTimeout     = 5 * time.Second // The timeout for HTTP requests
+	parallelPosters = 5               // The number of goroutines to use for posting events to the event recorder service
+)
 
 type tempData struct {
 	startTime                time.Time
@@ -175,7 +177,7 @@ func (a *aggregateEventRecorder) ingestEvents() {
 				tempData.attemptedProtocolSet[protocol] = struct{}{}
 
 			case events.CandidatesFoundEvent:
-				if tempData.timeToFirstIndexerResult == "" {
+				if tempData.timeToFirstIndexerResult == "" { // only set the first indexer result time once
 					tempData.timeToFirstIndexerResult = ret.Time().Sub(tempData.startTime).String()
 				}
 				tempData.candidatesFound += len(ret.Candidates())

--- a/pkg/build/version.go
+++ b/pkg/build/version.go
@@ -10,13 +10,17 @@ import (
 )
 
 var (
-	defaultVersion string = "v0.0.0"
 	// version is the built version.
 	// Set with ldflags in .goreleaser.yaml via -ldflags="-X github.com/filecoin-project/lassie/pkg/build.version=v{{.Version}}".
 	version string
 	// Version returns the current version of the Lassie application
 	Version   string
 	UserAgent string
+)
+
+const (
+	defaultVersion string = "v0.0.0"       // Default version if not set by ldflags
+	versionFile    string = "version.json" // Version file path
 )
 
 func init() {
@@ -44,7 +48,7 @@ type versionJson struct {
 // should be present in the project, I hope :)
 func readVersionFromFile() (string, error) {
 	// Open file
-	file, err := os.Open("version.json")
+	file, err := os.Open(versionFile)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/lassie/lassie.go
+++ b/pkg/lassie/lassie.go
@@ -18,6 +18,8 @@ import (
 	"github.com/multiformats/go-multicodec"
 )
 
+const defaultProviderTimeout = 20 * time.Second
+
 // Lassie represents a reusable retrieval client.
 type Lassie struct {
 	cfg       *LassieConfig
@@ -67,7 +69,7 @@ func NewLassieWithConfig(ctx context.Context, cfg *LassieConfig) (*Lassie, error
 	}
 
 	if cfg.ProviderTimeout == 0 {
-		cfg.ProviderTimeout = 20 * time.Second
+		cfg.ProviderTimeout = defaultProviderTimeout
 	}
 
 	datastore := sync.MutexWrap(datastore.NewMapDatastore())

--- a/pkg/net/host/host.go
+++ b/pkg/net/host/host.go
@@ -19,8 +19,11 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-const yamuxID = "/yamux/1.0.0"
-const mplexID = "/mplex/6.7.0"
+const (
+	yamuxID            = "/yamux/1.0.0" // The yamux protocol ID
+	mplexID            = "/mplex/6.7.0" // The mplex protocol ID
+	yamuxAcceptBacklog = 512            // The number of streams that can be waiting to be accepted
+)
 
 func InitHost(ctx context.Context, opts []libp2p.Option, listenAddrs ...multiaddr.Multiaddr) (Host, error) {
 	opts = append([]libp2p.Option{libp2p.Identity(nil), libp2p.ResourceManager(&network.NullResourceManager{})}, opts...)
@@ -52,7 +55,7 @@ func InitHost(ctx context.Context, opts []libp2p.Option, listenAddrs ...multiadd
 
 func yamuxTransport() network.Multiplexer {
 	tpt := *yamux.DefaultTransport
-	tpt.AcceptBacklog = 512
+	tpt.AcceptBacklog = yamuxAcceptBacklog
 	return &tpt
 }
 

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -18,18 +18,19 @@ import (
 	"github.com/multiformats/go-multicodec"
 )
 
-var (
-	MimeTypeCar        = "application/vnd.ipld.car" // The only accepted MIME type
-	MimeTypeCarVersion = "1"                        // We only accept version 1 of the MIME type
-	FormatParameterCar = "car"                      // The only valid format parameter value
-	FilenameExtCar     = ".car"                     // The only valid filename extension
-
-	DefaultIncludeDupes = true // The default value for an unspecified "dups" parameter. See https://github.com/ipfs/specs/pull/412.
-
+const (
+	MimeTypeCar                = "application/vnd.ipld.car"            // The only accepted MIME type
+	MimeTypeCarVersion         = "1"                                   // We only accept version 1 of the MIME type
+	FormatParameterCar         = "car"                                 // The only valid format parameter value
+	FilenameExtCar             = ".car"                                // The only valid filename extension
+	DefaultIncludeDupes        = true                                  // The default value for an unspecified "dups" parameter. See https://github.com/ipfs/specs/pull/412.
 	ResponseAcceptRangesHeader = "none"                                // We currently don't accept range requests
 	ResponseCacheControlHeader = "public, max-age=29030400, immutable" // Magic cache control values
-	ResponseChunkDelimeter     = []byte("0\r\n")                       // An http/1.1 chunk delimeter, used for specifying an early end to the response
-	ResponseContentTypeHeader  = fmt.Sprintf("%s; version=%s", MimeTypeCar, MimeTypeCarVersion)
+)
+
+var (
+	ResponseChunkDelimeter    = []byte("0\r\n") // An http/1.1 chunk delimeter, used for specifying an early end to the response
+	ResponseContentTypeHeader = fmt.Sprintf("%s; version=%s", MimeTypeCar, MimeTypeCarVersion)
 )
 
 func ipfsHandler(lassie *lassie.Lassie, cfg HttpServerConfig) func(http.ResponseWriter, *http.Request) {


### PR DESCRIPTION
The goal was to take any constant or arbitrary strings and numbers and extract them for visibility with comments. Any constants where type defaults are used were ignored due to the large number of type defaults we utilize in an effort to keep clarity.

Closes #263