### PR TITLE
chore: post Go 1.19 multi-error cleanup

### DIFF
--- a/pkg/indexerlookup/candidatefinder.go
+++ b/pkg/indexerlookup/candidatefinder.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"path"
 
 	"github.com/filecoin-project/lassie/pkg/retriever"
 	"github.com/filecoin-project/lassie/pkg/types"
@@ -45,7 +44,6 @@ func (idxf *IndexerCandidateFinder) sendJsonRequest(req *http.Request) (*model.F
 	req.Header.Set("Accept", "application/json")
 	logger.Debugw("sending outgoing request", "url", req.URL, "accept", req.Header.Get("Accept"))
 	resp, err := idxf.httpClient.Do(req)
-
 	if err != nil {
 		logger.Debugw("Failed to perform json lookup", "err", err)
 		return nil, err
@@ -198,7 +196,5 @@ func (idxf *IndexerCandidateFinder) decodeProviderResultStream(ctx context.Conte
 }
 
 func (idxf *IndexerCandidateFinder) findByMultihashEndpoint(mh multihash.Multihash) string {
-	// TODO: Replace with URL.JoinPath once minimum go version in CI is updated to 1.19; like this:
-	//       return idxf.httpEndpoint.JoinPath("multihash", mh.B58String()).String()
-	return idxf.httpEndpoint.String() + path.Join("/multihash", mh.B58String())
+	return idxf.httpEndpoint.JoinPath("multihash", mh.B58String()).String()
 }

--- a/pkg/retriever/bitswapretriever.go
+++ b/pkg/retriever/bitswapretriever.go
@@ -28,7 +28,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multicodec"
-	"go.uber.org/multierr"
 )
 
 // IndexerRouting are the required methods to track indexer routing
@@ -290,14 +289,7 @@ func (br *bitswapRetrieval) runRetrieval(ctx context.Context, ayncCandidates typ
 		// if errors.Is(retrievalCtx.Err(), context.Canceled) && errors.Is(context.Cause(retrievalCtx), context.DeadlineExceeded) {
 		doneLk.Lock()
 		if timedOut {
-			// TODO: replace with %w: %w after 1.19
-			err = multierr.Append(ErrRetrievalFailed,
-				fmt.Errorf(
-					"%w after %s",
-					ErrRetrievalTimedOut,
-					br.cfg.BlockTimeout,
-				),
-			)
+			err = fmt.Errorf("%w; %w after %s", ErrRetrievalFailed, ErrRetrievalTimedOut, br.cfg.BlockTimeout)
 		}
 		doneLk.Unlock()
 		// exclude the case where the context was cancelled by the parent, which likely means that

--- a/pkg/retriever/bitswapretriever_test.go
+++ b/pkg/retriever/bitswapretriever_test.go
@@ -576,6 +576,7 @@ func newMockIndexerRouting() *mockIndexerRouting {
 		candidatesRemoved:  make(map[types.RetrievalID]struct{}),
 	}
 }
+
 func (mir *mockIndexerRouting) AddProviders(rid types.RetrievalID, candidates []types.RetrievalCandidate) {
 	mir.candidatesAdded[rid] = append(mir.candidatesAdded[rid], candidates...)
 }

--- a/pkg/retriever/parallelpeerretriever.go
+++ b/pkg/retriever/parallelpeerretriever.go
@@ -35,8 +35,10 @@ type TransportProtocol interface {
 	) (*types.RetrievalStats, error)
 }
 
-var _ types.CandidateRetriever = (*parallelPeerRetriever)(nil)
-var _ types.CandidateRetrieval = (*retrieval)(nil)
+var (
+	_ types.CandidateRetriever = (*parallelPeerRetriever)(nil)
+	_ types.CandidateRetrieval = (*retrieval)(nil)
+)
 
 // parallelPeerRetriever is an abstract utility type that implements a retrieval
 // flow that retrieves from multiple peers separately but needs to manage that
@@ -87,7 +89,6 @@ func (cfg *parallelPeerRetriever) Retrieve(
 	retrievalRequest types.RetrievalRequest,
 	eventsCallback func(types.RetrievalEvent),
 ) types.CandidateRetrieval {
-
 	if eventsCallback == nil {
 		eventsCallback = func(re types.RetrievalEvent) {}
 	}
@@ -270,7 +271,7 @@ func (retrieval *retrieval) runRetrievalCandidate(
 				if !errors.Is(ctx.Err(), context.Canceled) {
 					msg := retrievalErr.Error()
 					if errors.Is(retrievalErr, ErrRetrievalTimedOut) {
-						msg = fmt.Sprintf("timeout after %s", timeout)
+						msg = fmt.Sprintf("%s after %s", ErrRetrievalTimedOut.Error(), timeout)
 					}
 					shared.sendEvent(ctx, events.FailedRetrieval(retrieval.parallelPeerRetriever.Clock.Now(), retrieval.request.RetrievalID, candidate, retrieval.Protocol.Code(), msg))
 					if err := retrieval.Session.RecordFailure(retrieval.request.RetrievalID, candidate.MinerPeer.ID); err != nil {

--- a/pkg/retriever/retriever_test.go
+++ b/pkg/retriever/retriever_test.go
@@ -619,7 +619,7 @@ func TestRetriever(t *testing.T) {
 					AfterStart:         201*time.Millisecond + initialPause,
 					ReceivedRetrievals: []peer.ID{peerB},
 					ExpectedEvents: []types.RetrievalEvent{
-						events.FailedRetrieval(startTime.Add(201*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, "timeout after 200ms"),
+						events.FailedRetrieval(startTime.Add(201*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, "retrieval timed out 200ms"),
 					},
 					ExpectedMetrics: []testutil.SessionMetric{
 						{Type: testutil.SessionMetric_Failure, Provider: peerA},
@@ -977,7 +977,8 @@ func TestLinkSystemPerRequest(t *testing.T) {
 					events.FirstByte(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
 					events.BlockReceived(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, 100),
 					events.Success(startTime.Add(10*time.Millisecond+initialPause), rid, types.NewRetrievalCandidate(peerA, nil, cid1), 1, 2, 3*time.Second, multicodec.TransportGraphsyncFilecoinv1),
-					events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1})},
+					events.Finished(startTime.Add(10*time.Millisecond+initialPause), rid, types.RetrievalCandidate{RootCid: cid1}),
+				},
 			},
 		},
 	}.RunWithVerification(ctx, t, clock, client, candidateFinder, nil, nil, 0, []testutil.RunRetrieval{
@@ -1044,7 +1045,8 @@ func TestLinkSystemPerRequest(t *testing.T) {
 					events.FirstByte(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 5*time.Millisecond, multicodec.TransportGraphsyncFilecoinv1),
 					events.BlockReceived(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1), multicodec.TransportGraphsyncFilecoinv1, 100),
 					events.Success(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.NewRetrievalCandidate(peerB, nil, cid1), 10, 11, 12*time.Second, multicodec.TransportGraphsyncFilecoinv1),
-					events.Finished(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.RetrievalCandidate{RootCid: cid1})},
+					events.Finished(startTime.Add((10*time.Millisecond+initialPause)*2), rid, types.RetrievalCandidate{RootCid: cid1}),
+				},
 			},
 		},
 	}.RunWithVerification(ctx, t, clock, client, candidateFinder, nil, nil, 0, []testutil.RunRetrieval{


### PR DESCRIPTION
* replace some uses of multierr with fmt.Errorf's %w;%w
* fix up timeout error string inconsistencies: "timed out" vs "timeout"

as a result of checking the errors list with "Other" taking up a very large share, we have, in places 2 and 3:

```
 retrieval failed; retrieval timed out after 20s
 timeout after 20s
```

tbh I'm not actually sure why the former is now showing up more than the latter, I suspect it must have been something I did with the context juggling I've had to do

* https://github.com/filecoin-project/lassie/pull/374
* https://github.com/filecoin-project/lassie/pull/385

We're also getting this now:

```
 failed to load root node: failed to load root CID: context canceled
```

Which is fine, but I think it would be preferable to show this as a timeout instead (i.e. parent retrieval has a timeout and cancels context, the protocol retriever records it as a context cancel). It may be possible to use `WithCancelCause` to check for `DeadlineExceeded` post 1.19, but this'll need some investigation.