### PR TITLE
fix: properly detect context cancellation error type

### DIFF
--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -243,7 +243,8 @@ func (pg *ProtocolGraphsync) Retrieve(
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrRetrievalFailed, err)
+		// TODO: replace with %w: %w after 1.19
+		return nil, multierr.Append(ErrRetrievalFailed, err)
 	}
 	return stats, nil
 }

--- a/pkg/retriever/parallelpeerretriever.go
+++ b/pkg/retriever/parallelpeerretriever.go
@@ -351,7 +351,7 @@ func (retrieval *retrieval) runRetrievalCandidate(
 			if retrievalErr != nil {
 				// Exclude the case where the context was cancelled by the parent, which likely
 				// means that another protocol has succeeded.
-				if ctx.Err() == nil || !errors.Is(err, context.Canceled) {
+				if ctx.Err() == nil || !errors.Is(retrievalErr, context.Canceled) {
 					msg := retrievalErr.Error()
 					if errors.Is(retrievalErr, ErrRetrievalTimedOut) {
 						msg = fmt.Sprintf("timeout after %s", timeout)

--- a/pkg/retriever/parallelpeerretriever.go
+++ b/pkg/retriever/parallelpeerretriever.go
@@ -309,7 +309,6 @@ func (retrieval *retrieval) runRetrievalCandidate(
 	startTime time.Time,
 	candidate types.RetrievalCandidate,
 ) {
-
 	timeout := retrieval.Session.GetStorageProviderTimeout(candidate.MinerPeer.ID)
 
 	var stats *types.RetrievalStats
@@ -327,9 +326,9 @@ func (retrieval *retrieval) runRetrievalCandidate(
 	// Setup in parallel
 	connectTime, err := retrieval.Protocol.Connect(connectCtx, retrieval, startTime, candidate)
 	if err != nil {
-		// Exclude the case where the context was cancelled by the parent, whichikely means that
+		// Exclude the case where the context was cancelled by the parent, which likely means that
 		// another protocol has succeeded.
-		if ctx.Err() == nil || !errors.Is(err, context.Canceled) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			logger.Warnf("Failed to connect to SP %s on protocol %s: %v", candidate.MinerPeer.ID, retrieval.Protocol.Code().String(), err)
 			retrievalErr = fmt.Errorf("%w: %v", ErrConnectFailed, err)
 			if err := retrieval.Session.RecordFailure(retrieval.request.RetrievalID, candidate.MinerPeer.ID); err != nil {
@@ -351,7 +350,7 @@ func (retrieval *retrieval) runRetrievalCandidate(
 			if retrievalErr != nil {
 				// Exclude the case where the context was cancelled by the parent, which likely
 				// means that another protocol has succeeded.
-				if ctx.Err() == nil || !errors.Is(retrievalErr, context.Canceled) {
+				if !errors.Is(ctx.Err(), context.Canceled) {
 					msg := retrievalErr.Error()
 					if errors.Is(retrievalErr, ErrRetrievalTimedOut) {
 						msg = fmt.Sprintf("timeout after %s", timeout)


### PR DESCRIPTION
Copypasta mistake in https://github.com/filecoin-project/lassie/pull/374

**Edit** cleaned this up a bit more and made more strict; also added proper "timeout" reporting for Bitswap because the event logs are full of Bitswap "context cancelled" which are just going to be (mainly) timeouts.