### PR TITLE
fix: measure "connect time" per-peer for peer scoring

### DIFF
--- a/pkg/retriever/graphsyncretriever.go
+++ b/pkg/retriever/graphsyncretriever.go
@@ -115,7 +115,8 @@ func graphsyncMetadataCompare(a, b *metadata.GraphsyncFilecoinV1, defaultValue b
 	return defaultValue
 }
 
-func (pg *ProtocolGraphsync) Connect(ctx context.Context, retrieval *retrieval, startTime time.Time, candidate types.RetrievalCandidate) (time.Duration, error) {
+func (pg *ProtocolGraphsync) Connect(ctx context.Context, retrieval *retrieval, candidate types.RetrievalCandidate) (time.Duration, error) {
+	startTime := pg.Clock.Now()
 	if err := pg.Client.Connect(ctx, candidate.MinerPeer); err != nil {
 		return 0, err
 	}

--- a/pkg/retriever/httpretriever.go
+++ b/pkg/retriever/httpretriever.go
@@ -80,7 +80,7 @@ func (ph ProtocolHttp) GetMergedMetadata(cid cid.Cid, currentMetadata, newMetada
 	return &metadata.IpfsGatewayHttp{}
 }
 
-func (ph *ProtocolHttp) Connect(ctx context.Context, retrieval *retrieval, startTime time.Time, candidate types.RetrievalCandidate) (time.Duration, error) {
+func (ph *ProtocolHttp) Connect(ctx context.Context, retrieval *retrieval, candidate types.RetrievalCandidate) (time.Duration, error) {
 	// We could begin the request here by moving ph.beginRequest() to this function.
 	// That would result in parallel connections to candidates as they are received,
 	// then serial reading of bodies.


### PR DESCRIPTION
Prior to this, the "start" is the same for all peers, regardless of whether they come in from the indexer at different times; this makes it strictly local to the peer so we can score it accordingly.

I don't _think_ this should make a material difference if we're getting the graphsync and http peers in an initial batch from the indexer. The current start-time calculation begins from before we even get candidates back, but they are all the same start. The actual value for this only matters for scoring candidates so mostly it's the relative value that matters. What we intended for this, however, was that if this number is `0` or close to it, it means we're already connected to the peer so we should try them first.

`TransportProtocol` is a public interface so this would technically be a breaking change.