### PR TITLE
fix: add protocol detail to more events for better logging

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -277,12 +277,16 @@ func defaultFetchRun(
 		fmt.Fprintln(msgWriter)
 		return err
 	}
+	spid := stats.StorageProviderId
+	if spid == "" {
+		spid = types.BitswapIndentifier
+	}
 	fmt.Fprintf(msgWriter, "\nFetched [%s] from [%s]:\n"+
 		"\tDuration: %s\n"+
 		"\t  Blocks: %d\n"+
 		"\t   Bytes: %s\n",
 		rootCid,
-		stats.StorageProviderId,
+		spid,
 		stats.Duration,
 		blockCount,
 		humanize.IBytes(stats.Size),

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder_test.go
@@ -64,7 +64,7 @@ func TestAggregateEventRecorder(t *testing.T) {
 				subscriber(events.StartedRetrieval(clock.Now(), id, bitswapPeer, multicodec.TransportBitswap))
 				clock.Add(20 * time.Millisecond)
 				subscriber(events.FirstByte(clock.Now(), id, bitswapPeer, 20*time.Millisecond, multicodec.TransportBitswap))
-				subscriber(events.FailedRetrieval(clock.Now(), id, graphsyncCandidates[0], "failed to dial"))
+				subscriber(events.FailedRetrieval(clock.Now(), id, graphsyncCandidates[0], multicodec.TransportGraphsyncFilecoinv1, "failed to dial"))
 				clock.Add(20 * time.Millisecond)
 				subscriber(events.FirstByte(clock.Now(), id, graphsyncCandidates[1], 50*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1))
 				clock.Add(30 * time.Millisecond)

--- a/pkg/events/connectedtoprovider.go
+++ b/pkg/events/connectedtoprovider.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
 )
 
 var (
@@ -14,13 +15,15 @@ var (
 
 type ConnectedToProviderEvent struct {
 	providerRetrievalEvent
+	protocol multicodec.Code
 }
 
-func (e ConnectedToProviderEvent) Code() types.EventCode { return types.ConnectedToProviderCode }
+func (e ConnectedToProviderEvent) Code() types.EventCode     { return types.ConnectedToProviderCode }
+func (e ConnectedToProviderEvent) Protocol() multicodec.Code { return e.protocol }
 func (e ConnectedToProviderEvent) String() string {
 	return fmt.Sprintf("ConnectedToProviderEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
 }
 
-func ConnectedToProvider(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) ConnectedToProviderEvent {
-	return ConnectedToProviderEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}}
+func ConnectedToProvider(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code) ConnectedToProviderEvent {
+	return ConnectedToProviderEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, protocol}
 }

--- a/pkg/events/failedretrieval.go
+++ b/pkg/events/failedretrieval.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
 )
 
 var (
@@ -15,15 +16,17 @@ var (
 
 type FailedRetrievalEvent struct {
 	providerRetrievalEvent
+	protocol     multicodec.Code
 	errorMessage string
 }
 
-func (e FailedRetrievalEvent) Code() types.EventCode { return types.FailedRetrievalCode }
-func (e FailedRetrievalEvent) ErrorMessage() string  { return e.errorMessage }
+func (e FailedRetrievalEvent) Code() types.EventCode     { return types.FailedRetrievalCode }
+func (e FailedRetrievalEvent) ErrorMessage() string      { return e.errorMessage }
+func (e FailedRetrievalEvent) Protocol() multicodec.Code { return e.protocol }
 func (e FailedRetrievalEvent) String() string {
 	return fmt.Sprintf("FailedRetrievalEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.payloadCid, e.errorMessage)
 }
 
-func FailedRetrieval(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, errorMessage string) FailedRetrievalEvent {
-	return FailedRetrievalEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, errorMessage}
+func FailedRetrieval(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code, errorMessage string) FailedRetrievalEvent {
+	return FailedRetrievalEvent{providerRetrievalEvent{retrievalEvent{at, retrievalId, candidate.RootCid}, candidate.MinerPeer.ID}, protocol, errorMessage}
 }

--- a/pkg/events/firstbyte.go
+++ b/pkg/events/firstbyte.go
@@ -17,7 +17,7 @@ var (
 type FirstByteEvent struct {
 	providerRetrievalEvent
 	duration time.Duration
-	protocol multicodec.Code // TODO: remove when we can get the storage provider id from bitswap. This is required to determine the SP ID from events.Identifier().
+	protocol multicodec.Code
 }
 
 func (e FirstByteEvent) Code() types.EventCode     { return types.FirstByteCode }

--- a/pkg/events/graphsyncaccepted.go
+++ b/pkg/events/graphsyncaccepted.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
 )
 
 var (
@@ -17,6 +18,9 @@ type GraphsyncAcceptedEvent struct {
 }
 
 func (e GraphsyncAcceptedEvent) Code() types.EventCode { return types.AcceptedCode }
+func (e GraphsyncAcceptedEvent) Protocol() multicodec.Code {
+	return multicodec.TransportGraphsyncFilecoinv1
+}
 func (e GraphsyncAcceptedEvent) String() string {
 	return fmt.Sprintf("GraphsyncAcceptedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
 }

--- a/pkg/events/graphsyncproposed.go
+++ b/pkg/events/graphsyncproposed.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/multiformats/go-multicodec"
 )
 
 var (
@@ -17,6 +18,9 @@ type GraphsyncProposedEvent struct {
 }
 
 func (e GraphsyncProposedEvent) Code() types.EventCode { return types.ProposedCode }
+func (e GraphsyncProposedEvent) Protocol() multicodec.Code {
+	return multicodec.TransportGraphsyncFilecoinv1
+}
 func (e GraphsyncProposedEvent) String() string {
 	return fmt.Sprintf("GraphsyncProposedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
 }

--- a/pkg/events/manager_test.go
+++ b/pkg/events/manager_test.go
@@ -39,7 +39,7 @@ func TestEventManager(t *testing.T) {
 	em.DispatchEvent(events.CandidatesFiltered(time.Now(), id, cid, []types.RetrievalCandidate{{MinerPeer: peer.AddrInfo{ID: peerA}, RootCid: cid}, {MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, {MinerPeer: peer.AddrInfo{ID: peerC}, RootCid: cid}}))
 	em.DispatchEvent(events.StartedRetrieval(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, multicodec.TransportGraphsyncFilecoinv1))
 	em.DispatchEvent(events.Success(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, 100, 200, time.Second*300, multicodec.TransportGraphsyncFilecoinv1))
-	em.DispatchEvent(events.FailedRetrieval(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, "error @ retrieval failure"))
+	em.DispatchEvent(events.FailedRetrieval(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, multicodec.TransportGraphsyncFilecoinv1, "error @ retrieval failure"))
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -53,7 +53,7 @@ func TestEventManager(t *testing.T) {
 	em.DispatchEvent(events.CandidatesFiltered(time.Now(), id, cid, []types.RetrievalCandidate{{MinerPeer: peer.AddrInfo{ID: peerA}, RootCid: cid}, {MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, {MinerPeer: peer.AddrInfo{ID: peerC}, RootCid: cid}}))
 	em.DispatchEvent(events.StartedRetrieval(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, multicodec.TransportGraphsyncFilecoinv1))
 	em.DispatchEvent(events.Success(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, 100, 200, time.Second*300, multicodec.TransportGraphsyncFilecoinv1))
-	em.DispatchEvent(events.FailedRetrieval(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, "error @ retrieval failure"))
+	em.DispatchEvent(events.FailedRetrieval(time.Now(), id, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerB}, RootCid: cid}, multicodec.TransportGraphsyncFilecoinv1, "error @ retrieval failure"))
 
 	select {
 	case <-em.Stop():

--- a/pkg/retriever/bitswapretriever.go
+++ b/pkg/retriever/bitswapretriever.go
@@ -243,7 +243,7 @@ func (br *bitswapRetrieval) RetrieveFromAsyncCandidates(ayncCandidates types.Inb
 	br.bstore.RemoveLinkSystem(br.request.RetrievalID)
 	if err != nil {
 		// record failure
-		br.events(events.FailedRetrieval(br.clock.Now(), br.request.RetrievalID, bitswapCandidate, err.Error()))
+		br.events(events.FailedRetrieval(br.clock.Now(), br.request.RetrievalID, bitswapCandidate, multicodec.TransportBitswap, err.Error()))
 		return nil, err
 	}
 	duration := br.clock.Since(startTime)

--- a/pkg/retriever/graphsyncretriever_test.go
+++ b/pkg/retriever/graphsyncretriever_test.go
@@ -67,7 +67,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -118,7 +118,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -131,8 +131,8 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*50 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 50},
@@ -179,9 +179,9 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "unable to connect to provider: Nope"),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, "unable to connect to provider: Nope"),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, "unable to connect to provider: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "unable to connect to provider: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1, "unable to connect to provider: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1, "unable to connect to provider: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -217,7 +217,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -231,7 +231,7 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart: time.Millisecond*40 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -241,7 +241,7 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart:         time.Millisecond * 60,
 					ReceivedRetrievals: []peer.ID{peerBar},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*60), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*60), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 60},
@@ -288,7 +288,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -297,7 +297,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 25,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*25), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*25), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 25},
@@ -310,7 +310,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 60,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*60), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*60), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBaz, Duration: time.Millisecond * 60},
@@ -321,7 +321,7 @@ func TestRetrievalRacing(t *testing.T) {
 					ReceivedRetrievals: []peer.ID{peerBar},
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*120+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -332,7 +332,7 @@ func TestRetrievalRacing(t *testing.T) {
 					ReceivedRetrievals: []peer.ID{peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(time.Millisecond*220+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*220+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, "retrieval failed: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*220+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerBar},
@@ -342,7 +342,7 @@ func TestRetrievalRacing(t *testing.T) {
 					AfterStart: time.Millisecond*320 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(time.Millisecond*320+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*320+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, "retrieval failed: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*320+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerBaz},
@@ -386,7 +386,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 1,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 1},
@@ -399,9 +399,9 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -414,7 +414,7 @@ func TestRetrievalRacing(t *testing.T) {
 					ReceivedRetrievals: []peer.ID{peerBaz},
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(time.Millisecond*201+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*201+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*201+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -468,9 +468,9 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -530,7 +530,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 1,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 1},
@@ -543,7 +543,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 100,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBang}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBang, Duration: time.Millisecond * 100},
@@ -552,7 +552,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 200,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*200), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*200), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBaz, Duration: time.Millisecond * 200},
@@ -561,7 +561,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 220,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*220), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*220), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 220},
@@ -572,7 +572,7 @@ func TestRetrievalRacing(t *testing.T) {
 					ReceivedRetrievals: []peer.ID{peerBang},
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(time.Millisecond*401+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-						events.FailedRetrieval(startTime.Add(time.Millisecond*401+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+						events.FailedRetrieval(startTime.Add(time.Millisecond*401+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -624,7 +624,7 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond * 20,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*20), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 20},
@@ -633,8 +633,8 @@ func TestRetrievalRacing(t *testing.T) {
 				{
 					AfterStart: time.Millisecond*50 + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+						events.ConnectedToProvider(startTime.Add(time.Millisecond*40+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 50},
@@ -790,8 +790,8 @@ func TestMultipleRetrievals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 1,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.FailedRetrieval(startTime.Add(time.Millisecond*1), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBoom}}, "unable to connect to provider: Nope"),
-				events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+				events.FailedRetrieval(startTime.Add(time.Millisecond*1), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBoom}}, multicodec.TransportGraphsyncFilecoinv1, "unable to connect to provider: Nope"),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*1), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Failure, Provider: peerBoom},
@@ -806,7 +806,7 @@ func TestMultipleRetrievals(t *testing.T) {
 			AfterStart: time.Millisecond*2 + initialPause,
 			ExpectedEvents: []types.RetrievalEvent{
 				events.Proposed(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-				events.FailedRetrieval(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+				events.FailedRetrieval(startTime.Add(time.Millisecond*2+initialPause), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Failure, Provider: peerFoo},
@@ -815,8 +815,8 @@ func TestMultipleRetrievals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 100,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
-				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID1, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID2, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBing}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -999,7 +999,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 50,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.ConnectedToProvider(startTime.Add(time.Millisecond*50), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*50), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerFoo, Duration: time.Millisecond * 50},
@@ -1012,7 +1012,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 75,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.ConnectedToProvider(startTime.Add(time.Millisecond*75), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*75), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBaz}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerBaz, Duration: time.Millisecond * 75},
@@ -1021,7 +1021,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 		{
 			AfterStart: time.Millisecond * 100,
 			ExpectedEvents: []types.RetrievalEvent{
-				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}),
+				events.ConnectedToProvider(startTime.Add(time.Millisecond*100), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerBar}}, multicodec.TransportGraphsyncFilecoinv1),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Connect, Provider: peerBar, Duration: time.Millisecond * 100},
@@ -1032,7 +1032,7 @@ func TestDuplicateRetreivals(t *testing.T) {
 			ReceivedRetrievals: []peer.ID{peerBar},
 			ExpectedEvents: []types.RetrievalEvent{
 				events.Proposed(startTime.Add(time.Millisecond*200+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}),
-				events.FailedRetrieval(startTime.Add(time.Millisecond*200+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, "retrieval failed: Nope"),
+				events.FailedRetrieval(startTime.Add(time.Millisecond*200+initialPause), retrievalID, types.RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peerFoo}}, multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: Nope"),
 			},
 			ExpectedMetrics: []testutil.SessionMetric{
 				{Type: testutil.SessionMetric_Failure, Provider: peerFoo},

--- a/pkg/retriever/httpretriever_test.go
+++ b/pkg/retriever/httpretriever_test.go
@@ -101,7 +101,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -189,8 +189,8 @@ func TestHTTPRetriever(t *testing.T) {
 					ExpectedEvents: []types.RetrievalEvent{
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 						events.StartedRetrieval(startTime, rid2, toCandidate(cid2, cid2Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.ConnectedToProvider(startTime, rid2, toCandidate(cid2, cid2Cands[0].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid2, toCandidate(cid2, cid2Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -295,9 +295,9 @@ func TestHTTPRetriever(t *testing.T) {
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer)),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -313,7 +313,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: initialPause + time.Millisecond*10,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
-						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp, "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[0].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[1].MinerPeer.ID},
@@ -334,7 +334,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: initialPause + time.Millisecond*20,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.FirstByte(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
-						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp, "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[1].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[2].MinerPeer.ID},
@@ -355,7 +355,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: initialPause + time.Millisecond*30,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.FirstByte(startTime.Add(initialPause+time.Millisecond*30), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
-						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*30), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*30), rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp, "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[2].MinerPeer.ID},
 					ServedRetrievals: []testutil.RemoteStats{
@@ -421,9 +421,9 @@ func TestHTTPRetriever(t *testing.T) {
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer)),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[2].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID, Duration: 0},
@@ -439,7 +439,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: initialPause + time.Millisecond*10,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.FirstByte(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
-						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*10), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp, "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[0].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[1].MinerPeer.ID},
@@ -460,7 +460,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: initialPause + time.Millisecond*20,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.FirstByte(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), time.Millisecond*10, multicodec.TransportIpfsGatewayHttp),
-						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), "malformed CAR; unexpected EOF"),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*20), rid1, toCandidate(cid1, cid1Cands[1].MinerPeer), multicodec.TransportIpfsGatewayHttp, "malformed CAR; unexpected EOF"),
 					},
 					CompletedRetrievals: []peer.ID{cid1Cands[1].MinerPeer.ID},
 					ReceivedRetrievals:  []peer.ID{cid1Cands[2].MinerPeer.ID},
@@ -531,7 +531,7 @@ func TestHTTPRetriever(t *testing.T) {
 					AfterStart: 0,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.StartedRetrieval(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
-						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer)),
+						events.ConnectedToProvider(startTime, rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: cid1Cands[0].MinerPeer.ID},
@@ -553,7 +553,7 @@ func TestHTTPRetriever(t *testing.T) {
 				{
 					AfterStart: initialPause + time.Millisecond*40 + remoteBlockDuration*50,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*50), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), "missing block in CAR; ipld: could not find "+tbc1.AllBlocks()[50].Cid().String()),
+						events.FailedRetrieval(startTime.Add(initialPause+time.Millisecond*40+remoteBlockDuration*50), rid1, toCandidate(cid1, cid1Cands[0].MinerPeer), multicodec.TransportIpfsGatewayHttp, "missing block in CAR; ipld: could not find "+tbc1.AllBlocks()[50].Cid().String()),
 					},
 					ServedRetrievals: []testutil.RemoteStats{
 						{

--- a/pkg/retriever/parallelpeerretriever.go
+++ b/pkg/retriever/parallelpeerretriever.go
@@ -333,10 +333,10 @@ func (retrieval *retrieval) runRetrievalCandidate(
 			if err := retrieval.Session.RecordFailure(retrieval.request.RetrievalID, candidate.MinerPeer.ID); err != nil {
 				logger.Errorf("Error recording retrieval failure on protocol %s: %v", retrieval.Protocol.Code().String(), err)
 			}
-			shared.sendEvent(ctx, events.FailedRetrieval(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate, retrievalErr.Error()))
+			shared.sendEvent(ctx, events.FailedRetrieval(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate, retrieval.Protocol.Code(), retrievalErr.Error()))
 		}
 	} else {
-		shared.sendEvent(ctx, events.ConnectedToProvider(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate))
+		shared.sendEvent(ctx, events.ConnectedToProvider(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate, retrieval.Protocol.Code()))
 
 		retrieval.Session.RecordConnectTime(candidate.MinerPeer.ID, connectTime)
 
@@ -351,7 +351,7 @@ func (retrieval *retrieval) runRetrievalCandidate(
 				if errors.Is(retrievalErr, ErrRetrievalTimedOut) {
 					msg = fmt.Sprintf("timeout after %s", timeout)
 				}
-				shared.sendEvent(ctx, events.FailedRetrieval(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate, msg))
+				shared.sendEvent(ctx, events.FailedRetrieval(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate, retrieval.Protocol.Code(), msg))
 				if err := retrieval.Session.RecordFailure(retrieval.request.RetrievalID, candidate.MinerPeer.ID); err != nil {
 					logger.Errorf("Error recording retrieval failure for protocol %s: %v", retrieval.Protocol.Code().String(), err)
 				}

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -105,7 +105,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 20 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(20*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(20*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 20 * time.Millisecond},
@@ -178,7 +178,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -254,7 +254,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 50 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(50*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(50*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 50 * time.Millisecond},
@@ -328,7 +328,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FailedRetrieval(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), "unable to connect to provider: blip"),
+						events.FailedRetrieval(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, "unable to connect to provider: blip"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerA},
@@ -337,7 +337,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 50 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(50*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(50*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 50 * time.Millisecond},
@@ -412,7 +412,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -426,7 +426,7 @@ func TestRetriever(t *testing.T) {
 					AfterStart: 10*time.Millisecond + initialPause,
 					ExpectedEvents: []types.RetrievalEvent{
 						events.Proposed(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
-						events.FailedRetrieval(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), "retrieval failed: bork!"),
+						events.FailedRetrieval(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, "retrieval failed: bork!"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerB},
@@ -436,7 +436,7 @@ func TestRetriever(t *testing.T) {
 					AfterStart:         500 * time.Millisecond,
 					ReceivedRetrievals: []peer.ID{peerA},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(500*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(500*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 500 * time.Millisecond},
@@ -517,7 +517,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 1 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(1*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(1*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: time.Millisecond},
@@ -530,7 +530,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 100 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(100*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(100*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 100 * time.Millisecond},
@@ -540,7 +540,7 @@ func TestRetriever(t *testing.T) {
 					AfterStart:         201*time.Millisecond + initialPause,
 					ReceivedRetrievals: []peer.ID{peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FailedRetrieval(startTime.Add(201*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), "timeout after 200ms"),
+						events.FailedRetrieval(startTime.Add(201*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, "timeout after 200ms"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerA},
@@ -682,7 +682,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(1*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(1*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerA, Duration: 1 * time.Millisecond},
@@ -691,7 +691,7 @@ func TestRetriever(t *testing.T) {
 				{
 					AfterStart: 5 * time.Millisecond,
 					ExpectedEvents: []types.RetrievalEvent{
-						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+						events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Connect, Provider: peerB, Duration: 5 * time.Millisecond},
@@ -877,7 +877,7 @@ func TestLinkSystemPerRequest(t *testing.T) {
 			{
 				AfterStart: 5 * time.Millisecond,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1)),
+					events.ConnectedToProvider(startTime.Add(5*time.Millisecond), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 				},
 			},
 			{
@@ -943,7 +943,7 @@ func TestLinkSystemPerRequest(t *testing.T) {
 			{
 				AfterStart: 5 * time.Millisecond,
 				ExpectedEvents: []types.RetrievalEvent{
-					events.ConnectedToProvider(startTime.Add(15*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1)),
+					events.ConnectedToProvider(startTime.Add(15*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1),
 				},
 			},
 			{


### PR DESCRIPTION
Primarily for use with the CLI so you can see "Bitswap" where appropriate. events.Identifier() uses an interface check to get the SP ID and returns "" if the event doesn't have one and if it doesn't have a protocol; this means it returns "" for a lot of events where there could be a "Bitswap".