### PR TITLE
fix: CGO_ENABLED=0 for static release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
       - 'arm64'
     # Change to a static date for checksum verification. See https://goreleaser.com/customization/builds/#reproducible-builds.
     mod_timestamp: '{{.CommitTimestamp}}'
+    env:
+      - CGO_ENABLED=0
 universal_binaries:
   - replace: true
 archives:


### PR DESCRIPTION
I've manually rebuilt assets in https://github.com/filecoin-project/lassie/releases/tag/v0.16.1 and https://github.com/filecoin-project/lassie/releases/tag/v0.17.0 using this and they run properly on older distros, notably [bullseye](https://github.com/filecoin-saturn/L1-node/blob/fc33a81af6bad0fe083ff00174755253fb0fde96/Dockerfile#L4).