### PR TITLE
feat: add GroupWorkPool for managing global bitswap concurrency

### DIFF
--- a/cmd/lassie/daemon.go
+++ b/cmd/lassie/daemon.go
@@ -73,6 +73,7 @@ var daemonFlags = []cli.Flag{
 	FlagExcludeProviders,
 	FlagTempDir,
 	FlagBitswapConcurrency,
+	FlagBitswapConcurrencyPerRetrieval,
 	FlagGlobalTimeout,
 	FlagProviderTimeout,
 	&cli.StringFlag{

--- a/cmd/lassie/daemon_test.go
+++ b/cmd/lassie/daemon_test.go
@@ -37,7 +37,8 @@ func TestDaemonCommandFlags(t *testing.T) {
 				require.Equal(t, 0, len(lCfg.Protocols))
 				require.Equal(t, 0, len(lCfg.ProviderBlockList))
 				require.Equal(t, 0, len(lCfg.ProviderAllowList))
-				require.Equal(t, 12, lCfg.BitswapConcurrency)
+				require.Equal(t, 32, lCfg.BitswapConcurrency)
+				require.Equal(t, 12, lCfg.BitswapConcurrencyPerRetrieval)
 
 				// http server config
 				require.Equal(t, "127.0.0.1", hCfg.Address)

--- a/cmd/lassie/daemon_test.go
+++ b/cmd/lassie/daemon_test.go
@@ -37,7 +37,7 @@ func TestDaemonCommandFlags(t *testing.T) {
 				require.Equal(t, 0, len(lCfg.Protocols))
 				require.Equal(t, 0, len(lCfg.ProviderBlockList))
 				require.Equal(t, 0, len(lCfg.ProviderAllowList))
-				require.Equal(t, 6, lCfg.BitswapConcurrency)
+				require.Equal(t, 12, lCfg.BitswapConcurrency)
 
 				// http server config
 				require.Equal(t, "127.0.0.1", hCfg.Address)

--- a/cmd/lassie/fetch_test.go
+++ b/cmd/lassie/fetch_test.go
@@ -48,7 +48,7 @@ func TestFetchCommandFlags(t *testing.T) {
 				require.Equal(t, 0, len(lCfg.ProviderBlockList))
 				require.Equal(t, 0, len(lCfg.ProviderAllowList))
 				// require.Equal(t, "/tmp", lCfg.TempDir) // TODO: Default TempDir doesn't work with CI
-				require.Equal(t, 6, lCfg.BitswapConcurrency)
+				require.Equal(t, 12, lCfg.BitswapConcurrency)
 
 				// event recorder config
 				require.Equal(t, "", erCfg.EndpointURL)

--- a/cmd/lassie/fetch_test.go
+++ b/cmd/lassie/fetch_test.go
@@ -47,8 +47,9 @@ func TestFetchCommandFlags(t *testing.T) {
 				require.Equal(t, 0, len(lCfg.Protocols))
 				require.Equal(t, 0, len(lCfg.ProviderBlockList))
 				require.Equal(t, 0, len(lCfg.ProviderAllowList))
-				// require.Equal(t, "/tmp", lCfg.TempDir) // TODO: Default TempDir doesn't work with CI
-				require.Equal(t, 12, lCfg.BitswapConcurrency)
+				// there's only one --bitswap-concurrency for `fetch` and it sets both to be the same
+				require.Equal(t, 32, lCfg.BitswapConcurrency)
+				require.Equal(t, 32, lCfg.BitswapConcurrencyPerRetrieval)
 
 				// event recorder config
 				require.Equal(t, "", erCfg.EndpointURL)

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/filecoin-project/lassie/pkg/lassie"
 	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -24,7 +25,7 @@ var (
 )
 
 const (
-	defaultBitswapConcurrency int           = 6                // 6 concurrent requests
+	defaultBitswapConcurrency int           = lassie.DefaultBitswapConcurrencyPerRetrieval
 	defaultProviderTimeout    time.Duration = 20 * time.Second // 20 seconds
 )
 

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -25,8 +25,7 @@ var (
 )
 
 const (
-	defaultBitswapConcurrency int           = lassie.DefaultBitswapConcurrencyPerRetrieval
-	defaultProviderTimeout    time.Duration = 20 * time.Second // 20 seconds
+	defaultProviderTimeout time.Duration = 20 * time.Second // 20 seconds
 )
 
 // FlagVerbose enables verbose mode, which shows info information about
@@ -166,9 +165,16 @@ var FlagTempDir = &cli.StringFlag{
 
 var FlagBitswapConcurrency = &cli.IntFlag{
 	Name:    "bitswap-concurrency",
-	Usage:   "maximum number of concurrent bitswap requests per retrieval",
-	Value:   defaultBitswapConcurrency,
+	Usage:   "maximum number of concurrent bitswap requests",
+	Value:   lassie.DefaultBitswapConcurrency,
 	EnvVars: []string{"LASSIE_BITSWAP_CONCURRENCY"},
+}
+
+var FlagBitswapConcurrencyPerRetrieval = &cli.IntFlag{
+	Name:    "bitswap-concurrency-per-retrieval",
+	Usage:   "maximum number of concurrent bitswap requests per retrieval",
+	Value:   lassie.DefaultBitswapConcurrencyPerRetrieval,
+	EnvVars: []string{"LASSIE_BITSWAP_CONCURRENCY_PER_RETRIEVAL"},
 }
 
 var FlagGlobalTimeout = &cli.DurationFlag{

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -72,6 +72,7 @@ func buildLassieConfigFromCLIContext(cctx *cli.Context, lassieOpts []lassie.Lass
 	providerTimeout := cctx.Duration("provider-timeout")
 	globalTimeout := cctx.Duration("global-timeout")
 	bitswapConcurrency := cctx.Int("bitswap-concurrency")
+	bitswapConcurrencyPerRetrieval := cctx.Int("bitswap-concurrency-per-retrieval")
 
 	lassieOpts = append(lassieOpts, lassie.WithProviderTimeout(providerTimeout))
 
@@ -116,13 +117,13 @@ func buildLassieConfigFromCLIContext(cctx *cli.Context, lassieOpts []lassie.Lass
 	}
 
 	if bitswapConcurrency > 0 {
-		// single retrieval, so we set the bitswap concurrency to the same value
-		// as the bitswap concurrency per retrieval
-		lassieOpts = append(
-			lassieOpts,
-			lassie.WithBitswapConcurrency(bitswapConcurrency),
-			lassie.WithBitswapConcurrencyPerRetrieval(bitswapConcurrency),
-		)
+		lassieOpts = append(lassieOpts, lassie.WithBitswapConcurrency(bitswapConcurrency))
+	}
+
+	if bitswapConcurrencyPerRetrieval > 0 {
+		lassieOpts = append(lassieOpts, lassie.WithBitswapConcurrencyPerRetrieval(bitswapConcurrencyPerRetrieval))
+	} else if bitswapConcurrency > 0 {
+		lassieOpts = append(lassieOpts, lassie.WithBitswapConcurrencyPerRetrieval(bitswapConcurrency))
 	}
 
 	return lassie.NewLassieConfig(lassieOpts...), nil

--- a/cmd/lassie/main.go
+++ b/cmd/lassie/main.go
@@ -116,7 +116,13 @@ func buildLassieConfigFromCLIContext(cctx *cli.Context, lassieOpts []lassie.Lass
 	}
 
 	if bitswapConcurrency > 0 {
-		lassieOpts = append(lassieOpts, lassie.WithBitswapConcurrency(bitswapConcurrency))
+		// single retrieval, so we set the bitswap concurrency to the same value
+		// as the bitswap concurrency per retrieval
+		lassieOpts = append(
+			lassieOpts,
+			lassie.WithBitswapConcurrency(bitswapConcurrency),
+			lassie.WithBitswapConcurrencyPerRetrieval(bitswapConcurrency),
+		)
 	}
 
 	return lassie.NewLassieConfig(lassieOpts...), nil

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -263,9 +263,6 @@ func TestHttpFetch(t *testing.T) {
 			name:           "same content, http missing block, bitswap completes",
 			bitswapRemotes: 1,
 			httpRemotes:    1,
-			lassieOpts: func(t *testing.T, mrn *mocknet.MockRetrievalNet) []lassie.LassieOption {
-				return []lassie.LassieOption{lassie.WithProviderTimeout(500 * time.Millisecond)}
-			},
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				file := unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)
 				for _, c := range file.SelfCids {

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -240,7 +240,9 @@ func TestHttpFetch(t *testing.T) {
 			bitswapRemotes:   1,
 			expectUncleanEnd: true,
 			lassieOpts: func(t *testing.T, mrn *mocknet.MockRetrievalNet) []lassie.LassieOption {
-				return []lassie.LassieOption{lassie.WithProviderTimeout(500 * time.Millisecond)}
+				// this delay is going to depend on CI, if it's too short then a slower machine
+				// won't get bitswap setup in time to get the block
+				return []lassie.LassieOption{lassie.WithProviderTimeout(1 * time.Second)}
 			},
 			generate: func(t *testing.T, rndReader io.Reader, remotes []testpeer.TestPeer) []unixfs.DirEntry {
 				file := unixfs.GenerateFile(t, remotes[0].LinkSystem, rndReader, 4<<20)

--- a/pkg/retriever/bitswaphelpers/groupworkpool/groupworkpool.go
+++ b/pkg/retriever/bitswaphelpers/groupworkpool/groupworkpool.go
@@ -1,0 +1,167 @@
+package groupworkpool
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type WorkFunc func()
+
+// GroupWorkPool is a worker pool with a fixed number of workers. The pool
+// executes work in groups. Each group has a fixed maximum number of workers
+// it can use.
+type GroupWorkPool interface {
+	// AddGroup adds a new group to the pool. Cancellation of the provided
+	// context will cause the group to be removed from the pool.
+	AddGroup(context.Context) Group
+	// Start starts the pool. Cancellation of the provided context will cause
+	// the pool to stop.
+	Start(context.Context)
+	// Stop stops the pool. Will have the same effect as cancelling the context
+	// passed to Start.
+	Stop()
+}
+
+// Group is a group of workers that can execute work.
+type Group interface {
+	// Enqueue queues a work function to be executed by the group. It does not
+	// block and the WorkFunc should be assumed to execute in another goroutine.
+	Enqueue(WorkFunc)
+}
+
+type pool struct {
+	ctx             context.Context
+	cancel          context.CancelFunc
+	totalWorkers    int
+	workersPerGroup int
+	lk              sync.Mutex
+	cond            *sync.Cond
+	work            *list.List
+}
+
+type groupWork struct {
+	f     WorkFunc
+	group *group
+}
+
+type group struct {
+	pool   *pool
+	ctx    context.Context
+	lk     sync.Mutex
+	work   *list.List
+	active int
+}
+
+// New creates a new GroupWorkPool with the given number of total workers and
+// total workers per group.
+func New(totalWorkers, workersPerGroup int) GroupWorkPool {
+	pool := &pool{
+		totalWorkers:    totalWorkers,
+		workersPerGroup: workersPerGroup,
+		work:            list.New(),
+	}
+	pool.cond = sync.NewCond(&pool.lk)
+	return pool
+}
+
+func (p *pool) Start(ctx context.Context) {
+	p.ctx, p.cancel = context.WithCancel(ctx)
+	p.lk.Lock()
+	defer p.lk.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < p.totalWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			p.worker()
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		<-p.ctx.Done()
+		p.lk.Lock()
+		p.cond.Broadcast()
+		p.lk.Unlock()
+	}()
+	wg.Wait()
+}
+
+func (p *pool) Stop() {
+	p.cancel()
+}
+
+func (p *pool) worker() {
+	for p.ctx.Err() == nil {
+		// pop work from the pool and execute it
+		p.lk.Lock()
+		next := p.work.Front()
+		if next != nil {
+			p.work.Remove(next)
+			p.lk.Unlock()
+			gw := next.Value.(groupWork)
+			// execute work
+			gw.f()
+			// notify group that work is done
+			gw.group.workDone()
+			continue
+		}
+		if p.ctx.Err() == nil {
+			p.cond.Wait()
+		}
+		p.lk.Unlock()
+	}
+}
+
+func (p *pool) enqueue(gw groupWork) {
+	p.lk.Lock()
+	defer p.lk.Unlock()
+	p.work.PushBack(gw)
+	p.cond.Signal()
+}
+
+func (p *pool) AddGroup(ctx context.Context) Group {
+	return &group{
+		pool: p,
+		ctx:  ctx,
+		work: list.New(),
+	}
+}
+
+func (g *group) Enqueue(f WorkFunc) {
+	g.lk.Lock()
+	defer g.lk.Unlock()
+	g.work.PushBack(f)
+	g.maybePromote()
+}
+
+func (g *group) workDone() {
+	g.lk.Lock()
+	defer g.lk.Unlock()
+	g.active--
+	g.maybePromote()
+}
+
+func (g *group) maybePromote() {
+	// assume we have a lock
+	if g.ctx.Err() != nil {
+		// clear the queue
+		g.work.Init()
+		g.active = 0
+		return
+	}
+	for g.active < g.pool.workersPerGroup {
+		next := g.work.Front()
+		if next == nil {
+			return
+		}
+		g.work.Remove(next)
+		g.active++
+		g.pool.enqueue(groupWork{
+			f:     next.Value.(WorkFunc),
+			group: g,
+		})
+	}
+}

--- a/pkg/retriever/bitswaphelpers/groupworkpool/groupworkpool_test.go
+++ b/pkg/retriever/bitswaphelpers/groupworkpool/groupworkpool_test.go
@@ -1,0 +1,177 @@
+package groupworkpool_test
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/lassie/pkg/retriever/bitswaphelpers/groupworkpool"
+	"github.com/stretchr/testify/require"
+)
+
+type asyncTracker struct {
+	lk             sync.Mutex
+	delay          time.Duration
+	worked         map[int]int
+	groupActive    map[int]int
+	maxGroupActive map[int]int
+	active         int
+	maxActive      int
+}
+
+func newAsyncTracker(delay time.Duration) *asyncTracker {
+	return &asyncTracker{
+		delay:          delay,
+		worked:         make(map[int]int),
+		groupActive:    make(map[int]int),
+		maxGroupActive: make(map[int]int),
+	}
+}
+
+func (a *asyncTracker) work(id int) {
+	a.lk.Lock()
+	a.worked[id]++
+	a.groupActive[id]++
+	if a.groupActive[id] > a.maxGroupActive[id] {
+		a.maxGroupActive[id] = a.groupActive[id]
+	}
+	a.active++
+	if a.active > a.maxActive {
+		a.maxActive = a.active
+	}
+	a.lk.Unlock()
+	time.Sleep(a.delay)
+	a.lk.Lock()
+	a.groupActive[id]--
+	a.active--
+	a.lk.Unlock()
+}
+
+func TestGroupWorkPool(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		groups          int
+		workPerGroup    int
+		workers         int
+		workersPerGroup int
+		workDelay       time.Duration
+	}{
+		{
+			name:            "1 group, 1 worker",
+			groups:          1,
+			workPerGroup:    1,
+			workers:         1,
+			workersPerGroup: 1,
+			workDelay:       0,
+		},
+		{
+			name:            "1 group, 10 workers",
+			groups:          1,
+			workPerGroup:    1,
+			workers:         10,
+			workersPerGroup: 1,
+			workDelay:       0,
+		},
+		{
+			name:            "1 group, 10 workers, 10 work per group",
+			groups:          1,
+			workPerGroup:    10,
+			workers:         10,
+			workersPerGroup: 1,
+			workDelay:       0,
+		},
+		{
+			name:            "1 group, 10 workers, 100 work per group",
+			groups:          1,
+			workPerGroup:    100,
+			workers:         10,
+			workersPerGroup: 1,
+			workDelay:       0,
+		},
+		{
+			name:            "10 groups, 10 workers, 100 work per group",
+			groups:          10,
+			workPerGroup:    100,
+			workers:         10,
+			workersPerGroup: 1,
+			workDelay:       0,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			pool := groupworkpool.New(scenario.workers, scenario.workersPerGroup)
+			pool.Start(context.Background())
+			defer pool.Stop()
+
+			asyncTracker := newAsyncTracker(10 * time.Millisecond)
+
+			var wg sync.WaitGroup
+			for gid := 0; gid < scenario.groups; gid++ {
+				wg.Add(scenario.workPerGroup + 1)
+				go func(gid int) {
+					time.Sleep(time.Duration(rand.Intn(50)) * time.Millisecond) // add a bit of jitter
+					group := pool.AddGroup(context.Background())
+					for i := 0; i < scenario.workPerGroup; i++ {
+						time.Sleep(time.Duration(rand.Intn(2)) * time.Millisecond) // add a bit of jitter
+						group.Enqueue(func() {
+							asyncTracker.work(gid)
+							wg.Done()
+						})
+					}
+					wg.Done()
+				}(gid)
+			}
+
+			wg.Wait()
+
+			for gid := 0; gid <= 10; gid++ {
+				require.True(t, asyncTracker.maxGroupActive[gid] <= scenario.workersPerGroup)
+				require.True(t, asyncTracker.maxActive <= scenario.workers)
+			}
+
+			t.Log("max group active:", asyncTracker.maxGroupActive)
+			t.Log("max total active:", asyncTracker.maxActive)
+		})
+	}
+}
+
+func TestGroupCancellation(t *testing.T) {
+	pool := groupworkpool.New(2, 1)
+	pool.Start(context.Background())
+	defer pool.Stop()
+	asyncTracker := newAsyncTracker(10 * time.Millisecond)
+
+	// 2 groups, 10 work per group, second group is cancelled after first
+	// work item so we should see 10 work items for first group and 1 for
+	// second group
+
+	var wg sync.WaitGroup
+	wg.Add(2)  // one per group setup
+	wg.Add(10) // work for first group
+	wg.Add(1)  // work for second group
+	for gid := 0; gid < 2; gid++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func(gid int, ctx context.Context, cancel context.CancelFunc) {
+			group := pool.AddGroup(ctx)
+			for i := 0; i < 10; i++ {
+				group.Enqueue(func() {
+					asyncTracker.work(gid)
+					if gid == 1 {
+						cancel()
+					}
+					wg.Done()
+				})
+			}
+			wg.Done()
+		}(gid, ctx, cancel)
+	}
+
+	wg.Wait()
+
+	require.Equal(t, 10, asyncTracker.worked[0])
+	require.Equal(t, 1, asyncTracker.worked[1])
+}

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -388,7 +388,7 @@ func TestBitswapRetriever(t *testing.T) {
 					mir := newMockIndexerRouting()
 					mipc := &mockInProgressCids{}
 					awaitReceivedCandidates := make(chan struct{}, 1)
-					bsr := retriever.NewBitswapRetrieverFromDeps(bsrv, mir, mipc, mbs, testCase.cfg, clock, awaitReceivedCandidates)
+					bsr := retriever.NewBitswapRetrieverFromDeps(ctx, bsrv, mir, mipc, mbs, testCase.cfg, clock, awaitReceivedCandidates)
 					receivedEvents := make(map[cid.Cid][]types.RetrievalEvent)
 					retrievalCollector := func(evt types.RetrievalEvent) {
 						receivedEvents[evt.PayloadCid()] = append(receivedEvents[evt.PayloadCid()], evt)


### PR DESCRIPTION
* Removes the per-retrieval preload concurrency handling
* Adds a per-Lassie concurrency pool which has a maximum number of parallel workers and a maximum number of workers _per "group"_; each retrieval is a "group"
* New default total bitswap concurrency is 32
* New default per-retrieval concurrency is 12
