### PR TITLE
fix: prefix path with '/' for cli "Fetching bafy.../path"

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -244,10 +244,14 @@ func defaultFetchRun(
 		setupLassieEventRecorder(ctx, eventRecorderCfg, lassie)
 	}
 
+	printPath := path
+	if printPath != "" {
+		printPath = "/" + printPath
+	}
 	if len(fetchProviderAddrInfos) == 0 {
-		fmt.Fprintf(msgWriter, "Fetching %s", rootCid.String()+path)
+		fmt.Fprintf(msgWriter, "Fetching %s", rootCid.String()+printPath)
 	} else {
-		fmt.Fprintf(msgWriter, "Fetching %s from specified provider(s)", rootCid.String()+path)
+		fmt.Fprintf(msgWriter, "Fetching %s from specified provider(s)", rootCid.String()+printPath)
 	}
 	if progress {
 		fmt.Fprintln(msgWriter)


### PR DESCRIPTION
A legacy of switching to go-ipld-prime's datamodel.Path is that it doesn't prefix with '/' and this is one of the places we made the assumption it would come prefixed.