### PR TITLE
fix: send 502 when no indexer candidates

### DIFF
--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -119,7 +119,7 @@ func IpfsHandler(fetcher types.Fetcher, cfg HttpServerConfig) func(http.Response
 			default:
 			}
 			if errors.Is(err, retriever.ErrNoCandidates) {
-				errorResponse(res, statusLogger, http.StatusNotFound, errors.New("no candidates found"))
+				errorResponse(res, statusLogger, http.StatusBadGateway, errors.New("no candidates found"))
 			} else {
 				errorResponse(res, statusLogger, http.StatusGatewayTimeout, fmt.Errorf("failed to fetch CID: %w", err))
 			}

--- a/pkg/server/http/ipfs_test.go
+++ b/pkg/server/http/ipfs_test.go
@@ -151,7 +151,7 @@ func TestIpfsHandler(t *testing.T) {
 			fetchFunc: func(ctx context.Context, r types.RetrievalRequest, cb func(types.RetrievalEvent)) (*types.RetrievalStats, error) {
 				return nil, retriever.ErrNoCandidates
 			},
-			wantStatus: http.StatusNotFound,
+			wantStatus: http.StatusBadGateway,
 			wantBody:   "no candidates found\n",
 		},
 		{


### PR DESCRIPTION
Ref: https://github.com/ipfs/specs/pull/435