### PR TITLE
chore: big refactor of TestHttpFetch, add basic aggregateevent testing

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -1,5 +1,5 @@
 name: extend-tests-timeout
-description: add -timeout 10m flag to GOFLAGS to extend timeout for tests
+description: add -timeout 20m flag to GOFLAGS to extend timeout for tests
 
 runs:
   using: "composite"
@@ -7,4 +7,4 @@ runs:
     - name: Extend timeout for tests
       shell: bash
       run: |
-        echo "GOFLAGS=$GOFLAGS -timeout=10m" >> $GITHUB_ENV
+        echo "GOFLAGS=$GOFLAGS -timeout=20m" >> $GITHUB_ENV

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -128,6 +128,7 @@ func (a *aggregateEventRecorder) ingestEvents() {
 	for {
 		select {
 		case <-a.ctx.Done():
+			return
 
 		// Read incoming data
 		case event := <-a.ingestChan:
@@ -297,6 +298,7 @@ func (a *aggregateEventRecorder) postEvents() {
 		select {
 		case <-a.ctx.Done():
 			return
+
 		case batchedData := <-a.postChan:
 			byts, err := json.Marshal(batchedEvents{batchedData})
 			if err != nil {

--- a/pkg/internal/itest/e2e_test.go
+++ b/pkg/internal/itest/e2e_test.go
@@ -27,6 +27,9 @@ func TestTrustlessGatewayE2E(t *testing.T) {
 	if os.Getenv("CI") != "" && runtime.GOOS == "windows" {
 		t.Skip("skipping on windows in CI")
 	}
+	if os.Getenv("SKIP_E2E") != "" {
+		t.Skip("skipping e2e tests")
+	}
 
 	req := require.New(t)
 

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -1025,6 +1025,11 @@ func verifyHeaders(t *testing.T, resp response, root cid.Cid, path string, expec
 	req.Equal("public, max-age=29030400, immutable", resp.Header.Get("Cache-Control"))
 	req.Equal(trustlesshttp.DefaultContentType().WithDuplicates(!expectNoDups).String(), resp.Header.Get("Content-Type"))
 	req.Equal("nosniff", resp.Header.Get("X-Content-Type-Options"))
+	st := resp.Header.Get("Server-Timing")
+	req.Contains(st, "started-finding-candidates")
+	req.Contains(st, "candidates-found=")
+	req.Contains(st, "retrieval-")
+	req.Contains(st, "dur=") // at lest one of these
 	etagStart := fmt.Sprintf(`"%s.car.`, root.String())
 	etagGot := resp.Header.Get("ETag")
 	req.True(strings.HasPrefix(etagGot, etagStart), "ETag should start with [%s], got [%s]", etagStart, etagGot)

--- a/pkg/internal/itest/http_fetch_test.go
+++ b/pkg/internal/itest/http_fetch_test.go
@@ -606,6 +606,7 @@ func TestHttpFetch(t *testing.T) {
 				lsys := cidlink.DefaultLinkSystem()
 				lsys.SetReadStorage(store)
 				lsys.SetWriteStorage(store)
+				lsys.TrustedStorage = true
 				_, err := traversal.Config{
 					Root:               srcData.Root,
 					Selector:           selectorparse.CommonSelector_ExploreAllRecursively,
@@ -645,6 +646,7 @@ func TestHttpFetch(t *testing.T) {
 				lsys := cidlink.DefaultLinkSystem()
 				lsys.SetReadStorage(store)
 				lsys.SetWriteStorage(store)
+				lsys.TrustedStorage = true
 				_, err := traversal.Config{
 					Root:               srcData.Root,
 					Selector:           selectorparse.CommonSelector_ExploreAllRecursively,
@@ -701,6 +703,7 @@ func TestHttpFetch(t *testing.T) {
 				lsys := cidlink.DefaultLinkSystem()
 				lsys.SetReadStorage(store)
 				lsys.SetWriteStorage(store)
+				lsys.TrustedStorage = true
 				_, err := traversal.Config{
 					Root:               srcData.Root,
 					Selector:           selectorparse.CommonSelector_ExploreAllRecursively,

--- a/pkg/net/client/client_test.go
+++ b/pkg/net/client/client_test.go
@@ -36,6 +36,7 @@ func TestClient(t *testing.T) {
 	}
 	p := peer.ID("testpeer")
 	linkSys := cidlink.DefaultLinkSystem()
+	linkSys.TrustedStorage = true
 	gotLoadFor := cid.Undef
 	linkSys.StorageReadOpener = func(linkCtx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
 		gotLoadFor = lnk.(cidlink.Link).Cid
@@ -89,6 +90,7 @@ func TestClient_BadSelector(t *testing.T) {
 	}
 	p := peer.ID("testpeer")
 	linkSys := cidlink.DefaultLinkSystem()
+	linkSys.TrustedStorage = true
 	selector := basicnode.NewFloat(100.2)
 	proposal := &retrievaltypes.DealProposal{
 		PayloadCID: cid.MustParse("bafyreibdoxfay27gf4ye3t5a7aa5h4z2azw7hhhz36qrbf5qleldj76qfa"),

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -40,6 +40,7 @@ func TestBitswapRetriever(t *testing.T) {
 	lsys := cidlink.DefaultLinkSystem()
 	lsys.SetReadStorage(store)
 	lsys.SetWriteStorage(store)
+	lsys.TrustedStorage = true
 	tbc1 := gstestutil.SetupBlockChain(ctx, t, lsys, 1000, 100)
 	tbc2 := gstestutil.SetupBlockChain(ctx, t, lsys, 1000, 100)
 	var tbc1Cids []cid.Cid
@@ -599,6 +600,7 @@ func makeLsys(blocks []blocks.Block, threadsafe bool) *linking.LinkSystem {
 	}
 	lsys.SetReadStorage(store)
 	lsys.SetWriteStorage(store)
+	lsys.TrustedStorage = true
 	return &lsys
 }
 

--- a/pkg/retriever/httpretriever_test.go
+++ b/pkg/retriever/httpretriever_test.go
@@ -45,6 +45,7 @@ func TestHTTPRetriever(t *testing.T) {
 	lsys := cidlink.DefaultLinkSystem()
 	lsys.SetReadStorage(store)
 	lsys.SetWriteStorage(store)
+	lsys.TrustedStorage = true
 	tbc1 := gstestutil.SetupBlockChain(ctx, t, lsys, 1000, 100)
 	tbc2 := gstestutil.SetupBlockChain(ctx, t, lsys, 1000, 100)
 	var tbc1Cids []cid.Cid

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -102,7 +102,7 @@ func IpfsHandler(fetcher types.Fetcher, cfg HttpServerConfig) func(http.Response
 			"maxBlocks", request.MaxBlocks,
 		)
 
-		stats, err := fetcher.Fetch(req.Context(), request, servertimingsSubscriber(req))
+		stats, err := fetcher.Fetch(req.Context(), request, servertimingsSubscriber(req, bytesWritten))
 
 		// force all blocks to flush
 		if cerr := carWriter.Close(); cerr != nil && !errors.Is(cerr, context.Canceled) {


### PR DESCRIPTION
Builds on #345 but is separate because this is a major refactor of `TestHttpFetch`, mainly just moving things around to make it slightly more readable.

Also adds some basic aggregateevent testing into the integration test so we can start to assert it reports things that we expect.