### PR TITLE
Escape paths for HTTP requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/trace v1.14.0
 	go.uber.org/multierr v1.11.0
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 )
 
 require (
@@ -152,7 +153,6 @@ require (
 	go.uber.org/fx v1.20.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/pkg/internal/testutil/collectingeventlsubscriber.go
+++ b/pkg/internal/testutil/collectingeventlsubscriber.go
@@ -152,4 +152,12 @@ func VerifyCollectedEvent(t *testing.T, actual types.RetrievalEvent, expected ty
 			require.Fail(t, "wrong event type", expected.Code())
 		}
 	}
+	if esf, ok := expected.(events.StartedFetchEvent); ok {
+		if asf, ok := actual.(events.StartedFetchEvent); ok {
+			require.Equal(t, esf.UrlPath(), asf.UrlPath(), fmt.Sprintf("url path for %s", expected.Code()))
+			require.Equal(t, esf.Protocols(), asf.Protocols(), fmt.Sprintf("protocols for %s", expected.Code()))
+		} else {
+			require.Fail(t, "wrong event type", expected.Code())
+		}
+	}
 }

--- a/pkg/internal/testutil/mockroundtripper.go
+++ b/pkg/internal/testutil/mockroundtripper.go
@@ -94,7 +94,7 @@ func (mrt *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	require.Equal(mrt.t, us[1], "ipfs")
 	root, err := cid.Parse(us[2])
 	require.NoError(mrt.t, err)
-	path := strings.TrimSuffix(req.URL.Path, "/ipfs/"+root.String())
+	path := strings.TrimPrefix(strings.TrimPrefix(req.URL.Path, "/ipfs/"+root.String()), "/")
 	expectedPath, ok := mrt.expectedPath[root]
 	if !ok {
 		require.Equal(mrt.t, path, "")

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -599,6 +599,18 @@ func sizeOf(blocks []blocks.Block) uint64 {
 	return total
 }
 
+func sizeOfStored(lsys linking.LinkSystem, links []cid.Cid) uint64 {
+	total := uint64(0)
+	for _, c := range links {
+		b, err := lsys.LoadRaw(linking.LinkContext{}, cidlink.Link{Cid: c})
+		if err != nil {
+			panic(err)
+		}
+		total += uint64(len(b))
+	}
+	return total
+}
+
 type mockInProgressCids struct {
 	incremented []cid.Cid
 	decremented []cid.Cid

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -155,10 +155,14 @@ func (retriever *Retriever) Retrieve(
 		eventsCB,
 	)
 
-	urlPath, _ := request.GetUrlPath()
+	descriptor, err := request.GetDescriptorString()
+	if err != nil {
+		return nil, err
+	}
+	descriptor = strings.TrimPrefix(descriptor, "/ipfs/"+request.Cid.String())
 
 	// Emit a StartedFetch event signaling that the Lassie fetch has started
-	onRetrievalEvent(events.StartedFetch(retriever.clock.Now(), request.RetrievalID, request.Cid, urlPath, request.GetSupportedProtocols(retriever.protocols)...))
+	onRetrievalEvent(events.StartedFetch(retriever.clock.Now(), request.RetrievalID, request.Cid, descriptor, request.GetSupportedProtocols(retriever.protocols)...))
 
 	// retrieve, note that we could get a successful retrieval
 	// (retrievalStats!=nil) _and_ also an error return because there may be

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -155,7 +155,7 @@ func ipfsHandler(fetcher types.Fetcher, cfg HttpServerConfig) func(http.Response
 			res.Header().Set("Content-Type", ResponseContentTypeHeader)
 			res.Header().Set("Etag", request.Etag())
 			res.Header().Set("X-Content-Type-Options", "nosniff")
-			res.Header().Set("X-Ipfs-Path", "/"+datamodel.ParsePath(req.URL.Path).String())
+			res.Header().Set("X-Ipfs-Path", types.PathEscape(req.URL.Path))
 			// TODO: set X-Ipfs-Roots header when we support root+path
 			// see https://github.com/ipfs/kubo/pull/8720
 			res.Header().Set("X-Trace-Id", requestId)

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -155,9 +156,14 @@ func (r RetrievalRequest) GetUrlPath() (string, error) {
 	if legacyScope == string(DagScopeEntity) {
 		legacyScope = "file"
 	}
-	path := r.Path
-	if path != "" {
-		path = "/" + path
+	var path string
+	if r.Path != "" {
+		p := datamodel.ParsePath(r.Path)
+		for p.Len() > 0 {
+			var ps datamodel.PathSegment
+			ps, p = p.Shift()
+			path += "/" + url.PathEscape(ps.String())
+		}
 	}
 	return fmt.Sprintf("%s?dag-scope=%s&car-scope=%s", path, scope, legacyScope), nil
 }

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -195,11 +195,7 @@ func (r RetrievalRequest) GetDescriptorString() (string, error) {
 	if r.Scope == "" {
 		scope = DagScopeAll
 	}
-	var path string
-	if r.Path != "" {
-		path = "/" + datamodel.ParsePath(r.Path).String()
-	}
-
+	path := PathEscape(r.Path)
 	dups := "y"
 	if !r.Duplicates {
 		dups = "n"

--- a/pkg/types/request_test.go
+++ b/pkg/types/request_test.go
@@ -6,7 +6,12 @@ import (
 
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
+	"github.com/stretchr/testify/require"
 )
+
+var testCidV1 = cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+var testCidV0 = cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK")
 
 func TestEtag(t *testing.T) {
 	// To generate independent fixtures using Node.js, `npm install xxhash` then
@@ -26,72 +31,72 @@ func TestEtag(t *testing.T) {
 		expected string
 	}{
 		{
-			cid:      cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK"),
+			cid:      testCidV0,
 			scope:    types.DagScopeAll,
 			expected: `"QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK.car.58mf8vcmd2eo8"`,
 		},
 		{
-			cid:      cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK"),
+			cid:      testCidV0,
 			scope:    types.DagScopeEntity,
 			expected: `"QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK.car.3t6g88g8u04i6"`,
 		},
 		{
-			cid:      cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK"),
+			cid:      testCidV0,
 			scope:    types.DagScopeBlock,
 			expected: `"QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK.car.1fe71ua3km0b5"`,
 		},
 		{
-			cid:      cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK"),
+			cid:      testCidV0,
 			scope:    types.DagScopeAll,
 			dups:     true,
 			expected: `"QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK.car.4mglp6etuagob"`,
 		},
 		{
-			cid:      cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK"),
+			cid:      testCidV0,
 			scope:    types.DagScopeEntity,
 			dups:     true,
 			expected: `"QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK.car.fqhsp0g4l66m1"`,
 		},
 		{
-			cid:      cid.MustParse("QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK"),
+			cid:      testCidV0,
 			scope:    types.DagScopeBlock,
 			dups:     true,
 			expected: `"QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK.car.8u1ga109k62pp"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeAll,
 			path:     "/some/path/to/thing",
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.8q5lna3r43lgj"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeEntity,
 			path:     "/some/path/to/thing",
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.e4hni8qqgeove"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeBlock,
 			path:     "/some/path/to/thing",
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.7pdc786smhd1n"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeAll,
 			path:     "/some/path/to/thing",
 			dups:     true,
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.bdfv1q76a1oem"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeEntity,
 			path:     "/some/path/to/thing",
 			dups:     true,
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.790m13mh0recp"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeBlock,
 			path:     "/some/path/to/thing",
 			dups:     true,
@@ -99,13 +104,13 @@ func TestEtag(t *testing.T) {
 		},
 		// path variations should be normalised
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeAll,
 			path:     "some/path/to/thing",
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.8q5lna3r43lgj"`,
 		},
 		{
-			cid:      cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+			cid:      testCidV1,
 			scope:    types.DagScopeAll,
 			path:     "///some//path//to/thing/",
 			expected: `"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.car.8q5lna3r43lgj"`,
@@ -131,4 +136,144 @@ func TestEtag(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequestStringRepresentations(t *testing.T) {
+	testCases := []struct {
+		name               string
+		request            types.RetrievalRequest
+		expectedUrlPath    string
+		expectedDescriptor string
+	}{
+		{
+			name: "plain",
+			request: types.RetrievalRequest{
+				Cid: testCidV1,
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n",
+		},
+		{
+			name: "path",
+			request: types.RetrievalRequest{
+				Cid:  testCidV1,
+				Path: "/some/path/to/thing",
+			},
+			expectedUrlPath:    "/some/path/to/thing?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/some/path/to/thing?dag-scope=all&dups=n",
+		},
+		{
+			name: "escaped path",
+			request: types.RetrievalRequest{
+				Cid:  testCidV1,
+				Path: "/?/#/;/&/ /!",
+			},
+			expectedUrlPath:    "/%3F/%23/%3B/&/%20/%21?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/?/#/;/&/ /!?dag-scope=all&dups=n",
+		},
+		{
+			name: "entity",
+			request: types.RetrievalRequest{
+				Cid:   testCidV1,
+				Scope: types.DagScopeEntity,
+			},
+			expectedUrlPath:    "?dag-scope=entity&car-scope=file",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=entity&dups=n",
+		},
+		{
+			name: "block",
+			request: types.RetrievalRequest{
+				Cid:   testCidV1,
+				Scope: types.DagScopeBlock,
+			},
+			expectedUrlPath:    "?dag-scope=block&car-scope=block",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=block&dups=n",
+		},
+		{
+			name: "protocol",
+			request: types.RetrievalRequest{
+				Cid:       testCidV0,
+				Protocols: []multicodec.Code{multicodec.TransportGraphsyncFilecoinv1},
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK?dag-scope=all&dups=n&protocols=transport-graphsync-filecoinv1",
+		},
+		{
+			name: "protocols",
+			request: types.RetrievalRequest{
+				Cid:       testCidV1,
+				Protocols: []multicodec.Code{multicodec.TransportBitswap, multicodec.TransportIpfsGatewayHttp},
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&protocols=transport-bitswap,transport-ipfs-gateway-http",
+		},
+		{
+			name: "duplicates",
+			request: types.RetrievalRequest{
+				Cid:        testCidV0,
+				Duplicates: true,
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK?dag-scope=all&dups=y",
+		},
+		{
+			name: "block limit",
+			request: types.RetrievalRequest{
+				Cid:       testCidV1,
+				MaxBlocks: 100,
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&blockLimit=100",
+		},
+		{
+			name: "fixed peer",
+			request: types.RetrievalRequest{
+				Cid:        testCidV1,
+				FixedPeers: must(types.ParseProviderStrings("/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		},
+		{
+			name: "fixed peers",
+			request: types.RetrievalRequest{
+				Cid:        testCidV1,
+				FixedPeers: must(types.ParseProviderStrings("/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
+			},
+			expectedUrlPath:    "?dag-scope=all&car-scope=all",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		},
+		{
+			name: "all the things",
+			request: types.RetrievalRequest{
+				Cid:        testCidV0,
+				Path:       "/some/path/to/thing",
+				Scope:      types.DagScopeEntity,
+				Duplicates: true,
+				MaxBlocks:  222,
+				Protocols:  []multicodec.Code{multicodec.TransportBitswap, multicodec.TransportIpfsGatewayHttp},
+				FixedPeers: must(types.ParseProviderStrings("/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
+			},
+			expectedUrlPath:    "/some/path/to/thing?dag-scope=entity&car-scope=file",
+			expectedDescriptor: "/ipfs/QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK/some/path/to/thing?dag-scope=entity&dups=y&blockLimit=222&protocols=transport-bitswap,transport-ipfs-gateway-http&providers=/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.request.GetUrlPath()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedUrlPath, actual)
+			actual, err = tc.request.GetDescriptorString()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedDescriptor, actual)
+		})
+	}
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
 }

--- a/pkg/types/request_test.go
+++ b/pkg/types/request_test.go
@@ -169,7 +169,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 				Path: "/?/#/;/&/ /!",
 			},
 			expectedUrlPath:    "/%3F/%23/%3B/&/%20/%21?dag-scope=all&car-scope=all",
-			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/?/#/;/&/ /!?dag-scope=all&dups=n",
+			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/%3F/%23/%3B/&/%20/%21?dag-scope=all&dups=n",
 		},
 		{
 			name: "entity",


### PR DESCRIPTION
* When sending requests, we path-escape each segment before sending it (it turns out we have the same problem as https://github.com/web3-storage/dag.w3s.link/commit/e3c9a3146ed6d72e17f719426be32c459b4291f8 solves!)
* Adds a new `Request#GetDescriptorString()` method that is like `GetUrlPath()` but is more descriptive for logging purposes - the result can't be used safely as a URL string but it should be good for the case we currently have where it goes into aggregated events--with this path escape change, we record the escaped form in the database which makes it less obvious what the actual path is--with this change we store the actual requested path, plus we add a bunch of other information that we don't currently store about the incoming request.
* Changes `X-Ipfs-Path` response header to use the path-escaped form. I think this'll need a spec update; or a discussion at least.
* Adds tests all up and down