### PR TITLE
Disable CGO in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.* .
 RUN go mod download
 COPY . .
 
-RUN go build -o /go/bin/lassie ./cmd/lassie
+RUN CGO_ENABLED=0 go build -o /go/bin/lassie ./cmd/lassie
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /go/bin/lassie /usr/bin/


### PR DESCRIPTION
Now that we use static debian image as base, and the fact that lassie does not require CGO, disable CGO for faster build and smaller images.