### PR TITLE
fix(cli): clean up path before passing it on

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/lassie/pkg/storage"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -126,12 +126,12 @@ func fetchAction(cctx *cli.Context) error {
 
 func parseCidPath(cpath string) (cid.Cid, string, error) {
 	cstr := strings.Split(cpath, "/")[0]
-	path := strings.TrimPrefix(cpath, cstr)
+	path := datamodel.ParsePath(strings.TrimPrefix(cpath, cstr))
 	rootCid, err := cid.Parse(cstr)
 	if err != nil {
 		return cid.Undef, "", err
 	}
-	return rootCid, path, nil
+	return rootCid, path.String(), nil
 }
 
 type progressPrinter struct {

--- a/cmd/lassie/fetch_test.go
+++ b/cmd/lassie/fetch_test.go
@@ -71,7 +71,7 @@ func TestFetchCommandFlags(t *testing.T) {
 				"bafybeic56z3yccnla3cutmvqsn5zy3g24muupcsjtoyp3pu5pm5amurjx4/birb.mp4",
 			},
 			assertRun: func(ctx context.Context, lCfg *l.LassieConfig, erCfg *a.EventRecorderConfig, msgWriter io.Writer, dataWriter io.Writer, rootCid cid.Cid, path string, dagScope string, tempDir string, progress bool, outfile string) error {
-				require.Equal(t, "/birb.mp4", path)
+				require.Equal(t, "birb.mp4", path)
 				return nil
 			},
 		},


### PR DESCRIPTION
8e45ccfa cleaned up pathing elsewhere, removing "/" prefixes, but left this undone. It means that a "/" prefix passes through the system and we end up with "//"; which is fine, except for the HTTP retriever which will fetch with a "//" prefix and be corrected by the server's `Location` header. This change does a parse, just like the daemon handler does, and strips out a "/" prefixe if it exists.