### PR TITLE
feat: allow missing peer ID & http:// url style on HTTP --providers

### DIFF
--- a/cmd/lassie/fetch.go
+++ b/cmd/lassie/fetch.go
@@ -92,7 +92,11 @@ var fetchCmd = &cli.Command{
 
 func fetchAction(cctx *cli.Context) error {
 	if cctx.Args().Len() != 1 {
-		return fmt.Errorf("usage: lassie fetch [-o <CAR file>] [-t <timeout>] <CID>[/path/to/content]")
+		// "help" becomes a subcommand, clear it to deal with a urfave/cli bug
+		// Ref: https://github.com/urfave/cli/blob/v2.25.7/help.go#L253-L255
+		cctx.Command.Subcommands = nil
+		cli.ShowCommandHelpAndExit(cctx, "fetch", 0)
+		return nil
 	}
 
 	msgWriter := cctx.App.ErrWriter

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -125,10 +125,9 @@ var FlagAllowProviders = &cli.StringFlag{
 	DefaultText: "Providers will be discovered automatically",
 	Usage: "Comma-separated addresses of providers, to use instead of " +
 		"automatic discovery. Accepts full multiaddrs including peer ID, " +
-		"multiaddrs without peer ID and url-style addresses for HTTP, Filecoin " +
-		"SP f0 actor addresses, and Filecoin peer IDs. Lassie will attempt to " +
-		"connect to the peer(s). " +
-		"Example: " +
+		"multiaddrs without peer ID and url-style addresses for HTTP and " +
+		"Filecoin SP f0 actor addresses. Lassie will attempt to connect to the " +
+		"peer(s). Example: " +
 		"/ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4,http://ipfs.io,f01234",
 	EnvVars: []string{"LASSIE_ALLOW_PROVIDERS"},
 	Action: func(cctx *cli.Context, v string) error {
@@ -137,9 +136,10 @@ var FlagAllowProviders = &cli.StringFlag{
 			return nil
 		}
 
-		// in case we have been given peer IDs or filecoin actor addresses we can
-		// look-up with heyfil, do it, otherwise this is a pass-through
-		trans, err := heyfil.TranslateAll(strings.Split(v, ","))
+		// in case we have been given filecoin actor addresses we can look them up
+		// with heyfil and translate to full multiaddrs, otherwise this is a
+		// pass-through
+		trans, err := heyfil.Heyfil{TranslateFaddr: true}.TranslateAll(strings.Split(v, ","))
 		if err != nil {
 			return err
 		}

--- a/cmd/lassie/flags.go
+++ b/cmd/lassie/flags.go
@@ -122,8 +122,11 @@ var FlagAllowProviders = &cli.StringFlag{
 	Name:        "providers",
 	Aliases:     []string{"provider"},
 	DefaultText: "Providers will be discovered automatically",
-	Usage:       "Addresses of providers, including peer IDs, to use instead of automatic discovery, seperated by a comma. All protocols will be attempted when connecting to these providers. Example: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
-	EnvVars:     []string{"LASSIE_ALLOW_PROVIDERS"},
+	Usage: "Addresses of providers, including peer IDs, to use instead of " +
+		"automatic discovery, seperated by a comma. Peer ID is optional for HTTP " +
+		"providers, which may also be specified using URL form. Example: " +
+		"/ip4/1.2.3.4/tcp/1234/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4,http://ipfs.io",
+	EnvVars: []string{"LASSIE_ALLOW_PROVIDERS"},
 	Action: func(cctx *cli.Context, v string) error {
 		// Do nothing if given an empty string
 		if v == "" {

--- a/pkg/heyfil/heyfil.go
+++ b/pkg/heyfil/heyfil.go
@@ -1,0 +1,180 @@
+package heyfil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/multierr"
+)
+
+const DefaultHeyfilEndpoint = "https://heyfil.prod.cid.contact/"
+
+var logger = log.Logger("lassie/heyfil")
+
+func isPeerId(s string) bool {
+	_, err := peer.Decode(s)
+	return err == nil
+}
+
+func isFilecoinFaddr(s string) bool {
+	// quick check if matches /^f0\d+$/ {
+	if len(s) > 2 && s[0] == 'f' && s[1] == '0' {
+		for _, c := range s[2:] {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func CanHeyfil(s string) bool {
+	return !strings.Contains(s, "/") && (isPeerId(s) || isFilecoinFaddr(s))
+}
+
+type Heyfil struct {
+	Endpoint string
+}
+
+func (h Heyfil) endpoint() string {
+	if h.Endpoint == "" {
+		return DefaultHeyfilEndpoint
+	}
+	return h.Endpoint
+}
+
+// TranslateAll performs a Translate on all strings in the input slice. If none
+// of the strings can be translated, the input slice is returned as-is.
+func TranslateAll(ss []string) ([]string, error) {
+	return Heyfil{}.TranslateAll(ss)
+}
+
+// Translate will translate an input string to a full multiaddr if the string
+// appears to be a Filecoin SP actor address or a peer id using the Heyfil
+// service. If the input string is not a Filecoin SP actor address or a peer id,
+// it will be returned as-is.
+func Translate(s string) (string, error) {
+	return Heyfil{}.Translate(s)
+}
+
+// TranslateAll performs a Translate on all strings in the input slice. If none
+// of the strings can be translated, the input slice is returned as-is.
+func (h Heyfil) TranslateAll(ss []string) ([]string, error) {
+	translated := make([]string, len(ss))
+	var merr error
+	var translatedLk sync.Mutex
+	var wg sync.WaitGroup
+	for ii, s := range ss {
+		if !CanHeyfil(s) {
+			translated[ii] = s
+			continue
+		}
+		wg.Add(1)
+		go func(ii int, s string) {
+			defer wg.Done()
+			res, err := h.Translate(s)
+			if err != nil {
+				translatedLk.Lock()
+				multierr.AppendInto(&merr, err)
+				translatedLk.Unlock()
+				return
+			}
+			translatedLk.Lock()
+			translated[ii] = res
+			translatedLk.Unlock()
+		}(ii, s)
+	}
+	wg.Wait()
+	if merr != nil {
+		return nil, merr
+	}
+	return translated, nil
+}
+
+// Translate will translate an input string to a full multiaddr if the string
+// appears to be a Filecoin SP actor address or a peer id using the Heyfil
+// service. If the input string is not a Filecoin SP actor address or a peer id,
+// it will be returned as-is.
+func (h Heyfil) Translate(s string) (string, error) {
+	if isPeerId(s) {
+		res, err := h.translatePeerId(s)
+		if err != nil {
+			logger.Debugw("failed to translate peer id", "input", s, "err", err)
+			return "", err
+		}
+		return res, nil
+	}
+	if isFilecoinFaddr(s) {
+		res, err := h.translateFaddr(s)
+		if err != nil {
+			logger.Debugw("failed to translate faddr", "input", s, "err", err)
+			return "", err
+		}
+		return res, nil
+	}
+	return s, nil // pass-through
+}
+
+func (h Heyfil) translatePeerId(s string) (string, error) {
+	url := h.endpoint() + "/sp?peerid=" + s
+	logger.Debugw("translating peer id", "input", s, "url", url)
+	got := make([]string, 0)
+	if err := httpGet(url, &got); err != nil {
+		return "", err
+	}
+	if len(got) == 0 {
+		return "", fmt.Errorf("expected at least 1 response, got %d", len(got))
+	}
+	return h.translateFaddr(got[0])
+}
+
+func (h Heyfil) translateFaddr(s string) (string, error) {
+	url := h.endpoint() + "/sp/" + s
+	got := make(map[string]interface{})
+	if err := httpGet(url, &got); err != nil {
+		return "", err
+	}
+	addrInfo, ok := got["addr_info"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("expected addr_info to be map[string]interface{}, got %T", got["addr_info"])
+	}
+	id, ok := addrInfo["ID"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("expected addr_info.ID to be string")
+	}
+	addrs, ok := addrInfo["Addrs"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("expected addr_info.Addrs to be []interface{}, got %T", addrInfo["Addrs"])
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("expected addr_info.Addrs to be non-empty")
+	}
+	addr, ok := addrs[0].(string)
+	if !ok {
+		return "", fmt.Errorf("expected addr_info.Addrs[0] to be string, got %T", addrs[0])
+	}
+	return addr + "/p2p/" + id, nil
+}
+
+func httpGet[T any](url string, result *T) error {
+	logger.Debugf("http get: %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("http get: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http get: %s", resp.Status)
+	}
+	err = json.NewDecoder(resp.Body).Decode(result)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	return nil
+}

--- a/pkg/heyfil/heyfil_test.go
+++ b/pkg/heyfil/heyfil_test.go
@@ -11,27 +11,30 @@ import (
 
 func TestCanHeyfil(t *testing.T) {
 	testCase := []struct {
-		name  string
-		input string
-		can   bool
+		name          string
+		input         string
+		canWithPeerID bool
+		canWithFaddr  bool
 	}{
-		{"empty", "", false},
-		{"faddr", "f01234", true},
-		{"faddr non miner", "f1234", false},
-		{"bad faddr", "f00cafebeef", false},
-		{"p2p", "12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", true},
-		{"cid p2p", "QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp", true},
-		{"cidv1 p2p", "bafzbeicwot2npbkuyjppqaoibbohqemn5dnbidt66mjdfso725vm4lmmlm", true},
-		{"cidv1 not p2p", "bafybeicwot2npbkuyjppqaoibbohqemn5dnbidt66mjdfso725vm4lmmlm", false},
-		{"multiaddr", "/dns4/dag.w3s.link/tcp/443/https", false},
-		{"http addr", "http://dag.w3s.link:443", false},
-		{"multiaddr long", "/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", false},
-		{"multiaddr ip4", "/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA", false},
+		{"empty", "", false, false},
+		{"faddr", "f01234", false, true},
+		{"faddr non miner", "f1234", false, false},
+		{"bad faddr", "f00cafebeef", false, false},
+		{"p2p", "12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", true, false},
+		{"cid p2p", "QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp", true, false},
+		{"cidv1 p2p", "bafzbeicwot2npbkuyjppqaoibbohqemn5dnbidt66mjdfso725vm4lmmlm", true, false},
+		{"cidv1 not p2p", "bafybeicwot2npbkuyjppqaoibbohqemn5dnbidt66mjdfso725vm4lmmlm", false, false},
+		{"multiaddr", "/dns4/dag.w3s.link/tcp/443/https", false, false},
+		{"http addr", "http://dag.w3s.link:443", false, false},
+		{"multiaddr long", "/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", false, false},
+		{"multiaddr ip4", "/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA", false, false},
 	}
 
 	for _, tc := range testCase {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, heyfil.CanHeyfil(tc.input), tc.can)
+			require.False(t, heyfil.Heyfil{}.CanTranslate(tc.input))
+			require.Equal(t, heyfil.Heyfil{TranslatePeerId: true}.CanTranslate(tc.input), tc.canWithPeerID)
+			require.Equal(t, heyfil.Heyfil{TranslateFaddr: true}.CanTranslate(tc.input), tc.canWithFaddr)
 		})
 	}
 }
@@ -42,9 +45,15 @@ func TestHeyfil(t *testing.T) {
 
 	trans, err := heyfil.Heyfil{Endpoint: ts.URL}.Translate("12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ")
 	require.NoError(t, err)
+	require.Equal(t, "12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", trans)
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL, TranslatePeerId: true}.Translate("12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ")
+	require.NoError(t, err)
 	require.Equal(t, "/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", trans)
 
 	trans, err = heyfil.Heyfil{Endpoint: ts.URL}.Translate("f0127896")
+	require.NoError(t, err)
+	require.Equal(t, "f0127896", trans)
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL, TranslateFaddr: true}.Translate("f0127896")
 	require.NoError(t, err)
 	require.Equal(t, "/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", trans)
 
@@ -56,7 +65,7 @@ func TestHeyfil(t *testing.T) {
 		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
 		"WOT?", // this is an error for another layer ...
 	} {
-		trans, err := heyfil.Heyfil{Endpoint: ts.URL}.Translate(inp)
+		trans, err := heyfil.Heyfil{Endpoint: ts.URL, TranslatePeerId: true, TranslateFaddr: true}.Translate(inp)
 		require.NoError(t, err)
 		require.Equal(t, trans, inp)
 	}
@@ -66,48 +75,60 @@ func TestHeyfilTranslateAll(t *testing.T) {
 	ts := newHeyfilServer()
 	defer ts.Close()
 
-	input := []string{
-		"/dns4/dag.w3s.link/tcp/443/https",
-		"http://dag.w3s.link:443",
-		"12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
-		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
-		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
-		"f0127896",
-		"WOT?", // this is an error for another layer ...
+	testData := []struct {
+		addr     string
+		want     string
+		ispeerid bool
+		isfaddr  bool
+	}{
+		{"/dns4/dag.w3s.link/tcp/443/https", "/dns4/dag.w3s.link/tcp/443/https", false, false},
+		{"http://dag.w3s.link:443", "http://dag.w3s.link:443", false, false},
+		{"12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", "/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", true, false},
+		{"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", "/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", false, false},
+		{"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA", "/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA", false, false},
+		{"f0127896", "/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", false, true},
+		{"WOT?", "WOT?", false, false}, // this is an error for another layer ..."WOT?"
 	}
-	expected := []string{
-		"/dns4/dag.w3s.link/tcp/443/https",
-		"http://dag.w3s.link:443",
-		"/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
-		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
-		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
-		"/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
-		"WOT?",
+	input := make([]string, len(testData))
+	for ii, td := range testData {
+		input[ii] = td.addr
 	}
 
 	trans, err := heyfil.Heyfil{Endpoint: ts.URL}.TranslateAll(input)
 	require.NoError(t, err)
-	require.Equal(t, trans, expected)
-
-	// same but nothing to translate, make sure we can pass through without even trying
-	input = []string{
-		"/dns4/dag.w3s.link/tcp/443/https",
-		"http://dag.w3s.link:443",
-		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
-		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
-		"WOT?", // this is an error for another layer ...
-	}
-	expected = []string{
-		"/dns4/dag.w3s.link/tcp/443/https",
-		"http://dag.w3s.link:443",
-		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
-		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
-		"WOT?",
+	for ii, td := range testData {
+		want := td.want
+		if td.isfaddr || td.ispeerid {
+			want = td.addr
+		}
+		require.Equal(t, trans[ii], want)
 	}
 
-	trans, err = heyfil.Heyfil{Endpoint: ts.URL}.TranslateAll(input)
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL, TranslatePeerId: true}.TranslateAll(input)
 	require.NoError(t, err)
-	require.Equal(t, trans, expected)
+	for ii, td := range testData {
+		want := td.want
+		if td.isfaddr {
+			want = td.addr
+		}
+		require.Equal(t, trans[ii], want)
+	}
+
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL, TranslateFaddr: true}.TranslateAll(input)
+	require.NoError(t, err)
+	for ii, td := range testData {
+		want := td.want
+		if td.ispeerid {
+			want = td.addr
+		}
+		require.Equal(t, trans[ii], want)
+	}
+
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL, TranslateFaddr: true, TranslatePeerId: true}.TranslateAll(input)
+	require.NoError(t, err)
+	for ii, td := range testData {
+		require.Equal(t, trans[ii], td.want)
+	}
 }
 
 func newHeyfilServer() *httptest.Server {

--- a/pkg/heyfil/heyfil_test.go
+++ b/pkg/heyfil/heyfil_test.go
@@ -1,0 +1,126 @@
+package heyfil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/filecoin-project/lassie/pkg/heyfil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanHeyfil(t *testing.T) {
+	testCase := []struct {
+		name  string
+		input string
+		can   bool
+	}{
+		{"empty", "", false},
+		{"faddr", "f01234", true},
+		{"faddr non miner", "f1234", false},
+		{"bad faddr", "f00cafebeef", false},
+		{"p2p", "12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", true},
+		{"cid p2p", "QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp", true},
+		{"cidv1 p2p", "bafzbeicwot2npbkuyjppqaoibbohqemn5dnbidt66mjdfso725vm4lmmlm", true},
+		{"cidv1 not p2p", "bafybeicwot2npbkuyjppqaoibbohqemn5dnbidt66mjdfso725vm4lmmlm", false},
+		{"multiaddr", "/dns4/dag.w3s.link/tcp/443/https", false},
+		{"http addr", "http://dag.w3s.link:443", false},
+		{"multiaddr long", "/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4", false},
+		{"multiaddr ip4", "/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA", false},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, heyfil.CanHeyfil(tc.input), tc.can)
+		})
+	}
+}
+
+func TestHeyfil(t *testing.T) {
+	ts := newHeyfilServer()
+	defer ts.Close()
+
+	trans, err := heyfil.Heyfil{Endpoint: ts.URL}.Translate("12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ")
+	require.NoError(t, err)
+	require.Equal(t, "/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", trans)
+
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL}.Translate("f0127896")
+	require.NoError(t, err)
+	require.Equal(t, "/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ", trans)
+
+	// no translation, pass-through
+	for _, inp := range []string{
+		"/dns4/dag.w3s.link/tcp/443/https",
+		"http://dag.w3s.link:443",
+		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
+		"WOT?", // this is an error for another layer ...
+	} {
+		trans, err := heyfil.Heyfil{Endpoint: ts.URL}.Translate(inp)
+		require.NoError(t, err)
+		require.Equal(t, trans, inp)
+	}
+}
+
+func TestHeyfilTranslateAll(t *testing.T) {
+	ts := newHeyfilServer()
+	defer ts.Close()
+
+	input := []string{
+		"/dns4/dag.w3s.link/tcp/443/https",
+		"http://dag.w3s.link:443",
+		"12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
+		"f0127896",
+		"WOT?", // this is an error for another layer ...
+	}
+	expected := []string{
+		"/dns4/dag.w3s.link/tcp/443/https",
+		"http://dag.w3s.link:443",
+		"/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
+		"/ip4/85.11.148.122/tcp/24001/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+		"WOT?",
+	}
+
+	trans, err := heyfil.Heyfil{Endpoint: ts.URL}.TranslateAll(input)
+	require.NoError(t, err)
+	require.Equal(t, trans, expected)
+
+	// same but nothing to translate, make sure we can pass through without even trying
+	input = []string{
+		"/dns4/dag.w3s.link/tcp/443/https",
+		"http://dag.w3s.link:443",
+		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
+		"WOT?", // this is an error for another layer ...
+	}
+	expected = []string{
+		"/dns4/dag.w3s.link/tcp/443/https",
+		"http://dag.w3s.link:443",
+		"/dns4/dag.w3s.link/tcp/443/https/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
+		"/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA",
+		"WOT?",
+	}
+
+	trans, err = heyfil.Heyfil{Endpoint: ts.URL}.TranslateAll(input)
+	require.NoError(t, err)
+	require.Equal(t, trans, expected)
+}
+
+func newHeyfilServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/sp/f0127896" {
+			w.Write([]byte(`{"id":"f0127896","status":6,"addr_info":{"ID":"12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ","Addrs":["/ip4/85.11.148.122/tcp/24001"]},"last_checked":"2023-09-29T05:57:19.193226313Z","err":"failed to dial 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ:\n  * [/ip4/85.11.148.122/tcp/24001] dial tcp4 85.11.148.122:24001: connect: connection refused","head":null,"known_by_indexer":true,"state_miner_power":{"HasMinPower":false,"MinerPower":{"QualityAdjPower":"0","RawBytePower":"0"},"TotalPower":{"QualityAdjPower":"27973870915671523328","RawBytePower":"12090904615566966784"}},"deal_count":2031}`))
+			return
+		}
+		if r.URL.Path == "/sp" && r.URL.RawQuery == "peerid=12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ" {
+			w.Write([]byte(`["f0127896"]`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("NO JSON FOR YOU!"))
+	}))
+}

--- a/pkg/server/http/ipfs.go
+++ b/pkg/server/http/ipfs.go
@@ -280,9 +280,10 @@ func parseProtocols(req *http.Request) ([]multicodec.Code, error) {
 
 func parseProviders(req *http.Request) ([]peer.AddrInfo, error) {
 	if req.URL.Query().Has("providers") {
-		// in case we have been given peer IDs or filecoin actor addresses we can
-		// look-up with heyfil, do it, otherwise this is a pass-through
-		trans, err := heyfil.TranslateAll(strings.Split(req.URL.Query().Get("providers"), ","))
+		// in case we have been given filecoin actor addresses we can look them up
+		// with heyfil and translate to full multiaddrs, otherwise this is a
+		// pass-through
+		trans, err := heyfil.Heyfil{TranslateFaddr: true}.TranslateAll(strings.Split(req.URL.Query().Get("providers"), ","))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/types/request_test.go
+++ b/pkg/types/request_test.go
@@ -1,9 +1,8 @@
-package types_test
+package types
 
 import (
 	"testing"
 
-	"github.com/filecoin-project/lassie/pkg/types"
 	"github.com/ipfs/go-cid"
 	trustlessutils "github.com/ipld/go-trustless-utils"
 	"github.com/multiformats/go-multicodec"
@@ -18,13 +17,13 @@ func TestRequestStringRepresentations(t *testing.T) {
 
 	testCases := []struct {
 		name               string
-		request            types.RetrievalRequest
+		request            RetrievalRequest
 		expectedUrlPath    string
 		expectedDescriptor string
 	}{
 		{
 			name: "plain",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{Root: testCidV1},
 			},
 			expectedUrlPath:    "?dag-scope=all",
@@ -32,7 +31,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "path",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{Root: testCidV1, Path: "/some/path/to/thing"},
 			},
 			expectedUrlPath:    "/some/path/to/thing?dag-scope=all",
@@ -40,7 +39,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "escaped path",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{Root: testCidV1, Path: "/?/#/;/&/ /!"},
 			},
 			expectedUrlPath:    "/%3F/%23/%3B/&/%20/%21?dag-scope=all",
@@ -48,7 +47,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "entity",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{Root: testCidV1, Scope: trustlessutils.DagScopeEntity},
 			},
 			expectedUrlPath:    "?dag-scope=entity",
@@ -56,7 +55,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "block",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{Root: testCidV1, Scope: trustlessutils.DagScopeBlock},
 			},
 			expectedUrlPath:    "?dag-scope=block",
@@ -64,7 +63,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "protocol",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request:   trustlessutils.Request{Root: testCidV0},
 				Protocols: []multicodec.Code{multicodec.TransportGraphsyncFilecoinv1},
 			},
@@ -73,7 +72,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "protocols",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request:   trustlessutils.Request{Root: testCidV1},
 				Protocols: []multicodec.Code{multicodec.TransportBitswap, multicodec.TransportIpfsGatewayHttp},
 			},
@@ -82,7 +81,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "duplicates",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{Root: testCidV0, Duplicates: true},
 			},
 			expectedUrlPath:    "?dag-scope=all",
@@ -90,7 +89,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "block limit",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request:   trustlessutils.Request{Root: testCidV1},
 				MaxBlocks: 100,
 			},
@@ -99,25 +98,25 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "fixed peer",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request:    trustlessutils.Request{Root: testCidV1},
-				FixedPeers: must(types.ParseProviderStrings("/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
+				FixedPeers: must(ParseProviderStrings("/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
 			},
 			expectedUrlPath:    "?dag-scope=all",
 			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 		},
 		{
 			name: "fixed peers",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request:    trustlessutils.Request{Root: testCidV1},
-				FixedPeers: must(types.ParseProviderStrings("/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
+				FixedPeers: must(ParseProviderStrings("/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
 			},
 			expectedUrlPath:    "?dag-scope=all",
 			expectedDescriptor: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
 		},
 		{
 			name: "byte range",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{
 					Root:  testCidV1,
 					Bytes: &trustlessutils.ByteRange{From: 100, To: ptr(200)},
@@ -128,7 +127,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "byte range -ve",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{
 					Root:  testCidV1,
 					Bytes: &trustlessutils.ByteRange{From: -100},
@@ -139,7 +138,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 		},
 		{
 			name: "all the things",
-			request: types.RetrievalRequest{
+			request: RetrievalRequest{
 				Request: trustlessutils.Request{
 					Root:       testCidV0,
 					Path:       "/some/path/to/thing",
@@ -149,7 +148,7 @@ func TestRequestStringRepresentations(t *testing.T) {
 				},
 				MaxBlocks:  222,
 				Protocols:  []multicodec.Code{multicodec.TransportBitswap, multicodec.TransportIpfsGatewayHttp},
-				FixedPeers: must(types.ParseProviderStrings("/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
+				FixedPeers: must(ParseProviderStrings("/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4")),
 			},
 			expectedUrlPath:    "/some/path/to/thing?dag-scope=entity&entity-bytes=100:-200",
 			expectedDescriptor: "/ipfs/QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK/some/path/to/thing?dag-scope=entity&entity-bytes=100:-200&dups=y&blockLimit=222&protocols=transport-bitswap,transport-ipfs-gateway-http&providers=/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/ip4/127.0.0.1/tcp/5000/p2p/12D3KooWBSTEYMLSu5FnQjshEVah9LFGEZoQt26eacCEVYfedWA4",
@@ -165,6 +164,97 @@ func TestRequestStringRepresentations(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedDescriptor, actual)
 		})
+	}
+
+	t.Run("fixed peer, no peer ID", func(t *testing.T) {
+		pps, err := ParseProviderStrings("/ip4/127.0.0.1/tcp/5000/http")
+		require.NoError(t, err)
+		request := RetrievalRequest{
+			Request:    trustlessutils.Request{Root: testCidV1},
+			FixedPeers: pps,
+		}
+		ds, err := request.GetDescriptorString()
+		require.NoError(t, err)
+		expectedStart := "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/ip4/127.0.0.1/tcp/5000/http/p2p/1TunknownX"
+		require.Equal(t, expectedStart, ds[0:len(expectedStart)])
+	})
+
+	t.Run("fixed peer, http:// URL", func(t *testing.T) {
+		pps, err := ParseProviderStrings("http://127.0.0.1:5000")
+		require.NoError(t, err)
+		request := RetrievalRequest{
+			Request:    trustlessutils.Request{Root: testCidV1},
+			FixedPeers: pps,
+		}
+		ds, err := request.GetDescriptorString()
+		require.NoError(t, err)
+		expectedStart := "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/ip4/127.0.0.1/tcp/5000/http/p2p/1TunknownX"
+		require.Equal(t, expectedStart, ds[0:len(expectedStart)])
+	})
+}
+
+func TestProviderStrings(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expectMatch string // regex
+		expectErr   string
+	}{
+		{
+			name:      "empty",
+			input:     "",
+			expectErr: "failed to parse multiaddr",
+		},
+		{
+			name:        "single",
+			input:       "/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg",
+			expectMatch: "^/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg$",
+		},
+		{
+			name:        "multi",
+			input:       "/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/dns4/dag.w3s.link/tcp/443/https/p2p/QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp",
+			expectMatch: "^/dns/beep.boop.com/tcp/3747/p2p/12D3KooWDXAVxjSTKbHKpNk8mFVQzHdBDvR4kybu582Xd4Zrvagg,/dns4/dag.w3s.link/tcp/443/https/p2p/QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp$",
+		},
+		{
+			name:        "no id",
+			input:       "/ip4/127.0.0.1/tcp/5000/http",
+			expectMatch: "^/ip4/127.0.0.1/tcp/5000/http/p2p/1TunknownX",
+		},
+		{
+			name:        "http:// form",
+			input:       "http://127.0.0.1:5000",
+			expectMatch: "^/ip4/127.0.0.1/tcp/5000/http/p2p/1TunknownX",
+		},
+		{
+			name:      "http:// form with path err",
+			input:     "http://127.0.0.1:5000/boop",
+			expectErr: "invalid provider URL, paths not supported:",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParseProviderStrings(tc.input)
+			if tc.expectErr != "" {
+				require.Contains(t, err.Error(), tc.expectErr)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			actual, err := ToProviderString(parsed)
+			require.NoError(t, err)
+
+			require.Regexp(t, tc.expectMatch, actual)
+		})
+	}
+}
+
+func TestUnknownPeerID(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		p := nextUnknownPeerID()
+		require.Equal(t, "1TunknownX", p.String()[0:10])
+		require.True(t, IsUnknownPeerID(p))
 	}
 }
 


### PR DESCRIPTION
Where peer ID is not provided, we generate a random one for internal use.

Ref: https://github.com/filecoin-project/lassie/issues/418

One of the accidental outcomes of this is that it makes lassie into a really easy trustless **gateway** download client:

```
lassie fetch --provider http://ipfs.io bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze/wiki/Cat
```

Would be just like doing a `curl` with `Accept: application/vnd.ipld.car` but _also_ doing a full verification of the download so the trustless data can be trusted.

<img width="1259" alt="Screenshot 2023-09-29 at 5 45 42 pm" src="https://github.com/filecoin-project/lassie/assets/495647/eb90508b-0a11-4142-baf1-9e8db1a75209">

Note the 3 made-up peer IDs in there since none of the providers have them. Peer ID flows through the internal event system and is mainly used as a unique key and for reporting, so we need one (atm).

This also impacts `?providers` on the daemon, they'll be processed in the same way.