### PR TITLE
Export IpfsHandler

### DIFF
--- a/pkg/server/http/client_close_test.go
+++ b/pkg/server/http/client_close_test.go
@@ -46,7 +46,7 @@ func TestHttpClientClose(t *testing.T) {
 	req.NoError(err)
 
 	reqCtx, reqCancel := context.WithCancel(context.Background())
-	handler := ipfsHandler(lassie, HttpServerConfig{TempDir: t.TempDir()})
+	handler := IpfsHandler(lassie, HttpServerConfig{TempDir: t.TempDir()})
 	response := &responseWriter{t: t, header: http.Header{}, ctx: reqCtx, cancelFn: reqCancel, fatalCh: make(chan struct{})}
 	addr := fmt.Sprintf("http://%s/ipfs/%s%s", "127.0.0.1", srcData.Root.String(), "")
 	request, err := http.NewRequestWithContext(reqCtx, "GET", addr, nil)

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -33,7 +33,7 @@ var (
 	ResponseContentTypeHeader = fmt.Sprintf("%s; version=%s", MimeTypeCar, MimeTypeCarVersion)
 )
 
-func ipfsHandler(fetcher types.Fetcher, cfg HttpServerConfig) func(http.ResponseWriter, *http.Request) {
+func IpfsHandler(fetcher types.Fetcher, cfg HttpServerConfig) func(http.ResponseWriter, *http.Request) {
 	return func(res http.ResponseWriter, req *http.Request) {
 		statusLogger := newStatusLogger(req.Method, req.URL.Path)
 		path := datamodel.ParsePath(req.URL.Path)

--- a/pkg/server/http/ipfs_test.go
+++ b/pkg/server/http/ipfs_test.go
@@ -238,7 +238,7 @@ func TestIpfsHandler(t *testing.T) {
 			if tt.httpServerConfig != nil {
 				cfg = tt.httpServerConfig
 			}
-			handler := ipfsHandler(fetcher, *cfg)
+			handler := IpfsHandler(fetcher, *cfg)
 
 			req, err := http.NewRequest(tt.method, tt.path, nil)
 			if err != nil {

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -73,7 +73,7 @@ func NewHttpServer(ctx context.Context, lassie *lassie.Lassie, cfg HttpServerCon
 	}
 
 	// Routes
-	mux.HandleFunc("/ipfs/", ipfsHandler(lassie, cfg))
+	mux.HandleFunc("/ipfs/", IpfsHandler(lassie, cfg))
 
 	// Handle pprof endpoints
 	mux.HandleFunc("/debug/pprof/", pprof.Index)


### PR DESCRIPTION
Saturn / other clients want to experiment with other http servers making using of lassie.

The IPFS Handler in the server/http package contains application logic for how to parse / render URLs that is reusable. The specific semantics of the HTTP server that this handler is currently attached to are specific to the lassie daemon mode - e.g. it may not be wnated to have the pprof debug endpoints on the same mux, or extra middleware like caching may be desired.