### PR TITLE
fix: "Bitswap" shouldn't convert peer.ID to display as b64

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -277,7 +277,7 @@ func defaultFetchRun(
 		fmt.Fprintln(msgWriter)
 		return err
 	}
-	spid := stats.StorageProviderId
+	spid := stats.StorageProviderId.String()
 	if spid == "" {
 		spid = types.BitswapIndentifier
 	}


### PR DESCRIPTION
Late change in https://github.com/filecoin-project/lassie/pull/373 after a review didn't catch this fact; explicitly making `spid` a string will prevent the b64("Bitswap") output, which is meaningless!