### PR TITLE
chore: skip e2e test when not in CI

### DIFF
--- a/pkg/internal/itest/e2e_test.go
+++ b/pkg/internal/itest/e2e_test.go
@@ -23,12 +23,15 @@ import (
 )
 
 func TestTrustlessGatewayE2E(t *testing.T) {
-	// skip if windows, just too slow in CI, maybe revisit this later
-	if os.Getenv("CI") != "" && runtime.GOOS == "windows" {
-		t.Skip("skipping on windows in CI")
-	}
-	if os.Getenv("SKIP_E2E") != "" {
-		t.Skip("skipping e2e tests")
+	switch os.Getenv("CI") {
+	case "":
+		// skip when not running in a CI environment
+		t.Skip("skipping when not in CI environment")
+	default:
+		if runtime.GOOS == "windows" {
+			// skip if windows, just too slow in CI, maybe revisit this later
+			t.Skip("skipping on windows in CI")
+		} // else in CI and we're good to go
 	}
 
 	req := require.New(t)

--- a/pkg/internal/itest/trustless_fetch_test.go
+++ b/pkg/internal/itest/trustless_fetch_test.go
@@ -76,6 +76,7 @@ func TestTrustlessUnixfsFetch(t *testing.T) {
 				go func() {
 					serverError <- httpServer.Start()
 				}()
+				defer httpServer.Close()
 				responseChan := make(chan *http.Response, 1)
 				go func() {
 					// Make a request for our CID and read the complete CAR bytes

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -98,11 +98,10 @@ func (s *HttpServer) Start() error {
 		logger.Errorw("failed to start http server", "err", err)
 		return err
 	}
-
 	return nil
 }
 
-// Close shutsdown the server and cancels the server context
+// Close shuts down the server and cancels the server context
 func (s *HttpServer) Close() error {
 	logger.Info("closing http server")
 	s.cancel()


### PR DESCRIPTION
already sick of this, it takes ~20 seconds to run locally when the packages are cache-ready and a pass result doesn't get cached between test runs.