### PR TITLE
fix: compare multihash only in CAR verifier

### DIFF
--- a/pkg/verifiedcar/verifiedcar.go
+++ b/pkg/verifiedcar/verifiedcar.go
@@ -243,7 +243,8 @@ func (cr *carReader) readNextBlock(ctx context.Context, expected cid.Cid) ([]byt
 		return nil, multierr.Combine(ErrMalformedCar, err)
 	}
 
-	if blk.Cid() != expected {
+	// compare by multihash only
+	if !bytes.Equal(blk.Cid().Hash(), expected.Hash()) {
 		return nil, fmt.Errorf("%w: %s != %s", ErrUnexpectedBlock, blk.Cid(), expected)
 	}
 	return blk.RawData(), nil


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lassie/issues/388 (doesn't close this, I still need to check our temp CAR storage that we're doing only MH lookups)