### PR TITLE
fix: improve path checking and handling for http url providers

### DIFF
--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-unixfsnode"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	ipldstorage "github.com/ipld/go-ipld-prime/storage"
 	trustlessutils "github.com/ipld/go-trustless-utils"
@@ -248,9 +249,10 @@ func ParseProviderStrings(v string) ([]peer.AddrInfo, error) {
 			if err != nil {
 				return nil, err
 			}
-			if u.Path != "" {
+			if datamodel.ParsePath(u.Path).Len() != 0 {
 				return nil, fmt.Errorf("invalid provider URL, paths not supported: %s", v)
 			}
+			u.Path = "" // just in case..
 			maddr, err = maurl.FromURL(u)
 			if err != nil {
 				return nil, err

--- a/pkg/types/request_test.go
+++ b/pkg/types/request_test.go
@@ -180,16 +180,25 @@ func TestRequestStringRepresentations(t *testing.T) {
 	})
 
 	t.Run("fixed peer, http:// URL", func(t *testing.T) {
-		pps, err := ParseProviderStrings("http://127.0.0.1:5000")
-		require.NoError(t, err)
-		request := RetrievalRequest{
-			Request:    trustlessutils.Request{Root: testCidV1},
-			FixedPeers: pps,
+		for _, p := range []string{"", "/", "///"} {
+			t.Run("w/ path=["+p+"]", func(t *testing.T) {
+				pps, err := ParseProviderStrings("http://127.0.0.1:5000" + p)
+				require.NoError(t, err)
+				request := RetrievalRequest{
+					Request:    trustlessutils.Request{Root: testCidV1},
+					FixedPeers: pps,
+				}
+				ds, err := request.GetDescriptorString()
+				require.NoError(t, err)
+				expectedStart := "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/ip4/127.0.0.1/tcp/5000/http/p2p/1TunknownX"
+				require.Equal(t, expectedStart, ds[0:len(expectedStart)])
+			})
 		}
-		ds, err := request.GetDescriptorString()
-		require.NoError(t, err)
-		expectedStart := "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?dag-scope=all&dups=n&providers=/ip4/127.0.0.1/tcp/5000/http/p2p/1TunknownX"
-		require.Equal(t, expectedStart, ds[0:len(expectedStart)])
+	})
+
+	t.Run("fixed peer, http:// URL with path err", func(t *testing.T) {
+		_, err := ParseProviderStrings("http://127.0.0.1:5000/nope")
+		require.ErrorContains(t, err, "paths not supported")
 	})
 }
 


### PR DESCRIPTION
noticed when actually using this and providing a `/` on the end of the provider url and it was erroneously rejected