### PR TITLE
chore!: rename "payload" CID to "root" CID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 	* [HTTP API](#http-api)
 		* [Daemon Example](#daemon-example)
 	* [Golang Library](#golang-library)
+	* [Roots, pieces and payloads](#roots-pieces-and-payloads)
 * [Contribute](#contribute)
 * [License](#license)
 
@@ -276,6 +277,12 @@ if err != nil {
 ```
 
 The `Fetch` function takes a `context.Context`, a `*types.Request`, and a `*types.FetchOptions`. The `context.Context` is used to control the lifecycle of the fetch. The `*types.Request` is the fetch request we made above. The `*types.FetchOptions` is used to control the behavior of the fetch. The function returns a `*types.FetchStats` and an `error`. The `*types.FetchStats` is the fetch stats. The `error` is used to indicate if there was an error fetching the CID.
+
+### Roots, pieces and payloads
+
+Lassie uses the term **Root** to refer to the head block of a potential graph (DAG) of IPLD blocks. This is typically the block you request, using its CID, when you perform a _fetch_ with Lassie. Of course a root could also be a sub-root of a larger graph, but when performing a retrieval with Lassie, you are focusing on the graph underneath the block you are fetching, and considerations of larger DAGs are not relevant.
+
+In the Filecoin ecosystem, there exists terminology related to "pieces" and "payloads" and there may be confusion between the way lassie uses the term "root CID" and some of the language used in Filecoin. A **Piece** is a Filecoin storage deal unit, typically containing user data organized into a CAR; then padded to size to form a portion of a Filecoin sector. Filecoin pieces have their own CIDs, and it is possible to retrieve a whole, raw piece, from Filecoin. This can lead to terminology such as "piece root CID". Lassie currently does not perform whole-piece retrievals, and is not intended to be able to handle piece CIDs. Additionally, in Filecoin the term **Payload** is sometimes used in reference to the IPLD data inside a piece when performing a storage or retrieval deal. This is closer to the way Lassie uses the term **Root** and historical Lassie code contains some references to "payloads" that are actually referring to the root CID of a graph.
 
 ## Contribute
 

--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -217,7 +217,7 @@ type progressPrinter struct {
 func (pp *progressPrinter) subscriber(event types.RetrievalEvent) {
 	switch ret := event.(type) {
 	case events.StartedFindingCandidatesEvent:
-		fmt.Fprintf(pp.writer, "\rQuerying indexer for %s...\n", ret.PayloadCid())
+		fmt.Fprintf(pp.writer, "\rQuerying indexer for %s...\n", ret.RootCid())
 	case events.StartedRetrievalEvent:
 		fmt.Fprintf(pp.writer, "\rRetrieving from [%s] (%s)...\n", events.Identifier(ret), ret.Code())
 	case events.ConnectedToProviderEvent:

--- a/pkg/aggregateeventrecorder/aggregateeventrecorder.go
+++ b/pkg/aggregateeventrecorder/aggregateeventrecorder.go
@@ -145,7 +145,7 @@ func (a *aggregateEventRecorder) ingestEvents() {
 					candidatesFiltered:       0,
 					firstByteTime:            time.Time{},
 					spId:                     "",
-					rootCid:                  startedEvent.PayloadCid().String(),
+					rootCid:                  startedEvent.RootCid().String(),
 					urlPath:                  startedEvent.UrlPath(),
 					success:                  false,
 					bandwidth:                0,

--- a/pkg/events/base.go
+++ b/pkg/events/base.go
@@ -12,12 +12,12 @@ import (
 type retrievalEvent struct {
 	eventTime   time.Time
 	retrievalId types.RetrievalID
-	payloadCid  cid.Cid
+	rootCid     cid.Cid
 }
 
 func (r retrievalEvent) Time() time.Time                { return r.eventTime }
 func (r retrievalEvent) RetrievalId() types.RetrievalID { return r.retrievalId }
-func (r retrievalEvent) PayloadCid() cid.Cid            { return r.payloadCid }
+func (r retrievalEvent) RootCid() cid.Cid               { return r.rootCid }
 
 type providerRetrievalEvent struct {
 	retrievalEvent

--- a/pkg/events/blockreceived.go
+++ b/pkg/events/blockreceived.go
@@ -25,7 +25,7 @@ func (e BlockReceivedEvent) Code() types.EventCode     { return types.BlockRecei
 func (e BlockReceivedEvent) ByteCount() uint64         { return e.byteCount }
 func (e BlockReceivedEvent) Protocol() multicodec.Code { return e.protocol }
 func (e BlockReceivedEvent) String() string {
-	return fmt.Sprintf("BlockReceivedEvent<%s, %s, %s, %s, %s, %d>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.protocol, e.byteCount)
+	return fmt.Sprintf("BlockReceivedEvent<%s, %s, %s, %s, %s, %d>", e.eventTime, e.retrievalId, e.rootCid, e.providerId, e.protocol, e.byteCount)
 }
 
 func BlockReceived(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code, byteCount uint64) BlockReceivedEvent {

--- a/pkg/events/candidatesfiltered.go
+++ b/pkg/events/candidatesfiltered.go
@@ -25,11 +25,11 @@ func (e CandidatesFilteredEvent) Code() types.EventCode                  { retur
 func (e CandidatesFilteredEvent) Candidates() []types.RetrievalCandidate { return e.candidates }
 func (e CandidatesFilteredEvent) Protocols() []multicodec.Code           { return e.protocols }
 func (e CandidatesFilteredEvent) String() string {
-	return fmt.Sprintf("CandidatesFilteredEvent<%s, %s, %s, %d>", e.eventTime, e.retrievalId, e.payloadCid, len(e.candidates))
+	return fmt.Sprintf("CandidatesFilteredEvent<%s, %s, %s, %d>", e.eventTime, e.retrievalId, e.rootCid, len(e.candidates))
 }
 
-func CandidatesFiltered(at time.Time, retrievalId types.RetrievalID, payloadCid cid.Cid, candidates []types.RetrievalCandidate) CandidatesFilteredEvent {
+func CandidatesFiltered(at time.Time, retrievalId types.RetrievalID, rootCid cid.Cid, candidates []types.RetrievalCandidate) CandidatesFilteredEvent {
 	c := make([]types.RetrievalCandidate, len(candidates))
 	copy(c, candidates)
-	return CandidatesFilteredEvent{retrievalEvent{at, retrievalId, payloadCid}, c, collectProtocols(c)}
+	return CandidatesFilteredEvent{retrievalEvent{at, retrievalId, rootCid}, c, collectProtocols(c)}
 }

--- a/pkg/events/candidatesfound.go
+++ b/pkg/events/candidatesfound.go
@@ -21,11 +21,11 @@ type CandidatesFoundEvent struct {
 func (e CandidatesFoundEvent) Code() types.EventCode                  { return types.CandidatesFoundCode }
 func (e CandidatesFoundEvent) Candidates() []types.RetrievalCandidate { return e.candidates }
 func (e CandidatesFoundEvent) String() string {
-	return fmt.Sprintf("CandidatesFoundEvent<%s, %s, %s, %d>", e.eventTime, e.retrievalId, e.payloadCid, len(e.candidates))
+	return fmt.Sprintf("CandidatesFoundEvent<%s, %s, %s, %d>", e.eventTime, e.retrievalId, e.rootCid, len(e.candidates))
 }
 
-func CandidatesFound(at time.Time, retrievalId types.RetrievalID, payloadCid cid.Cid, candidates []types.RetrievalCandidate) CandidatesFoundEvent {
+func CandidatesFound(at time.Time, retrievalId types.RetrievalID, rootCid cid.Cid, candidates []types.RetrievalCandidate) CandidatesFoundEvent {
 	c := make([]types.RetrievalCandidate, len(candidates))
 	copy(c, candidates)
-	return CandidatesFoundEvent{retrievalEvent{at, retrievalId, payloadCid}, c}
+	return CandidatesFoundEvent{retrievalEvent{at, retrievalId, rootCid}, c}
 }

--- a/pkg/events/connectedtoprovider.go
+++ b/pkg/events/connectedtoprovider.go
@@ -21,7 +21,7 @@ type ConnectedToProviderEvent struct {
 func (e ConnectedToProviderEvent) Code() types.EventCode     { return types.ConnectedToProviderCode }
 func (e ConnectedToProviderEvent) Protocol() multicodec.Code { return e.protocol }
 func (e ConnectedToProviderEvent) String() string {
-	return fmt.Sprintf("ConnectedToProviderEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+	return fmt.Sprintf("ConnectedToProviderEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid, e.providerId)
 }
 
 func ConnectedToProvider(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code) ConnectedToProviderEvent {

--- a/pkg/events/failed.go
+++ b/pkg/events/failed.go
@@ -20,7 +20,7 @@ type FailedEvent struct {
 func (e FailedEvent) Code() types.EventCode { return types.FailedCode }
 func (e FailedEvent) ErrorMessage() string  { return e.errorMessage }
 func (e FailedEvent) String() string {
-	return fmt.Sprintf("FailedEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.payloadCid, e.errorMessage)
+	return fmt.Sprintf("FailedEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.rootCid, e.errorMessage)
 }
 
 func Failed(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, errorMessage string) FailedEvent {

--- a/pkg/events/failedretrieval.go
+++ b/pkg/events/failedretrieval.go
@@ -24,7 +24,7 @@ func (e FailedRetrievalEvent) Code() types.EventCode     { return types.FailedRe
 func (e FailedRetrievalEvent) ErrorMessage() string      { return e.errorMessage }
 func (e FailedRetrievalEvent) Protocol() multicodec.Code { return e.protocol }
 func (e FailedRetrievalEvent) String() string {
-	return fmt.Sprintf("FailedRetrievalEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.payloadCid, e.errorMessage)
+	return fmt.Sprintf("FailedRetrievalEvent<%s, %s, %s, %v>", e.eventTime, e.retrievalId, e.rootCid, e.errorMessage)
 }
 
 func FailedRetrieval(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code, errorMessage string) FailedRetrievalEvent {

--- a/pkg/events/finished.go
+++ b/pkg/events/finished.go
@@ -18,7 +18,7 @@ type FinishedEvent struct {
 
 func (e FinishedEvent) Code() types.EventCode { return types.FinishedCode }
 func (e FinishedEvent) String() string {
-	return fmt.Sprintf("FinishedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+	return fmt.Sprintf("FinishedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid, e.providerId)
 }
 
 func Finished(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) FinishedEvent {

--- a/pkg/events/firstbyte.go
+++ b/pkg/events/firstbyte.go
@@ -24,7 +24,7 @@ func (e FirstByteEvent) Code() types.EventCode     { return types.FirstByteCode 
 func (e FirstByteEvent) Duration() time.Duration   { return e.duration }
 func (e FirstByteEvent) Protocol() multicodec.Code { return e.protocol }
 func (e FirstByteEvent) String() string {
-	return fmt.Sprintf("FirstByteEvent<%s, %s, %s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.duration.String(), e.protocol.String())
+	return fmt.Sprintf("FirstByteEvent<%s, %s, %s, %s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid, e.providerId, e.duration.String(), e.protocol.String())
 }
 
 func FirstByte(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, duration time.Duration, protocol multicodec.Code) FirstByteEvent {

--- a/pkg/events/graphsyncaccepted.go
+++ b/pkg/events/graphsyncaccepted.go
@@ -22,7 +22,7 @@ func (e GraphsyncAcceptedEvent) Protocol() multicodec.Code {
 	return multicodec.TransportGraphsyncFilecoinv1
 }
 func (e GraphsyncAcceptedEvent) String() string {
-	return fmt.Sprintf("GraphsyncAcceptedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+	return fmt.Sprintf("GraphsyncAcceptedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid, e.providerId)
 }
 
 func Accepted(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) GraphsyncAcceptedEvent {

--- a/pkg/events/graphsyncproposed.go
+++ b/pkg/events/graphsyncproposed.go
@@ -22,7 +22,7 @@ func (e GraphsyncProposedEvent) Protocol() multicodec.Code {
 	return multicodec.TransportGraphsyncFilecoinv1
 }
 func (e GraphsyncProposedEvent) String() string {
-	return fmt.Sprintf("GraphsyncProposedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId)
+	return fmt.Sprintf("GraphsyncProposedEvent<%s, %s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid, e.providerId)
 }
 
 func Proposed(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate) GraphsyncProposedEvent {

--- a/pkg/events/manager_test.go
+++ b/pkg/events/manager_test.go
@@ -81,7 +81,7 @@ func TestEventManager(t *testing.T) {
 	verifyIndexerStarted := func(event types.RetrievalEvent) {
 		require.IsType(t, events.StartedFindingCandidatesEvent{}, event)
 		require.Equal(t, id, event.RetrievalId())
-		require.Equal(t, cid, event.PayloadCid())
+		require.Equal(t, cid, event.RootCid())
 		require.Equal(t, types.StartedFindingCandidatesCode, event.Code())
 	}
 	verifyEvent(gotEvents1, types.StartedFindingCandidatesCode, verifyIndexerStarted)
@@ -90,7 +90,7 @@ func TestEventManager(t *testing.T) {
 	verifyIndexerCandidatesFound := func(event types.RetrievalEvent) {
 		require.IsType(t, events.CandidatesFoundEvent{}, event)
 		require.Equal(t, id, event.RetrievalId())
-		require.Equal(t, cid, event.PayloadCid())
+		require.Equal(t, cid, event.RootCid())
 		require.Equal(t, types.CandidatesFoundCode, event.Code())
 		storageProviderIds := event.(events.CandidatesFoundEvent).Candidates()
 		require.Len(t, storageProviderIds, 3)
@@ -104,7 +104,7 @@ func TestEventManager(t *testing.T) {
 	verifyIndexerCandidatesFiltered := func(event types.RetrievalEvent) {
 		require.IsType(t, events.CandidatesFilteredEvent{}, event)
 		require.Equal(t, id, event.RetrievalId())
-		require.Equal(t, cid, event.PayloadCid())
+		require.Equal(t, cid, event.RootCid())
 		require.Equal(t, types.CandidatesFilteredCode, event.Code())
 		storageProviderIds := event.(events.CandidatesFilteredEvent).Candidates()
 		require.Len(t, storageProviderIds, 3)
@@ -118,7 +118,7 @@ func TestEventManager(t *testing.T) {
 	verifyRetrievalStarted := func(event types.RetrievalEvent) {
 		require.IsType(t, events.StartedRetrievalEvent{}, event)
 		require.Equal(t, id, event.RetrievalId())
-		require.Equal(t, cid, event.PayloadCid())
+		require.Equal(t, cid, event.RootCid())
 		require.Equal(t, types.StartedRetrievalCode, event.Code())
 		require.Equal(t, peerB, event.(events.StartedRetrievalEvent).ProviderId())
 	}
@@ -128,7 +128,7 @@ func TestEventManager(t *testing.T) {
 	verifyRetrievalSuccess := func(event types.RetrievalEvent) {
 		require.IsType(t, events.SucceededEvent{}, event)
 		require.Equal(t, id, event.RetrievalId())
-		require.Equal(t, cid, event.PayloadCid())
+		require.Equal(t, cid, event.RootCid())
 
 		successEvent := event.(events.SucceededEvent)
 		require.Equal(t, peerB, successEvent.ProviderId())
@@ -141,7 +141,7 @@ func TestEventManager(t *testing.T) {
 	verifyRetrievalFailure := func(event types.RetrievalEvent) {
 		require.IsType(t, events.FailedRetrievalEvent{}, event)
 		require.Equal(t, id, event.RetrievalId())
-		require.Equal(t, cid, event.PayloadCid())
+		require.Equal(t, cid, event.RootCid())
 
 		failedEvent := event.(events.FailedRetrievalEvent)
 		require.Equal(t, peerB, failedEvent.ProviderId())

--- a/pkg/events/startedfetch.go
+++ b/pkg/events/startedfetch.go
@@ -25,7 +25,7 @@ func (e StartedFetchEvent) Code() types.EventCode        { return types.StartedF
 func (e StartedFetchEvent) UrlPath() string              { return e.urlPath }
 func (e StartedFetchEvent) Protocols() []multicodec.Code { return e.supportedProtocols }
 func (e StartedFetchEvent) String() string {
-	return fmt.Sprintf("StartedFetchEvent<%s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid)
+	return fmt.Sprintf("StartedFetchEvent<%s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid)
 }
 
 func StartedFetch(at time.Time, retrievalId types.RetrievalID, rootCid cid.Cid, urlPath string, supportedProtocols ...multicodec.Code) StartedFetchEvent {

--- a/pkg/events/startedfindingcandidates.go
+++ b/pkg/events/startedfindingcandidates.go
@@ -19,9 +19,9 @@ func (e StartedFindingCandidatesEvent) Code() types.EventCode {
 	return types.StartedFindingCandidatesCode
 }
 func (e StartedFindingCandidatesEvent) String() string {
-	return fmt.Sprintf("StartedFindingCandidatesEvent<%s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid)
+	return fmt.Sprintf("StartedFindingCandidatesEvent<%s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid)
 }
 
-func StartedFindingCandidates(at time.Time, retrievalId types.RetrievalID, payloadCid cid.Cid) StartedFindingCandidatesEvent {
-	return StartedFindingCandidatesEvent{retrievalEvent{at, retrievalId, payloadCid}}
+func StartedFindingCandidates(at time.Time, retrievalId types.RetrievalID, rootCid cid.Cid) StartedFindingCandidatesEvent {
+	return StartedFindingCandidatesEvent{retrievalEvent{at, retrievalId, rootCid}}
 }

--- a/pkg/events/startedretrieval.go
+++ b/pkg/events/startedretrieval.go
@@ -23,7 +23,7 @@ type StartedRetrievalEvent struct {
 func (e StartedRetrievalEvent) Code() types.EventCode     { return types.StartedRetrievalCode }
 func (e StartedRetrievalEvent) Protocol() multicodec.Code { return e.protocol }
 func (e StartedRetrievalEvent) String() string {
-	return fmt.Sprintf("StartedRetrievalEvent<%s, %s, %s, %s, %s>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.protocol)
+	return fmt.Sprintf("StartedRetrievalEvent<%s, %s, %s, %s, %s>", e.eventTime, e.retrievalId, e.rootCid, e.providerId, e.protocol)
 }
 
 func StartedRetrieval(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, protocol multicodec.Code) StartedRetrievalEvent {

--- a/pkg/events/succeeded.go
+++ b/pkg/events/succeeded.go
@@ -28,7 +28,7 @@ func (e SucceededEvent) ReceivedCidsCount() uint64 { return e.receivedCidsCount 
 func (e SucceededEvent) Duration() time.Duration   { return e.duration }
 func (e SucceededEvent) Protocol() multicodec.Code { return e.protocol }
 func (e SucceededEvent) String() string {
-	return fmt.Sprintf("SucceededEvent<%s, %s, %s, %s, { %d, %d, %s, %s }>", e.eventTime, e.retrievalId, e.payloadCid, e.providerId, e.receivedBytesSize, e.receivedCidsCount, e.protocol, e.duration)
+	return fmt.Sprintf("SucceededEvent<%s, %s, %s, %s, { %d, %d, %s, %s }>", e.eventTime, e.retrievalId, e.rootCid, e.providerId, e.receivedBytesSize, e.receivedCidsCount, e.protocol, e.duration)
 }
 
 func Success(at time.Time, retrievalId types.RetrievalID, candidate types.RetrievalCandidate, receivedBytesSize uint64, receivedCidsCount uint64, duration time.Duration, protocol multicodec.Code) SucceededEvent {

--- a/pkg/internal/testutil/collectingeventlsubscriber.go
+++ b/pkg/internal/testutil/collectingeventlsubscriber.go
@@ -99,7 +99,7 @@ func VerifyContainsCollectedEvent(t *testing.T, afterStart time.Duration, expect
 func VerifyCollectedEvent(t *testing.T, actual types.RetrievalEvent, expected types.RetrievalEvent) {
 	require.Equal(t, expected.Code(), actual.Code(), "event code")
 	require.Equal(t, expected.RetrievalId(), actual.RetrievalId(), fmt.Sprintf("retrieval id for %s", expected.Code()))
-	require.Equal(t, expected.PayloadCid(), actual.PayloadCid(), fmt.Sprintf("cid for %s", expected.Code()))
+	require.Equal(t, expected.RootCid(), actual.RootCid(), fmt.Sprintf("cid for %s", expected.Code()))
 	require.Equal(t, expected.Time(), actual.Time(), fmt.Sprintf("time for %s", expected.Code()))
 
 	if asp, ok := actual.(events.EventWithProviderID); ok {

--- a/pkg/retriever/assignablecandidatefinder_test.go
+++ b/pkg/retriever/assignablecandidatefinder_test.go
@@ -174,7 +174,7 @@ func TestAssignableCandidateFinder(t *testing.T) {
 			}
 			receivedEvents := make(map[cid.Cid][]types.RetrievalEvent)
 			retrievalCollector := func(evt types.RetrievalEvent) {
-				receivedEvents[evt.PayloadCid()] = append(receivedEvents[evt.PayloadCid()], evt)
+				receivedEvents[evt.RootCid()] = append(receivedEvents[evt.RootCid()], evt)
 			}
 			retrievalCandidateFinder := retriever.NewAssignableCandidateFinder(candidateFinder, isAcceptableStorageProvider)
 			rid1, err := types.NewRetrievalID()

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -393,7 +393,7 @@ func TestBitswapRetriever(t *testing.T) {
 					bsr := retriever.NewBitswapRetrieverFromDeps(ctx, bsrv, mir, mipc, mbs, testCase.cfg, clock, awaitReceivedCandidates)
 					receivedEvents := make(map[cid.Cid][]types.RetrievalEvent)
 					retrievalCollector := func(evt types.RetrievalEvent) {
-						receivedEvents[evt.PayloadCid()] = append(receivedEvents[evt.PayloadCid()], evt)
+						receivedEvents[evt.RootCid()] = append(receivedEvents[evt.RootCid()], evt)
 					}
 
 					// retrieve

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -237,7 +237,7 @@ func handleFailureEvent(
 	logger.Warnf(
 		"Failed to retrieve from miner %s for %s: %s",
 		event.ProviderId(),
-		event.PayloadCid(),
+		event.RootCid(),
 		event.ErrorMessage(),
 	)
 }
@@ -274,7 +274,7 @@ func logEvent(event types.RetrievalEvent) {
 		}
 	}
 	logadd("code", event.Code(),
-		"payloadCid", event.PayloadCid(),
+		"rootCid", event.RootCid(),
 		"storageProviderId", events.Identifier(event))
 	switch tevent := event.(type) {
 	case events.EventWithCandidates:

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -80,8 +80,13 @@ type RetrievalRequest struct {
 	FixedPeers []peer.AddrInfo
 }
 
-// NewRequestForPath creates a new RetrievalRequest from the provided parameters
-// and assigns a new RetrievalID to it.
+// NewRequestForPath creates a new RetrievalRequest for the given root CID as
+// the head of the graph to fetch, the path within that graph to fetch, the
+// scope that dictates the depth of fetching withint he graph and the byte
+// range to fetch if intending to fetch part of a large UnixFS file.
+//
+// The byteRange parameter should be left nil if this is not a request for a
+// partial UnixFS file; and if it is set, the dagScope should be DagScopeEntity.
 //
 // The LinkSystem is configured to use the provided store for both reading
 // and writing and it is explicitly set to be trusted (i.e. it will not
@@ -89,7 +94,7 @@ type RetrievalRequest struct {
 // request.LinkSystem.TrustedStore should be set to false after this call.
 func NewRequestForPath(
 	store ipldstorage.WritableStorage,
-	cid cid.Cid,
+	rootCid cid.Cid,
 	path string,
 	dagScope trustlessutils.DagScope,
 	byteRange *trustlessutils.ByteRange,
@@ -110,7 +115,7 @@ func NewRequestForPath(
 
 	return RetrievalRequest{
 		Request: trustlessutils.Request{
-			Root:       cid,
+			Root:       rootCid,
 			Path:       path,
 			Scope:      dagScope,
 			Bytes:      byteRange,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -45,9 +45,12 @@ func NewFetchConfig(opts ...FetchOption) FetchConfig {
 }
 
 // RetrievalCandidate describes a peer and CID combination that can be used to
-// retrieve data from the peer. The Metadata field contains information about
-// the protocols supported by the peer that may be used to further refine
-// how the retrieval is performed.
+// retrieve data from the peer. The RootCid describes the head of an IPLD graph
+// that is being retrieved. The MinerPeer is the peer that is (apparently)
+// storing the data.
+//
+// The Metadata field contains information about the protocols supported by the
+// peer that may be used to further refine how the retrieval is performed.
 type RetrievalCandidate struct {
 	MinerPeer peer.AddrInfo
 	RootCid   cid.Cid

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -247,8 +247,8 @@ type RetrievalEvent interface {
 	RetrievalId() RetrievalID
 	// Code returns the type of event this is
 	Code() EventCode
-	// PayloadCid returns the CID being requested
-	PayloadCid() cid.Cid
+	// RootCid returns the CID being requested
+	RootCid() cid.Cid
 }
 
 const BitswapIndentifier = "Bitswap"


### PR DESCRIPTION
except in the case of data-transfer requests where this is the lingo for retrievals.

BREAKING only in that consumers of the internal event system will have trouble with this; otherwise we use "root" CID externally everywhere else already.

Closes: https://github.com/filecoin-project/lassie/issues/334