### PR TITLE
Build and publish lassie container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.github
+docs
+.goreleaser.yaml
+*.md
+LICENSE-*

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,65 @@
+name: Container
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  workflow_run:
+    workflows: [ Releaser ]
+    types:
+      - completed
+  pull_request:
+
+jobs:
+  prepare-checkout:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    name: Prepare ref
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ github.event_name != 'workflow_run' && github.ref || steps.releaser.outputs.version }}
+    steps:
+      - name: Get Ref from releaser
+        id: releaser
+        if: github.event_name == 'workflow_run'
+        uses: pl-strflt/uci/.github/actions/inspect-releaser@v0.0
+        with:
+          artifacts-url: ${{ github.event.workflow_run.artifacts_url }}
+  build:
+    name: Publish
+    needs: [ prepare-checkout ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prepare_checkout.outputs.ref }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+      - name: Publish
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.20-bullseye as build
+
+WORKDIR /go/src/lassie
+
+COPY go.* .
+RUN go mod download
+COPY . .
+
+RUN go build -o /go/bin/lassie ./cmd/lassie
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /go/bin/lassie /usr/bin/
+
+ENTRYPOINT ["/usr/bin/lassie"]


### PR DESCRIPTION
Define Dockerfile to containerise Lassie binary in a minimal image.

Add CI job to build the container on PRs and publish a tagged version of it on:
 * merge to main.
 * github tags of `v*`.
 * successful run of unified CI releaser.